### PR TITLE
refac(hal): do away with the Architecture trait

### DIFF
--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -1,0 +1,262 @@
+use core::{fmt, ops};
+
+pub trait Address:
+    Copy
+    + ops::Add<usize, Output = Self>
+    + ops::Sub<usize, Output = Self>
+    + ops::AddAssign<usize>
+    + ops::SubAssign<usize>
+    + PartialEq
+    + Eq
+    + PartialOrd
+    + Ord
+    + fmt::Debug
+{
+    fn as_usize(self) -> usize;
+
+    /// Aligns `self` up to `align`.
+    ///
+    /// The specified alignment must be a power of two.
+    fn align_up<A: Into<usize>>(self, align: A) -> Self;
+
+    /// Aligns `self` down to `align`.
+    ///
+    /// The specified alignment must be a power of two.
+    fn align_down<A: Into<usize>>(self, align: A) -> Self;
+
+    /// Offsets this address by `offset`.
+    ///
+    /// If the specified offset would overflow, this function saturates instead.
+    fn offset(self, offset: i32) -> Self {
+        if offset > 0 {
+            self + offset as usize
+        } else {
+            let offset = -offset;
+            self - offset as usize
+        }
+    }
+
+    /// Returns the difference between `self` and `other`.
+    fn difference(self, other: Self) -> isize {
+        if self > other {
+            -(self.as_usize() as isize - other.as_usize() as isize)
+        } else {
+            (other.as_usize() - self.as_usize()) as isize
+        }
+    }
+
+    /// Returns `true` if `self` is aligned on the specified alignment.
+    fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
+        self.align_down(align) == self
+    }
+
+    fn as_ptr(&self) -> *const ();
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
+pub struct PAddr(usize);
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(transparent)]
+pub struct VAddr(usize);
+
+impl fmt::Debug for PAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(width) = f.width() {
+            f.debug_tuple("PAddr")
+                .field(&format_args!("{:#0width$x}", self.0, width = width))
+                .finish()
+        } else {
+            f.debug_tuple("PAddr")
+                .field(&format_args!("{:#x}", self.0,))
+                .finish()
+        }
+    }
+}
+
+impl ops::Add<usize> for PAddr {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self {
+        PAddr(self.0 + rhs)
+    }
+}
+
+impl ops::Add for PAddr {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        PAddr(self.0 + rhs.0)
+    }
+}
+
+impl ops::AddAssign for PAddr {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl ops::AddAssign<usize> for PAddr {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 += rhs;
+    }
+}
+
+impl ops::Sub<usize> for PAddr {
+    type Output = Self;
+    fn sub(self, rhs: usize) -> Self {
+        PAddr(self.0 - rhs)
+    }
+}
+
+impl ops::Sub for PAddr {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        PAddr(self.0 - rhs.0)
+    }
+}
+
+impl ops::SubAssign for PAddr {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl ops::SubAssign<usize> for PAddr {
+    fn sub_assign(&mut self, rhs: usize) {
+        self.0 -= rhs;
+    }
+}
+
+impl Address for PAddr {
+    fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+
+    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
+        unimplemented!("eliza")
+    }
+
+    /// Aligns `self` down to `align`.
+    ///
+    /// The specified alignment must be a power of two.
+    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
+        unimplemented!("eliza")
+    }
+
+    /// Returns `true` if `self` is aligned on the specified alignment.
+    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
+        unimplemented!("eliza")
+    }
+
+    fn as_ptr(&self) -> *const () {
+        unimplemented!("eliza")
+    }
+}
+
+impl PAddr {
+    #[cfg(target_pointer_width = "64")]
+    pub fn from_u64(u: u64) -> Self {
+        // TODO(eliza): ensure that this is a valid physical address?
+        PAddr(u as usize)
+    }
+}
+
+impl ops::Add<usize> for VAddr {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self {
+        VAddr(self.0 + rhs)
+    }
+}
+
+impl ops::Add for VAddr {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        VAddr(self.0 + rhs.0)
+    }
+}
+
+impl ops::AddAssign for VAddr {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl ops::AddAssign<usize> for VAddr {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 += rhs;
+    }
+}
+
+impl ops::Sub<usize> for VAddr {
+    type Output = Self;
+    fn sub(self, rhs: usize) -> Self {
+        VAddr(self.0 - rhs)
+    }
+}
+
+impl ops::Sub for VAddr {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self {
+        VAddr(self.0 - rhs.0)
+    }
+}
+
+impl ops::SubAssign for VAddr {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl ops::SubAssign<usize> for VAddr {
+    fn sub_assign(&mut self, rhs: usize) {
+        self.0 -= rhs;
+    }
+}
+
+impl Address for VAddr {
+    fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+
+    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
+        unimplemented!("eliza")
+    }
+
+    /// Aligns `self` down to `align`.
+    ///
+    /// The specified alignment must be a power of two.
+    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
+        unimplemented!("eliza")
+    }
+
+    /// Returns `true` if `self` is aligned on the specified alignment.
+    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
+        unimplemented!("eliza")
+    }
+
+    fn as_ptr(&self) -> *const () {
+        unimplemented!("eliza")
+    }
+}
+
+impl VAddr {
+    #[cfg(target_pointer_width = "64")]
+    pub fn from_u64(u: u64) -> Self {
+        // TODO(eliza): ensure that this is a valid virtual address?
+        VAddr(u as usize)
+    }
+}
+
+impl fmt::Debug for VAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(width) = f.width() {
+            f.debug_tuple("VAddr")
+                .field(&format_args!("{:#0width$x}", self.0, width = width))
+                .finish()
+        } else {
+            f.debug_tuple("VAddr")
+                .field(&format_args!("{:#x}", self.0,))
+                .finish()
+        }
+    }
+}

--- a/hal-core/src/boot.rs
+++ b/hal-core/src/boot.rs
@@ -1,9 +1,8 @@
-use crate::{mem, Architecture};
+use crate::mem;
 use core::iter::Iterator;
 
 pub trait BootInfo {
-    type Arch: Architecture;
-    type MemoryMap: Iterator<Item = mem::Region<Self::Arch>>;
+    type MemoryMap: Iterator<Item = mem::Region>;
     type Writer: core::fmt::Write;
 
     /// Returns the boot info's memory map.

--- a/hal-core/src/interrupt/ctx.rs
+++ b/hal-core/src/interrupt/ctx.rs
@@ -1,8 +1,7 @@
-use crate::Architecture;
+use crate::VAddr;
 use core::fmt;
 
 pub trait Context {
-    type Arch: Architecture;
     // TODO(eliza): Registers trait
     type Registers: fmt::Debug;
 
@@ -11,14 +10,14 @@ pub trait Context {
 }
 
 pub trait PageFault: Context {
-    fn fault_vaddr(&self) -> <<Self as Context>::Arch as Architecture>::VAddr;
+    fn fault_vaddr(&self) -> VAddr;
 
     // TODO(eliza): more
 }
 
 pub trait CodeFault: Context {
     fn is_user_mode(&self) -> bool;
-    fn instruction_ptr(&self) -> <<Self as Context>::Arch as Architecture>::VAddr;
+    fn instruction_ptr(&self) -> VAddr;
 }
 
 #[non_exhaustive]

--- a/hal-core/src/interrupt/ctx.rs
+++ b/hal-core/src/interrupt/ctx.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 pub trait Context {
     // TODO(eliza): Registers trait
-    type Registers: fmt::Debug;
+    type Registers: fmt::Debug + fmt::Display;
 
     fn registers(&self) -> &Self::Registers;
     unsafe fn registers_mut(&mut self) -> &mut Self::Registers;

--- a/hal-core/src/interrupt/mod.rs
+++ b/hal-core/src/interrupt/mod.rs
@@ -1,4 +1,3 @@
-use crate::Architecture;
 use core::fmt;
 use core::marker::PhantomData;
 
@@ -7,7 +6,6 @@ pub use self::ctx::Context;
 
 /// An interrupt controller for a platform.
 pub trait Control {
-    type Arch: Architecture;
     /// Disable all interrupts.
     ///
     /// # Safety
@@ -30,7 +28,7 @@ pub trait Control {
 
     fn register_handlers<H>(&mut self) -> Result<(), RegistrationError>
     where
-        H: Handlers<Self::Arch>;
+        H: Handlers;
 
     /// Enter a critical section, returning a guard.
     fn enter_critical(&mut self) -> CriticalGuard<'_, Self> {
@@ -41,19 +39,19 @@ pub trait Control {
     }
 }
 
-pub trait Handlers<A: Architecture> {
+pub trait Handlers {
     fn page_fault<C>(cx: C)
     where
-        C: ctx::Context<Arch = A> + ctx::PageFault;
+        C: ctx::Context + ctx::PageFault;
 
     fn code_fault<C>(cx: C)
     where
-        C: ctx::Context<Arch = A> + ctx::CodeFault;
+        C: ctx::Context + ctx::CodeFault;
 
     #[inline(always)]
     fn double_fault<C>(cx: C)
     where
-        C: ctx::Context<Arch = A> + ctx::CodeFault,
+        C: ctx::Context + ctx::CodeFault,
     {
         Self::code_fault(cx)
     }
@@ -64,7 +62,7 @@ pub trait Handlers<A: Architecture> {
 
     fn test_interrupt<C>(cx: C)
     where
-        C: ctx::Context<Arch = A>,
+        C: ctx::Context,
     {
         // nop
     }

--- a/hal-core/src/lib.rs
+++ b/hal-core/src/lib.rs
@@ -1,19 +1,7 @@
 #![cfg_attr(target_os = "none", no_std)]
-use core::{fmt, ops};
 mod addr;
 pub mod boot;
 pub mod interrupt;
 pub mod mem;
 pub use self::addr::*;
 pub use self::boot::BootInfo;
-
-pub trait Architecture {
-    type InterruptCtrl: interrupt::Control + 'static;
-
-    /// The name of the architecture, as a string.
-    const NAME: &'static str;
-
-    fn init_interrupts(bootinfo: &impl boot::BootInfo) -> &'static mut Self::InterruptCtrl
-    where
-        Self: Sized;
-}

--- a/hal-core/src/lib.rs
+++ b/hal-core/src/lib.rs
@@ -1,78 +1,19 @@
 #![cfg_attr(target_os = "none", no_std)]
 use core::{fmt, ops};
+mod addr;
 pub mod boot;
 pub mod interrupt;
 pub mod mem;
+pub use self::addr::*;
+pub use self::boot::BootInfo;
 
 pub trait Architecture {
-    /// The architecture's physical address representation.
-    type PAddr: Address;
-    /// The architecture's virtual address representation.
-    type VAddr: Address;
-
     type InterruptCtrl: interrupt::Control + 'static;
 
     /// The name of the architecture, as a string.
     const NAME: &'static str;
 
-    fn init_interrupts(
-        bootinfo: &impl boot::BootInfo<Arch = Self>,
-    ) -> &'static mut Self::InterruptCtrl
+    fn init_interrupts(bootinfo: &impl boot::BootInfo) -> &'static mut Self::InterruptCtrl
     where
         Self: Sized;
 }
-
-pub trait Address:
-    Copy
-    + ops::Add<usize, Output = Self>
-    + ops::Sub<usize, Output = Self>
-    + ops::AddAssign<usize>
-    + ops::SubAssign<usize>
-    + PartialEq
-    + Eq
-    + PartialOrd
-    + Ord
-    + fmt::Debug
-{
-    fn as_usize(self) -> usize;
-
-    /// Aligns `self` up to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_up<A: Into<usize>>(self, align: A) -> Self;
-
-    /// Aligns `self` down to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, align: A) -> Self;
-
-    /// Offsets this address by `offset`.
-    ///
-    /// If the specified offset would overflow, this function saturates instead.
-    fn offset(self, offset: i32) -> Self {
-        if offset > 0 {
-            self + offset as usize
-        } else {
-            let offset = -offset;
-            self - offset as usize
-        }
-    }
-
-    /// Returns the difference between `self` and `other`.
-    fn difference(self, other: Self) -> isize {
-        if self > other {
-            -(self.as_usize() as isize - other.as_usize() as isize)
-        } else {
-            (other.as_usize() - self.as_usize()) as isize
-        }
-    }
-
-    /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
-        self.align_down(align) == self
-    }
-
-    fn as_ptr(&self) -> *const ();
-}
-
-pub use self::boot::BootInfo;

--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -1,11 +1,11 @@
-use crate::Architecture;
+use crate::Address;
 use core::fmt;
 pub mod page;
 
 /// A cross-platform representation of a memory region.
 #[derive(Clone)]
-pub struct Region<A: Architecture> {
-    base: A::PAddr,
+pub struct Region<A = crate::PAddr> {
+    base: A,
     // TODO(eliza): should regions be stored as (start -> end) or as
     // (base + offset)?
     size: usize,
@@ -46,13 +46,13 @@ enum KindInner {
     PageTable,
 }
 
-impl<A: Architecture> Region<A> {
-    pub fn new(base: A::PAddr, size: usize, kind: RegionKind) -> Self {
+impl<A: Address> Region<A> {
+    pub fn new(base: A, size: usize, kind: RegionKind) -> Self {
         Self { base, size, kind }
     }
 
     /// Returns the base address of the memory region
-    pub fn base_addr(&self) -> A::PAddr {
+    pub fn base_addr(&self) -> A {
         self.base
     }
 
@@ -62,13 +62,13 @@ impl<A: Architecture> Region<A> {
     }
 
     /// Returns `true` if `self` contains the specified address.
-    pub fn contains(&self, addr: impl Into<A::PAddr>) -> bool {
+    pub fn contains(&self, addr: impl Into<A>) -> bool {
         let addr = addr.into();
         addr > self.base && addr < self.end_addr()
     }
 
     /// Returns the end address of the memory region.
-    pub fn end_addr(&self) -> A::PAddr {
+    pub fn end_addr(&self) -> A {
         self.base + self.size
     }
 
@@ -76,14 +76,14 @@ impl<A: Architecture> Region<A> {
         self.kind
     }
 
-    pub fn page_range<S: page::Size>(&self) -> page::PageRange<A::PAddr, S> {
+    pub fn page_range<S: page::Size>(&self) -> page::PageRange<A, S> {
         unimplemented!("eliza")
     }
 }
 
-impl<A: Architecture> fmt::Debug for Region<A>
+impl<A> fmt::Debug for Region<A>
 where
-    A::PAddr: fmt::Debug,
+    A: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Region")

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -1,4 +1,4 @@
-use crate::{Address, Architecture};
+use crate::{Address, PAddr};
 use core::{cmp, fmt, marker::PhantomData, ops, slice};
 
 pub trait Size: Copy + PartialEq + Eq {
@@ -13,7 +13,7 @@ pub trait Size: Copy + PartialEq + Eq {
 /// This trait is unsafe to implement, as implementations are responsible for
 /// guaranteeing that allocated pages are unique, and may not be allocated by
 /// another page allocator.
-pub unsafe trait Alloc<A: Architecture, S: Size> {
+pub unsafe trait Alloc<S: Size> {
     /// Allocate a single page.
     ///
     /// Note that an implementation of this method is provided as long as an
@@ -22,7 +22,7 @@ pub unsafe trait Alloc<A: Architecture, S: Size> {
     /// # Returns
     /// - `Ok(Page)` if a page was successfully allocated.
     /// - `Err` if no more pages can be allocated by this allocator.
-    fn alloc(&mut self) -> Result<Page<A::PAddr, S>, AllocErr> {
+    fn alloc(&mut self) -> Result<Page<PAddr, S>, AllocErr> {
         self.alloc_range(1).map(|r| r.start())
     }
 
@@ -31,7 +31,7 @@ pub unsafe trait Alloc<A: Architecture, S: Size> {
     /// # Returns
     /// - `Ok(PageRange)` if a range of pages was successfully allocated
     /// - `Err` if the requested range could not be satisfied by this allocator.
-    fn alloc_range(&mut self, len: usize) -> Result<PageRange<A::PAddr, S>, AllocErr>;
+    fn alloc_range(&mut self, len: usize) -> Result<PageRange<PAddr, S>, AllocErr>;
 
     /// Deallocate a single page.
     ///
@@ -41,7 +41,7 @@ pub unsafe trait Alloc<A: Architecture, S: Size> {
     /// # Returns
     /// - `Ok(())` if the page was successfully deallocated.
     /// - `Err` if the requested range could not be deallocated.
-    fn dealloc(&mut self, page: Page<A::PAddr, S>) -> Result<(), AllocErr> {
+    fn dealloc(&mut self, page: Page<PAddr, S>) -> Result<(), AllocErr> {
         self.dealloc_range(page.range_inclusive(page))
     }
 
@@ -50,7 +50,7 @@ pub unsafe trait Alloc<A: Architecture, S: Size> {
     /// # Returns
     /// - `Ok(())` if a range of pages was successfully deallocated
     /// - `Err` if the requested range could not be deallocated.
-    fn dealloc_range(&self, range: PageRange<A::PAddr, S>) -> Result<(), AllocErr>;
+    fn dealloc_range(&self, range: PageRange<PAddr, S>) -> Result<(), AllocErr>;
 }
 
 /// A memory page.

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -205,6 +205,17 @@ impl fmt::Debug for Registers {
     }
 }
 
+impl fmt::Display for Registers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "  rip:   {:?}", self.instruction_ptr)?;
+        writeln!(f, "  cs:    {:?}", self.code_segment)?;
+        writeln!(f, "  flags: {:#b}", self.cpu_flags)?;
+        writeln!(f, "  rsp:   {:?}", self.stack_ptr)?;
+        writeln!(f, "  ss:    {:?}", self.stack_segment)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -11,6 +11,8 @@ pub use pic::CascadedPic;
 
 use hal_core::interrupt::{ctx, Handlers};
 
+pub type Control = &'static mut Idt;
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct Context<'a, T = ()> {
@@ -107,7 +109,7 @@ impl Handlers for TestHandlersImpl {
     }
 }
 
-pub fn init(bootinfo: &impl hal_core::boot::BootInfo) -> &'static mut idt::Idt {
+pub fn init(bootinfo: &impl hal_core::boot::BootInfo) -> Control {
     use hal_core::interrupt::Control;
 
     let span = tracing::info_span!("interrupts::init");

--- a/hal-x86_64/src/interrupt/pic.rs
+++ b/hal-x86_64/src/interrupt/pic.rs
@@ -48,11 +48,9 @@ impl CascadedPic {
 }
 
 impl hal_core::interrupt::Control for CascadedPic {
-    type Arch = crate::X64;
-
     fn register_handlers<H>(&mut self) -> Result<(), hal_core::interrupt::RegistrationError>
     where
-        H: Handlers<Self::Arch>,
+        H: Handlers,
     {
         Err(RegistrationError::other(
             "x86_64 handlers must be registered via the IDT, not to the PIC interrupt component",
@@ -82,7 +80,7 @@ impl CascadedPic {
         // machines". it is not entirely clear what "older machines" exactly means, or where this
         // is or is not necessary precisely. this code happens to work in qemu without `iowait()`,
         // but is largely untested on real hardware where this may be a concern.
-        let iowait = || { cpu::Port::at(0x80).writeb(0) };
+        let iowait = || cpu::Port::at(0x80).writeb(0);
 
         let primary_mask = self.primary.data.readb();
         let secondary_mask = self.secondary.data.readb();

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -7,8 +7,6 @@
 // inadvertantly copied.
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
-use core::{fmt, ops};
-use hal_core::{Address, Architecture};
 pub(crate) use hal_core::{PAddr, VAddr};
 pub mod cpu;
 pub mod interrupt;
@@ -17,17 +15,4 @@ pub mod serial;
 pub mod tracing;
 pub mod vga;
 
-#[derive(Debug)]
-pub struct X64;
-
-impl Architecture for X64 {
-    const NAME: &'static str = "x86_64";
-    type InterruptCtrl = crate::interrupt::Idt;
-
-    fn init_interrupts(bootinfo: &impl hal_core::boot::BootInfo) -> &'static mut Self::InterruptCtrl
-    where
-        Self: Sized,
-    {
-        crate::interrupt::init(bootinfo)
-    }
-}
+pub const NAME: &'static str = "x86_64";

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -9,7 +9,7 @@
 
 use core::{fmt, ops};
 use hal_core::{Address, Architecture};
-
+pub(crate) use hal_core::{PAddr, VAddr};
 pub mod cpu;
 pub mod interrupt;
 pub mod segment;
@@ -17,227 +17,17 @@ pub mod serial;
 pub mod tracing;
 pub mod vga;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[repr(transparent)]
-pub struct PAddr(u64);
-
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[repr(transparent)]
-pub struct VAddr(u64);
-
 #[derive(Debug)]
 pub struct X64;
 
 impl Architecture for X64 {
-    type PAddr = PAddr;
-    type VAddr = VAddr;
     const NAME: &'static str = "x86_64";
     type InterruptCtrl = crate::interrupt::Idt;
 
-    fn init_interrupts(
-        bootinfo: &impl hal_core::boot::BootInfo<Arch = Self>,
-    ) -> &'static mut Self::InterruptCtrl
+    fn init_interrupts(bootinfo: &impl hal_core::boot::BootInfo) -> &'static mut Self::InterruptCtrl
     where
         Self: Sized,
     {
         crate::interrupt::init(bootinfo)
-    }
-}
-
-impl fmt::Debug for PAddr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(width) = f.width() {
-            f.debug_tuple("PAddr")
-                .field(&format_args!("{:#0width$x}", self.0, width = width))
-                .finish()
-        } else {
-            f.debug_tuple("PAddr")
-                .field(&format_args!("{:#x}", self.0,))
-                .finish()
-        }
-    }
-}
-
-impl ops::Add<usize> for PAddr {
-    type Output = Self;
-    fn add(self, rhs: usize) -> Self {
-        PAddr(self.0 + rhs as u64)
-    }
-}
-
-impl ops::Add for PAddr {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        PAddr(self.0 + rhs.0)
-    }
-}
-
-impl ops::AddAssign for PAddr {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
-
-impl ops::AddAssign<usize> for PAddr {
-    fn add_assign(&mut self, rhs: usize) {
-        self.0 += rhs as u64;
-    }
-}
-
-impl ops::Sub<usize> for PAddr {
-    type Output = Self;
-    fn sub(self, rhs: usize) -> Self {
-        PAddr(self.0 - rhs as u64)
-    }
-}
-
-impl ops::Sub for PAddr {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self {
-        PAddr(self.0 - rhs.0)
-    }
-}
-
-impl ops::SubAssign for PAddr {
-    fn sub_assign(&mut self, rhs: Self) {
-        self.0 -= rhs.0;
-    }
-}
-
-impl ops::SubAssign<usize> for PAddr {
-    fn sub_assign(&mut self, rhs: usize) {
-        self.0 -= rhs as u64;
-    }
-}
-
-impl Address for PAddr {
-    fn as_usize(self) -> usize {
-        self.0 as usize
-    }
-
-    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Aligns `self` down to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
-        unimplemented!("eliza")
-    }
-
-    fn as_ptr(&self) -> *const () {
-        unimplemented!("eliza")
-    }
-}
-
-impl PAddr {
-    pub fn from_u64(u: u64) -> Self {
-        // TODO(eliza): ensure that this is a valid physical address?
-        PAddr(u)
-    }
-}
-
-impl ops::Add<usize> for VAddr {
-    type Output = Self;
-    fn add(self, rhs: usize) -> Self {
-        VAddr(self.0 + rhs as u64)
-    }
-}
-
-impl ops::Add for VAddr {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        VAddr(self.0 + rhs.0)
-    }
-}
-
-impl ops::AddAssign for VAddr {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
-
-impl ops::AddAssign<usize> for VAddr {
-    fn add_assign(&mut self, rhs: usize) {
-        self.0 += rhs as u64;
-    }
-}
-
-impl ops::Sub<usize> for VAddr {
-    type Output = Self;
-    fn sub(self, rhs: usize) -> Self {
-        VAddr(self.0 - rhs as u64)
-    }
-}
-
-impl ops::Sub for VAddr {
-    type Output = Self;
-    fn sub(self, rhs: Self) -> Self {
-        VAddr(self.0 - rhs.0)
-    }
-}
-
-impl ops::SubAssign for VAddr {
-    fn sub_assign(&mut self, rhs: Self) {
-        self.0 -= rhs.0;
-    }
-}
-
-impl ops::SubAssign<usize> for VAddr {
-    fn sub_assign(&mut self, rhs: usize) {
-        self.0 -= rhs as u64;
-    }
-}
-
-impl Address for VAddr {
-    fn as_usize(self) -> usize {
-        self.0 as usize
-    }
-
-    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Aligns `self` down to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
-        unimplemented!("eliza")
-    }
-
-    fn as_ptr(&self) -> *const () {
-        unimplemented!("eliza")
-    }
-}
-
-impl VAddr {
-    pub fn from_u64(u: u64) -> Self {
-        // TODO(eliza): ensure that this is a valid virtual address?
-        VAddr(u)
-    }
-}
-
-impl fmt::Debug for VAddr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(width) = f.width() {
-            f.debug_tuple("VAddr")
-                .field(&format_args!("{:#0width$x}", self.0, width = width))
-                .finish()
-        } else {
-            f.debug_tuple("VAddr")
-                .field(&format_args!("{:#x}", self.0,))
-                .finish()
-        }
     }
 }

--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -1,4 +1,4 @@
-use core::{cmp, fmt, ptr};
+use core::{fmt, ptr};
 use mycelium_util::{io, sync::spin};
 
 lazy_static::lazy_static! {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) use self::x86_64::*;
+pub use self::x86_64::*;

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,6 +1,7 @@
 use bootloader::bootinfo;
 use hal_core::{boot::BootInfo, mem, Address, PAddr};
-use hal_x86_64::{vga, X64};
+use hal_x86_64::vga;
+pub use hal_x86_64::{interrupt, NAME};
 
 #[derive(Debug)]
 pub struct RustbootBootInfo {
@@ -67,12 +68,12 @@ impl BootInfo for RustbootBootInfo {
 #[cfg(target_os = "none")]
 pub extern "C" fn _start(info: &'static bootinfo::BootInfo) -> ! {
     let bootinfo = RustbootBootInfo { inner: info };
-    mycelium_kernel::kernel_main(&bootinfo);
+    crate::kernel_main(&bootinfo);
 }
 
 #[cold]
 #[cfg(target_os = "none")]
-pub(crate) fn oops(cause: &dyn core::fmt::Display) -> ! {
+pub fn oops(cause: &dyn core::fmt::Display) -> ! {
     use core::fmt::Write;
 
     unsafe { asm!("cli" :::: "volatile") }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,6 +1,6 @@
 use bootloader::bootinfo;
-use hal_core::{boot::BootInfo, mem, Address};
-use hal_x86_64::{vga, PAddr, X64};
+use hal_core::{boot::BootInfo, mem, Address, PAddr};
+use hal_x86_64::{vga, X64};
 
 #[derive(Debug)]
 pub struct RustbootBootInfo {
@@ -10,10 +10,8 @@ pub struct RustbootBootInfo {
 type MemRegionIter = core::slice::Iter<'static, bootinfo::MemoryRegion>;
 
 impl BootInfo for RustbootBootInfo {
-    type Arch = X64;
     // TODO(eliza): implement
-    type MemoryMap =
-        core::iter::Map<MemRegionIter, fn(&bootinfo::MemoryRegion) -> mem::Region<X64>>;
+    type MemoryMap = core::iter::Map<MemRegionIter, fn(&bootinfo::MemoryRegion) -> mem::Region>;
 
     type Writer = vga::Writer;
 
@@ -35,7 +33,7 @@ impl BootInfo for RustbootBootInfo {
             }
         }
 
-        fn convert_region(region: &bootinfo::MemoryRegion) -> mem::Region<X64> {
+        fn convert_region(region: &bootinfo::MemoryRegion) -> mem::Region {
             let start = PAddr::from_u64(region.range.start_addr());
             let size = {
                 let end = PAddr::from_u64(region.range.end_addr()).offset(1);

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -128,7 +128,6 @@ pub extern "C" fn _start(info: &'static bootinfo::BootInfo) -> ! {
 }
 
 #[cold]
-#[cfg(target_os = "none")]
 pub fn oops(cause: &dyn core::fmt::Display) -> ! {
     use core::fmt::Write;
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,23 +1,17 @@
 use core::marker::PhantomData;
-use hal_core::{
-    interrupt::{self, ctx},
-    Architecture,
-};
+use hal_core::interrupt::{self, ctx};
 
-pub struct Handlers<A> {
-    _p: PhantomData<A>,
+pub struct Handlers {
+    _p: (),
 }
 
 // TODO(eliza): ag.
 static mut TIMER: usize = 0;
 
-impl<A> interrupt::Handlers<A> for Handlers<A>
-where
-    A: Architecture,
-{
+impl interrupt::Handlers for Handlers {
     fn page_fault<C>(cx: C)
     where
-        C: ctx::Context<Arch = A> + ctx::PageFault,
+        C: ctx::Context + ctx::PageFault,
     {
         tracing::error!(registers = ?cx.registers(), "page fault");
         loop {}
@@ -25,7 +19,7 @@ where
 
     fn code_fault<C>(cx: C)
     where
-        C: ctx::Context<Arch = A> + ctx::CodeFault,
+        C: ctx::Context + ctx::CodeFault,
     {
         tracing::error!(kind = ?cx.kind(), registers = ?cx.registers(), "code fault");
         loop {}
@@ -59,7 +53,7 @@ where
 
     fn test_interrupt<C>(cx: C)
     where
-        C: ctx::Context<Arch = A>,
+        C: ctx::Context,
     {
         tracing::info!(registers=?cx.registers(), "lol im in ur test interrupt");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,23 @@
 #![cfg_attr(target_os = "none", no_std)]
+#![cfg_attr(target_os = "none", no_main)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
-
+#![cfg_attr(target_os = "none", feature(asm))]
 extern crate alloc;
 
+pub mod arch;
+
 use core::fmt::Write;
-use hal_core::{boot::BootInfo, mem, Architecture};
+use hal_core::{boot::BootInfo, mem};
 
 use alloc::vec::Vec;
 
-pub fn kernel_main<A>(bootinfo: &impl BootInfo) -> !
-where
-    A: Architecture,
-{
+pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     let mut writer = bootinfo.writer();
     writeln!(
         &mut writer,
         "hello from mycelium {} (on {})",
         env!("CARGO_PKG_VERSION"),
-        A::NAME
+        arch::NAME
     )
     .unwrap();
     writeln!(&mut writer, "booting via {}", bootinfo.bootloader_name()).unwrap();
@@ -57,7 +57,7 @@ where
         );
     }
 
-    A::init_interrupts(bootinfo);
+    arch::interrupt::init(bootinfo);
 
     {
         let span = tracing::info_span!("alloc test");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use hal_core::{boot::BootInfo, mem, Architecture};
 
 use alloc::vec::Vec;
 
-pub fn kernel_main<A>(bootinfo: &impl BootInfo<Arch = A>) -> !
+pub fn kernel_main<A>(bootinfo: &impl BootInfo) -> !
 where
     A: Architecture,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(target_os = "none", no_std)]
-#![cfg_attr(target_os = "none", no_main)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 #![cfg_attr(target_os = "none", feature(asm))]
 extern crate alloc;
@@ -57,7 +56,7 @@ pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
         );
     }
 
-    arch::interrupt::init(bootinfo);
+    arch::interrupt::init::<arch::InterruptHandlers>();
 
     {
         let span = tracing::info_span!("alloc test");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod wasm;
 
 const HELLOWORLD_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/helloworld.wasm"));
 
+pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     let mut writer = bootinfo.writer();
     writeln!(
         &mut writer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
-#![cfg_attr(target_os = "none", feature(asm))]
+#![feature(asm)]
 extern crate alloc;
 
 pub mod arch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
         assert_eq!(v.pop(), Some(5));
     }
 
+    unsafe { asm!("int $$0") }
+
     // if this function returns we would boot loop. Hang, instead, so the debug
     // output can be read.
     //

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 #![cfg_attr(target_os = "none", feature(asm))]
 #![cfg_attr(target_os = "none", feature(panic_info_message, track_caller))]
-
-pub mod arch;
+use mycelium_kernel::arch;
 
 #[cfg(target_os = "none")]
 #[panic_handler]


### PR DESCRIPTION
The `Architecture` trait means that pretty much all downstream code that
consumes `hal-core` has to be parameterized over an architecture type,
which is kind of painful. `Architecture` pretty much only provides two
things: definitions of the `PAddr` and `VAddr` types, and an API
contract for architecture implementations.

On most architectures that we are likely to want to target, it's pretty
reasonable to represent `PAddr`s and `VAddr`s as words instead, using
`usize` as the inner repr. This means that for most architectures, HAL
implementations can still be written in separate crates without changing
`hal-core`. For architectures where we _do_ wish to add
architecture-specific logic in the address types, such as validating
that x86 addresses are in canonical form, or which require `PAddr`s or
`VAddr`s to have non-`usize` reprss, we can add `#[cfg(target_arch =
...)]` versions of the address types in `hal-core`.

As far as providing a contract for the shape of the top-level arch APIs,
we can probably solve this through documentation, if there are ever
third-party HAL impls. This may also not matter as much as I thought it
might, since non-arch crates written against the HAL will still probably
be generic over `hal-core` traits for whatever specific HAL APIs they
depend on.

I've also moved the interrupt handler implementations out of the 
`hal-x86_64` crate and into the kernel proper!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>