### PR TITLE
feat(x86_64): read memory map from bootloader

### DIFF
--- a/hal-core/src/boot.rs
+++ b/hal-core/src/boot.rs
@@ -12,6 +12,12 @@ pub trait BootInfo {
     /// Returns a writer for printing early kernel diagnostics
     fn writer(&self) -> Self::Writer;
 
+    fn bootloader_name(&self) -> &str;
+
+    fn bootloader_version(&self) -> Option<&str> {
+        None
+    }
+
     // TODO(eliza): figure out a non-bad way to represent boot command lines (is
     // it reasonable to convert them to rust strs when we barely have an operating
     // system???)

--- a/hal-core/src/lib.rs
+++ b/hal-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(target_os = "none", no_std)]
-use core::ops;
+use core::{fmt, ops};
 pub mod boot;
 pub mod interrupt;
 pub mod mem;
@@ -22,7 +22,10 @@ pub trait Address:
     + Eq
     + PartialOrd
     + Ord
+    + fmt::Debug
 {
+    fn as_usize(self) -> usize;
+
     /// Aligns `self` up to `align`.
     ///
     /// The specified alignment must be a power of two.
@@ -36,10 +39,23 @@ pub trait Address:
     /// Offsets this address by `offset`.
     ///
     /// If the specified offset would overflow, this function saturates instead.
-    fn offset(self, offset: i32) -> Self;
+    fn offset(self, offset: i32) -> Self {
+        if offset > 0 {
+            self + offset as usize
+        } else {
+            let offset = offset * -1;
+            self - offset as usize
+        }
+    }
 
     /// Returns the difference between `self` and `other`.
-    fn difference(self, other: Self) -> isize;
+    fn difference(self, other: Self) -> isize {
+        if self > other {
+            (self.as_usize() - other.as_usize()) as isize * -1
+        } else {
+            (other.as_usize() - self.as_usize()) as isize
+        }
+    }
 
     /// Returns `true` if `self` is aligned on the specified alignment.
     fn is_aligned<A: Into<usize>>(self, align: A) -> bool {

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -19,9 +19,15 @@ impl Architecture for X64 {
 
 impl fmt::Debug for PAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("PAddr")
-            .field(&format_args!("{:#x}", self.0))
-            .finish()
+        if let Some(width) = f.width() {
+            f.debug_tuple("PAddr")
+                .field(&format_args!("{:#0width$x}", self.0, width = width))
+                .finish()
+        } else {
+            f.debug_tuple("PAddr")
+                .field(&format_args!("{:#x}", self.0,))
+                .finish()
+        }
     }
 }
 
@@ -78,6 +84,10 @@ impl ops::SubAssign<usize> for PAddr {
 }
 
 impl Address for PAddr {
+    fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+
     fn align_up<A: Into<usize>>(self, align: A) -> Self {
         unimplemented!("eliza")
     }
@@ -89,18 +99,6 @@ impl Address for PAddr {
         unimplemented!("eliza")
     }
 
-    /// Offsets this address by `offset`.
-    ///
-    /// If the specified offset would overflow, this function saturates instead.
-    fn offset(self, offset: i32) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Returns the difference between `self` and `other`.
-    fn difference(self, other: Self) -> isize {
-        unimplemented!("eliza")
-    }
-
     /// Returns `true` if `self` is aligned on the specified alignment.
     fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
         unimplemented!("eliza")
@@ -108,5 +106,12 @@ impl Address for PAddr {
 
     fn as_ptr(&self) -> *const () {
         unimplemented!("eliza")
+    }
+}
+
+impl PAddr {
+    pub fn from_u64(u: u64) -> Self {
+        // TODO(eliza): ensure that this is a valid physical address?
+        PAddr(u)
     }
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -59,7 +59,7 @@ impl BootInfo for RustbootBootInfo {
     }
 
     fn bootloader_name(&self) -> &str {
-        "rust-bootinfo"
+        "rust-bootloader"
     }
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,33 +1,72 @@
-use hal_core::boot::BootInfo;
-use hal_x86_64::{vga, X64};
+use bootloader::bootinfo;
+use hal_core::{
+    boot::BootInfo,
+    mem::{self, page},
+    Address,
+};
+use hal_x86_64::{vga, PAddr, X64};
 
 #[derive(Debug)]
-pub struct X64BootInfo {
-    _p: (),
+pub struct RustbootBootInfo {
+    inner: &'static bootinfo::BootInfo,
 }
 
-impl BootInfo for X64BootInfo {
+impl BootInfo for RustbootBootInfo {
     type Arch = X64;
     // TODO(eliza): implement
-    type MemoryMap = core::iter::Empty<hal_core::mem::Region<X64>>;
+    type MemoryMap = core::iter::Map<
+        core::slice::Iter<'static, bootinfo::MemoryRegion>,
+        fn(&bootinfo::MemoryRegion) -> mem::Region<X64>,
+    >;
 
     type Writer = vga::Writer;
 
     /// Returns the boot info's memory map.
     fn memory_map(&self) -> Self::MemoryMap {
-        unimplemented!("eliza: add this!")
+        fn convert_region_kind(kind: &bootinfo::MemoryRegionType) -> mem::RegionKind {
+            match kind {
+                &bootinfo::MemoryRegionType::Usable => mem::RegionKind::FREE,
+                &bootinfo::MemoryRegionType::InUse => mem::RegionKind::USED,
+                &bootinfo::MemoryRegionType::Reserved => mem::RegionKind::USED,
+                &bootinfo::MemoryRegionType::AcpiReclaimable => mem::RegionKind::BOOT_RECLAIMABLE,
+                &bootinfo::MemoryRegionType::BadMemory => mem::RegionKind::BAD,
+                &bootinfo::MemoryRegionType::Kernel => mem::RegionKind::KERNEL,
+                &bootinfo::MemoryRegionType::KernelStack => mem::RegionKind::KERNEL,
+                &bootinfo::MemoryRegionType::PageTable => mem::RegionKind::PAGE_TABLE,
+                &bootinfo::MemoryRegionType::Bootloader => mem::RegionKind::BOOT,
+                &bootinfo::MemoryRegionType::BootInfo => mem::RegionKind::BOOT,
+                _ => mem::RegionKind::UNKNOWN,
+            }
+        }
+
+        fn convert_region(region: &bootinfo::MemoryRegion) -> mem::Region<X64> {
+            let start = PAddr::from_u64(region.range.start_addr());
+            let size = {
+                let end = PAddr::from_u64(region.range.end_addr()).offset(1);
+                assert!(start < end, "bad memory range from bootinfo!");
+                let size = start.difference(end);
+                assert!(size >= 0);
+                size as usize + 1
+            };
+            let kind = convert_region_kind(&region.region_type);
+            mem::Region::new(start, size, kind)
+        }
+        (&self.inner.memory_map[..]).iter().map(convert_region)
     }
 
     fn writer(&self) -> Self::Writer {
         vga::writer()
     }
+
+    fn bootloader_name(&self) -> &str {
+        "rust-bootinfo"
+    }
 }
 
 #[no_mangle]
 #[cfg(target_os = "none")]
-pub extern "C" fn _start() -> ! {
-    // TODO(eliza): unpack bootinfo!
-    let bootinfo = X64BootInfo { _p: () };
+pub extern "C" fn _start(info: &'static bootinfo::BootInfo) -> ! {
+    let bootinfo = RustbootBootInfo { inner: info };
     mycelium_kernel::kernel_main(&bootinfo);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(target_os = "none", no_std)]
 use core::fmt::Write;
-use hal_core::{boot::BootInfo, Architecture};
+use hal_core::{boot::BootInfo, mem, Architecture};
 
 pub fn kernel_main<A>(bootinfo: &impl BootInfo<Arch = A>) -> !
 where
@@ -12,6 +12,38 @@ where
         "hello from mycelium {} (on {})",
         env!("CARGO_PKG_VERSION"),
         A::NAME
+    )
+    .unwrap();
+    writeln!(&mut writer, "booting via {}", bootinfo.bootloader_name()).unwrap();
+
+    let mut regions = 0;
+    let mut free_regions = 0;
+    let mut free_bytes = 0;
+
+    writeln!(&mut writer, "memory map:").unwrap();
+
+    for region in bootinfo.memory_map() {
+        let kind = region.kind();
+        let size = region.size();
+        writeln!(
+            &mut writer,
+            "  {:>10?} {:>15?} {:>15?} B",
+            region.base_addr(),
+            kind,
+            size,
+        )
+        .unwrap();
+        regions += 1;
+        if region.kind() == mem::RegionKind::FREE {
+            free_regions += 1;
+            free_bytes += size;
+        }
+    }
+
+    writeln!(
+        &mut writer,
+        "found {} memory regions, {} free regions ({} bytes)",
+        regions, free_regions, free_bytes,
     )
     .unwrap();
     loop {}


### PR DESCRIPTION
depends on #27

the x64 kernel now reads the memory map from the bootloader and converts
it into our HAL types. i also implemented some unimplemented functions
in order to make this work.

<img width="832" alt="Screen Shot 2019-12-13 at 11 07 54 AM" src="https://user-images.githubusercontent.com/2796466/70837498-bf5db980-1db8-11ea-955c-f5c8be58684e.png">
