### PR TITLE
feat(alloc): add a super basic and limited allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "alloc",
     "util",
     "hal-core",
     "hal-x86_64",
@@ -16,6 +17,7 @@ name = "mycelium_kernel"
 
 [dependencies]
 hal-core = { path = "hal-core" }
+mycelium-alloc = { path = "alloc" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bootloader = "0.8.0"

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mycelium-alloc"
+version = "0.1.0"
+authors = ["Nika Layzell <nika@thelayzells.com>"]
+edition = "2018"
+
+[dependencies]

--- a/alloc/src/lib.rs
+++ b/alloc/src/lib.rs
@@ -1,0 +1,112 @@
+//! The simplest thing resembling an "allocator" I could possibly create.
+//! Allocates into a "large" static array.
+#![no_std]
+
+use core::alloc::Layout;
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(target_os = "none")]
+use core::alloc::GlobalAlloc;
+
+// 640k is enough for anyone
+const HEAP_SIZE: usize = 640 * 1024;
+
+#[repr(align(16))]
+struct Heap(UnsafeCell<MaybeUninit<[u8; HEAP_SIZE]>>);
+
+unsafe impl Sync for Heap {}
+
+static HEAP: Heap = Heap(UnsafeCell::new(MaybeUninit::uninit()));
+static USED: AtomicUsize = AtomicUsize::new(0);
+
+/// NOTABLE INVARIANTS:
+///  * `Layout` is non-zero sized (enforced by `GlobalAlloc`)
+///  * `align` is a power of two (enforced by `Layout::from_size_align`)
+pub unsafe fn alloc(layout: Layout) -> *mut u8 {
+    let heap = HEAP.0.get() as *mut u8;
+
+    let mut prev = USED.load(Ordering::Relaxed);
+    loop {
+        let align_offset = heap.add(prev).align_offset(layout.align());
+
+        // NOTE: layout.size() is non-zero. The check will fail if
+        // `align_offset` exceeds `HEAP_SIZE - prev`.
+        let space = (HEAP_SIZE - prev).saturating_sub(align_offset);
+        if space < layout.size() {
+            return ptr::null_mut();
+        }
+
+        let next = prev + align_offset + layout.size();
+        match USED.compare_exchange_weak(prev, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => {
+                return heap.add(prev + align_offset);
+            }
+            Err(next_prev) => {
+                prev = next_prev;
+                continue;
+            }
+        }
+    }
+}
+
+pub unsafe fn dealloc(_ptr: *mut u8, _layout: Layout) {
+    // lol
+}
+
+#[cfg(target_os = "none")]
+pub struct Global;
+
+#[cfg(target_os = "none")]
+unsafe impl GlobalAlloc for Global {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        dealloc(ptr, layout)
+    }
+}
+
+#[cfg(target_os = "none")]
+#[global_allocator]
+pub static GlOBAL: Global = Global;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use core::mem;
+
+    #[test]
+    fn alloc_small() {
+        let p0 = unsafe { alloc(Layout::new::<u32>()) };
+        assert!(!p0.is_null());
+
+        let p1 = unsafe { alloc(Layout::new::<u32>()) };
+        assert!(!p1.is_null());
+
+        assert_eq!(p0.align_offset(mem::align_of::<u32>()), 0);
+        assert_eq!(p1.align_offset(mem::align_of::<u32>()), 0);
+
+        assert_eq!((p1 as usize) - (p0 as usize), 4);
+    }
+
+    #[test]
+    fn alloc_alignment() {
+        let p0 = unsafe { alloc(Layout::new::<u8>()) };
+        assert!(!p0.is_null());
+
+        let p1 = unsafe { alloc(Layout::new::<u8>()) };
+        assert!(!p1.is_null());
+
+        let p2 = unsafe { alloc(Layout::new::<u32>()) };
+        assert!(!p2.is_null());
+
+        assert_eq!((p1 as usize) - (p0 as usize), 1);
+        assert!((p2 as usize) - (p1 as usize) > 0);
+
+        assert_eq!(p2.align_offset(mem::align_of::<u32>()), 0);
+    }
+}

--- a/alloc/src/lib.rs
+++ b/alloc/src/lib.rs
@@ -2,14 +2,12 @@
 //! Allocates into a "large" static array.
 #![no_std]
 
-use core::alloc::Layout;
+use core::alloc::{Layout, GlobalAlloc};
 use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(target_os = "none")]
-use core::alloc::GlobalAlloc;
 
 // 640k is enough for anyone
 const HEAP_SIZE: usize = 640 * 1024;
@@ -56,11 +54,9 @@ pub unsafe fn dealloc(_ptr: *mut u8, _layout: Layout) {
     // lol
 }
 
-#[cfg(target_os = "none")]
-pub struct Global;
+pub struct Alloc;
 
-#[cfg(target_os = "none")]
-unsafe impl GlobalAlloc for Global {
+unsafe impl GlobalAlloc for Alloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         alloc(layout)
     }
@@ -69,10 +65,6 @@ unsafe impl GlobalAlloc for Global {
         dealloc(ptr, layout)
     }
 }
-
-#[cfg(target_os = "none")]
-#[global_allocator]
-pub static GlOBAL: Global = Global;
 
 #[cfg(test)]
 mod test {

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -73,11 +73,3 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     vga.set_color(vga::ColorSpec::new(vga::Color::Red, vga::Color::Black));
     mycelium_kernel::handle_panic(&mut vga, info)
 }
-
-#[alloc_error_handler]
-#[cfg(target_os = "none")]
-fn alloc_error(layout: core::alloc::Layout) -> ! {
-    let mut vga = vga::writer();
-    vga.set_color(vga::ColorSpec::new(vga::Color::Red, vga::Color::Black));
-    mycelium_kernel::handle_alloc_error(&mut vga, layout)
-}

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -73,3 +73,11 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     vga.set_color(vga::ColorSpec::new(vga::Color::Red, vga::Color::Black));
     mycelium_kernel::handle_panic(&mut vga, info)
 }
+
+#[alloc_error_handler]
+#[cfg(target_os = "none")]
+fn alloc_error(layout: core::alloc::Layout) -> ! {
+    let mut vga = vga::writer();
+    vga.set_color(vga::ColorSpec::new(vga::Color::Red, vga::Color::Black));
+    mycelium_kernel::handle_alloc_error(&mut vga, layout)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,6 @@
 
 extern crate alloc;
 
-// Force `mycelium_alloc` to be linked in, as it provides the allocator.
-#[cfg(target_os = "none")]
-extern crate mycelium_alloc;
-
 use core::fmt::Write;
 use hal_core::{boot::BootInfo, mem, Architecture};
 
@@ -88,9 +84,12 @@ pub fn handle_panic(writer: &mut impl Write, info: &core::panic::PanicInfo) -> !
     loop {}
 }
 
-pub fn handle_alloc_error(writer: &mut impl Write, layout: core::alloc::Layout) -> ! {
-    let _ = writeln!(writer, "alloc error:\n{:?}", layout);
+#[global_allocator]
+#[cfg(target_os = "none")]
+pub static GLOBAL: mycelium_alloc::Alloc = mycelium_alloc::Alloc;
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+#[alloc_error_handler]
+#[cfg(target_os = "none")]
+fn alloc_error(layout: core::alloc::Layout) -> ! {
+    panic!("alloc error: {:?}", layout);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", no_main)]
+#![cfg_attr(target_os = "none", feature(alloc_error_handler))]
+
 pub mod arch;
 
 fn main() {


### PR DESCRIPTION
I thought it might be useful to add a dummy kernel allocator, in case it is useful for building other components, before a proper paging abstraction is added to the `hal`. This allocator is about as dumb as it gets, providing only 640k of bump-allocating power, but allows the use of types like `Vec` in the kernel.