### PR TITLE
feat(kernel): dedicated kernel oops handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ members = [
     "util",
     "hal-core",
     "hal-x86_64",
-    "hal-multiboot2",
 ]
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "util",
     "hal-core",
     "hal-x86_64",
+    "hal-multiboot2",
 ]
 
 [package]

--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -179,6 +179,25 @@ impl Writer {
     pub fn clear(&mut self) {
         BUFFER.lock().clear();
     }
+
+    /// Forcibly unlock the VGA buffer's mutex.
+    ///
+    /// If a lock is currently held, it will be released, regardless of who's
+    /// holding it. Of course, this is **outrageously, disgustingly unsafe** and
+    /// you should never do it.
+    ///
+    /// # Safety
+    ///
+    /// This deliberately violates mutual exclusion.
+    ///
+    /// Only call this method when it is _guaranteed_ that no stack frame that
+    /// has previously locked the mutex will ever continue executing.
+    /// Essentially, this is only okay to call when the kernel is oopsing and
+    /// all code running on other cores has already been killed.
+    #[doc(hidden)]
+    pub unsafe fn force_unlock(&mut self) {
+        BUFFER.force_unlock();
+    }
 }
 
 impl fmt::Write for Writer {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) use self::x86_64::oops;
+pub(crate) use self::x86_64::*;

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod x86_64;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) use self::x86_64::oops;

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -72,6 +72,7 @@ pub extern "C" fn _start(info: &'static bootinfo::BootInfo) -> ! {
     mycelium_kernel::kernel_main(&bootinfo);
 }
 
+#[cold]
 pub(crate) fn oops(cause: &dyn core::fmt::Display) -> ! {
     use core::fmt::Write;
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -73,6 +73,7 @@ pub extern "C" fn _start(info: &'static bootinfo::BootInfo) -> ! {
 }
 
 #[cold]
+#[cfg(target_os = "none")]
 pub(crate) fn oops(cause: &dyn core::fmt::Display) -> ! {
     use core::fmt::Write;
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -84,8 +84,27 @@ pub(crate) fn oops(cause: &dyn core::fmt::Display) -> ! {
     vga.set_color(vga::ColorSpec::new(vga::Color::Red, vga::Color::White));
     let _ = vga.write_str("OOPSIE WOOPSIE");
     vga.set_color(RED_BG);
-    let _ = writeln!(vga, "\n\n  uwu we did a widdle fucky-wucky!\n  {}", cause);
-    // TODO(eliza): registers etc
+    let _ = writeln!(vga, "\n  uwu we did a widdle fucky-wucky!\n\n{:2>}", cause);
+    let rflags: u64;
+    let cr0: u64;
+    let cr3: u64;
+    unsafe {
+        asm!("
+            pushfq
+            popq $0
+            mov %cr0, $1
+            mov %cr3, $2
+            "
+            : "=r"(rflags), "=r"(cr0), "=r"(cr3) :: "memory"
+        );
+    };
+    let _ = writeln!(
+        vga,
+        "\n  cr0: {:#032b}\n  cr3: {:#032b}\n  rflags: {:#064b}",
+        cr0, cr3, rflags
+    );
+    let _ = vga.write_str("\n\n  it will never be safe to turn off your computer.");
+
     #[allow(clippy::empty_loop)]
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,24 +68,17 @@ where
         v.push(5u64);
         tracing::info!(vec = ?v, vec.addr = ?v.as_ptr());
         v.push(10u64);
-        tracing::info!(vec=?v, vec.addr = ?v.as_ptr());
+        tracing::info!(vec=?v, vec.addr=?v.as_ptr());
         assert_eq!(v.pop(), Some(10));
         assert_eq!(v.pop(), Some(5));
     }
+
+    panic!("fake panic!");
 
     // if this function returns we would boot loop. Hang, instead, so the debug
     // output can be read.
     //
     // eventually we'll call into a kernel main loop here...
-    #[allow(clippy::empty_loop)]
-    loop {}
-}
-
-pub fn handle_panic(writer: &mut impl Write, info: &core::panic::PanicInfo) -> ! {
-    writeln!(writer, "something went very wrong:\n{}", info).unwrap();
-
-    // we can't panic or make the thread sleep here, as we are in the panic
-    // handler!
     #[allow(clippy::empty_loop)]
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,6 @@ where
         assert_eq!(v.pop(), Some(5));
     }
 
-    panic!("fake panic!");
-
     // if this function returns we would boot loop. Hang, instead, so the debug
     // output can be read.
     //

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,44 @@
 #![cfg_attr(target_os = "none", no_main)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 #![cfg_attr(target_os = "none", feature(asm))]
+#![cfg_attr(target_os = "none", feature(panic_info_message, track_caller))]
 
 pub mod arch;
 
 #[panic_handler]
 #[cfg(target_os = "none")]
 fn panic(panic: &core::panic::PanicInfo) -> ! {
-    tracing::error!(%panic);
-    arch::oops(panic)
+    use core::fmt;
+
+    struct PrettyPanic<'a>(&'a core::panic::PanicInfo<'a>);
+    impl<'a> fmt::Display for PrettyPanic<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let message = self.0.message();
+            let location = self.0.location();
+            let caller = core::panic::Location::caller();
+            if let Some(message) = message {
+                writeln!(f, "  mycelium panicked: {}", message)?;
+                if let Some(loc) = location {
+                    writeln!(f, "  at: {}:{}:{}", loc.file(), loc.line(), loc.column(),)?;
+                }
+            } else {
+                writeln!(f, "  mycelium panicked: {}", self.0)?;
+            }
+            writeln!(
+                f,
+                "  in: {}:{}:{}",
+                caller.file(),
+                caller.line(),
+                caller.column()
+            )?;
+            Ok(())
+        }
+    }
+
+    let caller = core::panic::Location::caller();
+    tracing::error!(%panic, ?caller);
+    let pp = PrettyPanic(panic);
+    arch::oops(&pp)
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,16 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", no_main)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
+#![cfg_attr(target_os = "none", feature(asm))]
 
 pub mod arch;
+
+#[panic_handler]
+#[cfg(target_os = "none")]
+fn panic(panic: &core::panic::PanicInfo) -> ! {
+    tracing::error!(%panic);
+    arch::oops(panic)
+}
 
 fn main() {
     unsafe {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,9 @@
 
 pub mod arch;
 
-#[panic_handler]
 #[cfg(target_os = "none")]
+#[panic_handler]
+#[cold]
 fn panic(panic: &core::panic::PanicInfo) -> ! {
     use core::fmt;
 

--- a/util/src/sync/spin.rs
+++ b/util/src/sync/spin.rs
@@ -40,6 +40,24 @@ impl<T> Mutex<T> {
         }
         MutexGuard { mutex: self }
     }
+
+    /// Forcibly unlock the mutex.
+    ///
+    /// If a lock is currently held, it will be released, regardless of who's
+    /// holding it. Of course, this is **outrageously, disgustingly unsafe** and
+    /// you should never do it.
+    ///
+    /// # Safety
+    ///
+    /// This deliberately violates mutual exclusion.
+    ///
+    /// Only call this method when it is _guaranteed_ that no stack frame that
+    /// has previously locked the mutex will ever continue executing.
+    /// Essentially, this is only okay to call when the kernel is oopsing and
+    /// all code running on other cores has already been killed.
+    pub unsafe fn force_unlock(&self) {
+        self.locked.store(false, Ordering::Release);
+    }
 }
 
 unsafe impl<T> Send for Mutex<T> {}


### PR DESCRIPTION
This branch adds a (basic) kernel oops handler for when we do a
fucky-wucky. Right now it just makes a cool red screen of death 
and dumps a couple control registers, there's probably a lot of
additional state we should dump in here in the future.

Panics are also logged to serial prior to oopsing.

Right now it looks like this:
<img width="832" alt="Screen Shot 2019-12-31 at 2 44 42 PM" src="https://user-images.githubusercontent.com/2796466/71638575-7e6aff00-2c18-11ea-9e2b-628835a35a42.png">

Fatal CPU exception ISRs should eventually call into oops directly,
rather than by panicking, so we can dump additional exception info.

Closes #49 (I'm assuming we will open follow-up issues for getting
more useful info on the oops screen).
