### PR TITLE
style: placate clippy

### DIFF
--- a/hal-core/src/interrupt.rs
+++ b/hal-core/src/interrupt.rs
@@ -8,9 +8,20 @@ pub trait Control {
     type Vector;
 
     /// Disable interrupts.
+    ///
+    /// # Safety
+    ///
+    /// This may cause a fault if called when interrupts are already disabled
+    /// (depending on the platform). It does not guarantee that interrupts will
+    /// ever be unmasked.
     unsafe fn disable_irq(&mut self);
 
     /// Enable interrupts.
+    ///
+    /// # Safety
+    ///
+    /// This may cause a fault if called when interrupts are already enabled
+    /// (depending on the platform).
     unsafe fn enable_irq(&mut self);
 
     /// Returns `true` if interrupts are enabled.

--- a/hal-core/src/lib.rs
+++ b/hal-core/src/lib.rs
@@ -43,7 +43,7 @@ pub trait Address:
         if offset > 0 {
             self + offset as usize
         } else {
-            let offset = offset * -1;
+            let offset = -offset;
             self - offset as usize
         }
     }
@@ -51,7 +51,7 @@ pub trait Address:
     /// Returns the difference between `self` and `other`.
     fn difference(self, other: Self) -> isize {
         if self > other {
-            (self.as_usize() - other.as_usize()) as isize * -1
+            -(self.as_usize() as isize - other.as_usize() as isize)
         } else {
             (other.as_usize() - self.as_usize()) as isize
         }

--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -130,15 +130,15 @@ impl RegionKind {
 
 impl fmt::Debug for RegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            &RegionKind::FREE => f.pad("FREE"),
-            &RegionKind::USED => f.pad("USED"),
-            &RegionKind::BOOT => f.pad("BOOT"),
-            &RegionKind::BOOT_RECLAIMABLE => f.pad("BOOT_RECLAIMABLE"),
-            &RegionKind::BAD => f.pad("BAD T_T"),
-            &RegionKind::KERNEL => f.pad("KERNEL"),
-            &RegionKind::KERNEL_STACK => f.pad("KERNEL_STACK"),
-            &RegionKind::PAGE_TABLE => f.pad("PAGE_TABLE"),
+        match *self {
+            RegionKind::FREE => f.pad("FREE"),
+            RegionKind::USED => f.pad("USED"),
+            RegionKind::BOOT => f.pad("BOOT"),
+            RegionKind::BOOT_RECLAIMABLE => f.pad("BOOT_RECLAIMABLE"),
+            RegionKind::BAD => f.pad("BAD T_T"),
+            RegionKind::KERNEL => f.pad("KERNEL"),
+            RegionKind::KERNEL_STACK => f.pad("KERNEL_STACK"),
+            RegionKind::PAGE_TABLE => f.pad("PAGE_TABLE"),
             _ => f.pad("UNKNOWN ?_?"),
         }
     }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -192,6 +192,8 @@ impl<A: fmt::Debug, S: Size> fmt::Debug for Page<A, S> {
 
 // === impl PageRange ===
 
+// A PageRange has a minimum size of 1, this will never be empty.
+#[allow(clippy::len_without_is_empty)]
 impl<A: Address, S: Size> PageRange<A, S> {
     pub fn start(&self) -> Page<A, S> {
         self.start

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -88,19 +88,19 @@ impl Address for PAddr {
         self.0 as usize
     }
 
-    fn align_up<A: Into<usize>>(self, align: A) -> Self {
+    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
         unimplemented!("eliza")
     }
 
     /// Aligns `self` down to `align`.
     ///
     /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, align: A) -> Self {
+    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
         unimplemented!("eliza")
     }
 
     /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
+    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
         unimplemented!("eliza")
     }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,9 +1,5 @@
 use bootloader::bootinfo;
-use hal_core::{
-    boot::BootInfo,
-    mem::{self, page},
-    Address,
-};
+use hal_core::{boot::BootInfo, mem, Address};
 use hal_x86_64::{vga, PAddr, X64};
 
 #[derive(Debug)]
@@ -11,30 +7,30 @@ pub struct RustbootBootInfo {
     inner: &'static bootinfo::BootInfo,
 }
 
+type MemRegionIter = core::slice::Iter<'static, bootinfo::MemoryRegion>;
+
 impl BootInfo for RustbootBootInfo {
     type Arch = X64;
     // TODO(eliza): implement
-    type MemoryMap = core::iter::Map<
-        core::slice::Iter<'static, bootinfo::MemoryRegion>,
-        fn(&bootinfo::MemoryRegion) -> mem::Region<X64>,
-    >;
+    type MemoryMap =
+        core::iter::Map<MemRegionIter, fn(&bootinfo::MemoryRegion) -> mem::Region<X64>>;
 
     type Writer = vga::Writer;
 
     /// Returns the boot info's memory map.
     fn memory_map(&self) -> Self::MemoryMap {
-        fn convert_region_kind(kind: &bootinfo::MemoryRegionType) -> mem::RegionKind {
+        fn convert_region_kind(kind: bootinfo::MemoryRegionType) -> mem::RegionKind {
             match kind {
-                &bootinfo::MemoryRegionType::Usable => mem::RegionKind::FREE,
-                &bootinfo::MemoryRegionType::InUse => mem::RegionKind::USED,
-                &bootinfo::MemoryRegionType::Reserved => mem::RegionKind::USED,
-                &bootinfo::MemoryRegionType::AcpiReclaimable => mem::RegionKind::BOOT_RECLAIMABLE,
-                &bootinfo::MemoryRegionType::BadMemory => mem::RegionKind::BAD,
-                &bootinfo::MemoryRegionType::Kernel => mem::RegionKind::KERNEL,
-                &bootinfo::MemoryRegionType::KernelStack => mem::RegionKind::KERNEL,
-                &bootinfo::MemoryRegionType::PageTable => mem::RegionKind::PAGE_TABLE,
-                &bootinfo::MemoryRegionType::Bootloader => mem::RegionKind::BOOT,
-                &bootinfo::MemoryRegionType::BootInfo => mem::RegionKind::BOOT,
+                bootinfo::MemoryRegionType::Usable => mem::RegionKind::FREE,
+                bootinfo::MemoryRegionType::InUse => mem::RegionKind::USED,
+                bootinfo::MemoryRegionType::Reserved => mem::RegionKind::USED,
+                bootinfo::MemoryRegionType::AcpiReclaimable => mem::RegionKind::BOOT_RECLAIMABLE,
+                bootinfo::MemoryRegionType::BadMemory => mem::RegionKind::BAD,
+                bootinfo::MemoryRegionType::Kernel => mem::RegionKind::KERNEL,
+                bootinfo::MemoryRegionType::KernelStack => mem::RegionKind::KERNEL,
+                bootinfo::MemoryRegionType::PageTable => mem::RegionKind::PAGE_TABLE,
+                bootinfo::MemoryRegionType::Bootloader => mem::RegionKind::BOOT,
+                bootinfo::MemoryRegionType::BootInfo => mem::RegionKind::BOOT,
                 _ => mem::RegionKind::UNKNOWN,
             }
         }
@@ -48,7 +44,7 @@ impl BootInfo for RustbootBootInfo {
                 assert!(size >= 0);
                 size as usize + 1
             };
-            let kind = convert_region_kind(&region.region_type);
+            let kind = convert_region_kind(region.region_type);
             mem::Region::new(start, size, kind)
         }
         (&self.inner.memory_map[..]).iter().map(convert_region)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(target_os = "none", no_std)]
+
 use core::fmt::Write;
 use hal_core::{boot::BootInfo, mem, Architecture};
 
@@ -46,10 +47,20 @@ where
         regions, free_regions, free_bytes,
     )
     .unwrap();
+
+    // if this function returns we would boot loop. Hang, instead, so the debug
+    // output can be read.
+    //
+    // eventually we'll call into a kernel main loop here...
+    #[allow(clippy::empty_loop)]
     loop {}
 }
 
 pub fn handle_panic(writer: &mut impl Write, info: &core::panic::PanicInfo) -> ! {
     writeln!(writer, "something went very wrong:\n{}", info).unwrap();
+
+    // we can't panic or make the thread sleep here, as we are in the panic
+    // handler!
+    #[allow(clippy::empty_loop)]
     loop {}
 }

--- a/util/src/cell.rs
+++ b/util/src/cell.rs
@@ -131,9 +131,7 @@ mod causal {
         /// Panic if the CausaalCell access was invalid.
         ///
         /// When not running under `loom`, this does nothing.
-        pub fn check(mut self) {
-            self = CausalCheck::default();
-        }
+        pub fn check(self) {}
 
         /// Merge this check with another check
         ///

--- a/util/src/sync/spin.rs
+++ b/util/src/sync/spin.rs
@@ -25,7 +25,7 @@ impl<T> Mutex<T> {
     }
 
     pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
-        if self.locked.compare_and_swap(false, true, Ordering::Acquire) == false {
+        if !self.locked.compare_and_swap(false, true, Ordering::Acquire) {
             Some(MutexGuard { mutex: self })
         } else {
             None
@@ -33,7 +33,7 @@ impl<T> Mutex<T> {
     }
 
     pub fn lock(&self) -> MutexGuard<'_, T> {
-        while self.locked.compare_and_swap(false, true, Ordering::Acquire) != false {
+        while self.locked.compare_and_swap(false, true, Ordering::Acquire) {
             while self.locked.load(Ordering::Relaxed) {
                 spin_loop_hint();
             }


### PR DESCRIPTION
This fixes all clippy lints. Some of them were "fixed" by adding allow
attributes, but in those cases, I added comments explaining why we allow
those lints.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>