### PR TITLE
decode x86 instructions around where we fault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,8 @@ dependencies = [
  "tracing",
  "wasmi",
  "wat",
+ "yaxpeax-arch",
+ "yaxpeax-x86",
 ]
 
 [[package]]
@@ -1002,3 +1004,22 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaxpeax-arch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effe4b97c0b314b9fa460f2513cd3eb5ffaf9643cc13c3307476b84f92e54175"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "yaxpeax-x86"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8cf2aeb6c9b75d7e4ada5b26bcfa3ca7102b6b7c70a6a1ea2bcc59738b7229"
+dependencies = [
+ "num-traits",
+ "yaxpeax-arch",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ mycotest = { path = "mycotest" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 hal-x86_64 = { path = "hal-x86_64" }
+yaxpeax-x86 = { version = "0.0.13", default-features = false }
+yaxpeax-arch = { version = "0.0.4", default-features = false }
 
 [dependencies.tracing]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mycotest = { path = "mycotest" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 hal-x86_64 = { path = "hal-x86_64" }
-yaxpeax-x86 = { version = "0.0.13", default-features = false }
-yaxpeax-arch = { version = "0.0.4", default-features = false }
+yaxpeax-x86 = { version = "1.0.0", default-features = false, features = ["fmt"] }
+yaxpeax-arch = { version = "0.2.0", default-features = false }
 
 [dependencies.tracing]
 version = "0.1"

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -212,16 +212,16 @@ pub fn oops(
 
         use hal_core::Address;
         let fault_addr = registers.instruction_ptr.as_usize();
-        use yaxpeax_arch::{Arch, Decoder, Instruction, LengthedInstruction};
+        use yaxpeax_arch::LengthedInstruction;
         let _ = writeln!(vga, "Disassembly:");
         let mut ptr = fault_addr as u64;
-        let decoder = <yaxpeax_x86::long_mode::Arch as Arch>::Decoder::default();
-        for i in 0..10 {
+        let decoder = yaxpeax_x86::long_mode::InstDecoder::default();
+        for _ in 0..10 {
             // Safety: who cares! At worst this might double-fault by reading past the end of valid
             // memory. whoopsie.
             let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, 16) };
             let _ = write!(vga, "  {:016x}: ", ptr).unwrap();
-            match decoder.decode(bytes.iter().cloned()) {
+            match decoder.decode_slice(bytes) {
                 Ok(inst) => {
                     let _ = writeln!(vga, "{}", inst);
                     ptr += inst.len();

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -209,6 +209,29 @@ pub fn oops(
     let _ = writeln!(vga, "\n  uwu we did a widdle fucky-wucky!\n{}", cause);
     if let Some(registers) = registers {
         let _ = writeln!(vga, "\n{}\n", registers);
+
+        use hal_core::Address;
+        let fault_addr = registers.instruction_ptr.as_usize();
+        use yaxpeax_arch::{Arch, Decoder, Instruction, LengthedInstruction};
+        let _ = writeln!(vga, "Disassembly:");
+        let mut ptr = fault_addr as u64;
+        let decoder = <yaxpeax_x86::long_mode::Arch as Arch>::Decoder::default();
+        for i in 0..10 {
+            // Safety: who cares! At worst this might double-fault by reading past the end of valid
+            // memory. whoopsie.
+            let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, 16) };
+            let _ = write!(vga, "  {:016x}: ", ptr).unwrap();
+            match decoder.decode(bytes.iter().cloned()) {
+                Ok(inst) => {
+                    let _ = writeln!(vga, "{}", inst);
+                    ptr += inst.len();
+                }
+                Err(e) => {
+                    let _ = writeln!(vga, "{}", e);
+                    break;
+                }
+            }
+        }
     }
     let _ = vga.write_str("\n  it will never be safe to turn off your computer.");
 


### PR DESCRIPTION
![it decodes instructions! and prints them!](https://user-images.githubusercontent.com/4615790/82854393-24b3eb80-9ebd-11ea-9f32-b5ba81caaf38.png)

~we've talked about putting this in the oops fn, which i think would be much better, but by the time we're in `oops()` the only context we have is some `Display` thing. and even there, the cause we get is a call site is a `core::panic::Location`, which gets us a line and column of the offending source, but not an actual instruction pointer :(~

this punts decoding and displaying to the architecture-specific `oops` fn, i tried stitching it into `Context` in some form but trying to have a mutable iterator-shaped thing available from a `Context` is beyond what i have patience to get into the type system.

we might be able to do something with `backtrace` to get instruction pointers, and that probably lets us get function start addresses so we could actually disassemble some instructions before the fault address, like @mystor was hoping - hopefully the faulting instruction wasn't reached from a conditional!

also yaxpeax is crates now so i can just add 33 lines and it works and that owns