### PR TITLE
feat(hal-core): address type improvements

### DIFF
--- a/hal-core/Cargo.toml
+++ b/hal-core/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 tracing = { version = "0.1", default_features = false }
-
+mycelium-util = { path = "../util" }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -255,7 +255,7 @@ impl Address for VAddr {
     #[cfg(target_arch = "x86_64")]
     fn from_usize(u: usize) -> Self {
         // sign extend bit 47
-        let value = ((u as i64) << 16) as u64 >> 16;
+        let value = ((u << 16) as i64 >> 16) as u64;
         Self(value as usize)
     }
 

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -174,8 +174,12 @@ impl Address for PAddr {
     #[inline]
     fn from_usize(u: usize) -> Self {
         #[cfg(target_arch = "x86_64")]
-        debug_assert!(
-            u & MASK == 0,
+        const MASK: usize = 0xFFF0_0000_0000_0000;
+
+        #[cfg(target_arch = "x86_64")]
+        debug_assert_eq!(
+            u & MASK,
+            0,
             "x86_64 physical addresses may not have the 12 most significant bits set!"
         );
         Self(u)
@@ -254,9 +258,9 @@ impl Address for VAddr {
     #[inline]
     fn from_usize(u: usize) -> Self {
         #[cfg(target_arch = "x86_64")]
-        debug_assert!(
-            Vaddr(u),
-            Vaddr(((u << 16) as i64 >> 16) as usize), // sign extend bit 47
+        debug_assert_eq!(
+            VAddr(u),
+            VAddr(((u << 16) as i64 >> 16) as usize), // sign extend bit 47
             "x86_64 virtual addresses must be in canonical form"
         );
         Self(u)

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -73,7 +73,20 @@ pub trait Address:
         self.align_down(align) == self
     }
 
-    fn as_ptr(&self) -> *const ();
+    /// Returns `true` if `self` is aligned on the alignment of the specified
+    /// type.
+    #[inline]
+    fn is_aligned_for<T>(self) -> bool {
+        self.is_aligned(core::mem::align_of::<T>())
+    }
+
+    /// # Panics
+    ///
+    /// - If `self` is not aligned for a `T`-typed value.
+    fn as_ptr<T>(self) -> *mut T {
+        assert!(self.is_aligned_for::<T>());
+        self.as_usize() as *mut T
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -172,12 +172,11 @@ impl Address for PAddr {
     #[inline]
     #[cfg(target_arch = "x86_64")]
     fn from_usize(u: usize) -> Self {
-        const MASK: usize = 0xFFF0_0000_0000_0000;
         debug_assert!(
             u & MASK == 0,
             "x86_64 physical addresses may not have the 12 most significant bits set!"
         );
-        Self(u & !MASK)
+        Self(u)
     }
 
     #[cfg(not(target_arch = "x86_64"))]
@@ -254,9 +253,12 @@ impl Address for VAddr {
     #[inline]
     #[cfg(target_arch = "x86_64")]
     fn from_usize(u: usize) -> Self {
-        // sign extend bit 47
-        let value = ((u << 16) as i64 >> 16) as u64;
-        Self(value as usize)
+        debug_assert!(
+            Vaddr(u),
+            Vaddr(((u << 16) as i64 >> 16) as usize), // sign extend bit 47
+            "x86_64 vaddr must be in canonical form"
+        );
+        Self(u)
     }
 
     #[cfg(not(target_arch = "x86_64"))]
@@ -322,22 +324,22 @@ mod tests {
         );
     }
 
-    #[cfg(target_arch = "x86_64")]
-    #[test]
-    fn sign_extend_vaddr() {
-        let actual = VAddr::from_usize(123 | (1 << 47)).as_usize();
-        let expected = (0xFFFFF << 47) | 123;
-        assert_eq!(
-            actual, expected,
-            "\n  left: `{:064b}`\n right: `{:064b}`",
-            actual, expected
-        );
-        let actual = VAddr::from_usize(123 | (1010 << 47)).as_usize();
-        let expected = 123;
-        assert_eq!(
-            actual, expected,
-            "\n  left: `{:064b}`\n right: `{:064b}`",
-            actual, expected
-        );
-    }
+    // #[cfg(target_arch = "x86_64")]
+    // #[test]
+    // fn sign_extend_vaddr() {
+    //     let actual = VAddr::from_usize(123 | (1 << 47)).as_usize();
+    //     let expected = (0xFFFFF << 47) | 123;
+    //     assert_eq!(
+    //         actual, expected,
+    //         "\n  left: `{:064b}`\n right: `{:064b}`",
+    //         actual, expected
+    //     );
+    //     let actual = VAddr::from_usize(123 | (1010 << 47)).as_usize();
+    //     let expected = 123;
+    //     assert_eq!(
+    //         actual, expected,
+    //         "\n  left: `{:064b}`\n right: `{:064b}`",
+    //         actual, expected
+    //     );
+    // }
 }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -286,3 +286,39 @@ impl fmt::Debug for VAddr {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_up_1_aligned() {
+        // TODO(eliza): eventually, this could be a QuickCheck test that asserts
+        // that _all_ addresses align up by 1 to themselves.
+        assert_eq!(
+            PAddr::from_usize(0x0).align_up(1usize),
+            PAddr::from_usize(0x0)
+        );
+        assert_eq!(
+            PAddr::from_usize(0xDEADFACE).align_up(1usize),
+            PAddr::from_usize(0xDEADFACE)
+        );
+        assert_eq!(
+            PAddr::from_usize(0x000_F_FFFF_FFFF_FFFF).align_up(1usize),
+            PAddr::from_usize(0x000_F_FFFF_FFFF_FFFF)
+        );
+    }
+
+    #[test]
+    fn align_up() {
+        assert_eq!(PAddr::from_usize(2).align_up(2usize), PAddr::from_usize(2));
+        assert_eq!(
+            PAddr::from_usize(123).align_up(2usize),
+            PAddr::from_usize(124)
+        );
+        assert_eq!(
+            PAddr::from_usize(0x5555).align_up(16usize),
+            PAddr::from_usize(0x5560)
+        );
+    }
+}

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -25,8 +25,13 @@ pub trait Address:
     fn align_up<A: Into<usize>>(self, align: A) -> Self {
         let align = align.into();
         assert!(align.is_power_of_two());
-        let aligned = self.as_usize() & !(align - 1);
-        Self::from_usize(aligned)
+        let mask = align - 1;
+        let u = self.as_usize();
+        if u & mask == 0 {
+            return self;
+        }
+        let aligned = (u | mask) + 1;
+        Self::from_usize(aligned as usize)
     }
 
     /// Aligns `self` down to `align`.
@@ -39,13 +44,8 @@ pub trait Address:
     fn align_down<A: Into<usize>>(self, align: A) -> Self {
         let align = align.into();
         assert!(align.is_power_of_two());
-        let mask = align - 1;
-        let u = self.as_usize();
-        if u & mask == 0 {
-            return self;
-        }
-        let aligned = (u | mask) + 1;
-        Self::from_usize(aligned as usize)
+        let aligned = self.as_usize() & !(align - 1);
+        Self::from_usize(aligned)
     }
 
     /// Offsets this address by `offset`.

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -180,10 +180,6 @@ impl Address for PAddr {
         );
         Self(u)
     }
-
-    fn from_usize(u: usize) -> Self {
-        Self(u)
-    }
 }
 
 impl PAddr {

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -182,7 +182,7 @@ impl Address for PAddr {
 
     #[cfg(not(target_arch = "x86_64"))]
     fn from_usize(u: usize) -> Self {
-        Self(0)
+        Self(u)
     }
 }
 
@@ -261,7 +261,7 @@ impl Address for VAddr {
 
     #[cfg(not(target_arch = "x86_64"))]
     fn from_usize(u: usize) -> Self {
-        Self(0)
+        Self(u)
     }
 }
 

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -321,4 +321,23 @@ mod tests {
             PAddr::from_usize(0x5560)
         );
     }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn sign_extend_vaddr() {
+        let actual = VAddr::from_usize(123 | (1 << 47)).as_usize();
+        let expected = (0xFFFFF << 47) | 123;
+        assert_eq!(
+            actual, expected,
+            "\n  left: `{:064b}`\n right: `{:064b}`",
+            actual, expected
+        );
+        let actual = VAddr::from_usize(123 | (1010 << 47)).as_usize();
+        let expected = 123;
+        assert_eq!(
+            actual, expected,
+            "\n  left: `{:064b}`\n right: `{:064b}`",
+            actual, expected
+        );
+    }
 }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -185,7 +185,6 @@ impl Address for PAddr {
 impl PAddr {
     #[cfg(target_pointer_width = "64")]
     pub fn from_u64(u: u64) -> Self {
-        // TODO(eliza): ensure that this is a valid physical address?
         Self::from_usize(u as usize)
     }
 }
@@ -262,7 +261,6 @@ impl Address for VAddr {
 impl VAddr {
     #[cfg(target_pointer_width = "64")]
     pub fn from_u64(u: u64) -> Self {
-        // TODO(eliza): ensure that this is a valid virtual address?
         Self::from_usize(u as usize)
     }
 }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -190,6 +190,65 @@ macro_rules! impl_addrs {
                 pub fn from_u32(u: u32) -> Self {
                     Self::from_usize(u as usize)
                 }
+
+                /// Aligns `self` up to `align`.
+                ///
+                /// The specified alignment must be a power of two.
+                ///
+                /// # Panics
+                ///
+                /// - If `align` is not a power of two.
+                #[inline]
+                pub fn align_up<A: Into<usize>>(self, align: A) -> Self {
+                    Address::align_up(self, align)
+                }
+
+                /// Aligns `self` down to `align`.
+                ///
+                /// The specified alignment must be a power of two.
+                ///
+                /// # Panics
+                ///
+                /// - If `align` is not a power of two.
+                #[inline]
+                pub fn align_down<A: Into<usize>>(self, align: A) -> Self {
+                    Address::align_down(self, align)
+                }
+
+                /// Offsets this address by `offset`.
+                ///
+                /// If the specified offset would overflow, this function saturates instead.
+                #[inline]
+                pub fn offset(self, offset: i32) -> Self {
+                    Address::offset(self, offset)
+                }
+
+                /// Returns the difference between `self` and `other`.
+                #[inline]
+                pub fn difference(self, other: Self) -> isize {
+                    Address::difference(self, other)
+                }
+
+                /// Returns `true` if `self` is aligned on the specified alignment.
+                #[inline]
+                pub fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
+                    Address::is_aligned(self, align)
+                }
+
+                /// Returns `true` if `self` is aligned on the alignment of the specified
+                /// type.
+                #[inline]
+                pub fn is_aligned_for<T>(self) -> bool {
+                    Address::is_aligned_for::<T>(self)
+                }
+
+                /// # Panics
+                ///
+                /// - If `self` is not aligned for a `T`-typed value.
+                #[inline]
+                pub fn as_ptr<T>(self) -> *mut T {
+                    Address::as_ptr(self)
+                }
             }
         )+
     }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -187,6 +187,11 @@ impl PAddr {
     pub fn from_u64(u: u64) -> Self {
         Self::from_usize(u as usize)
     }
+
+    #[cfg(target_pointer_width = "u32")]
+    pub fn from_u32(u: u32) -> Self {
+        Self::from_usize(u as usize)
+    }
 }
 
 impl ops::Add<usize> for VAddr {
@@ -261,6 +266,11 @@ impl Address for VAddr {
 impl VAddr {
     #[cfg(target_pointer_width = "64")]
     pub fn from_u64(u: u64) -> Self {
+        Self::from_usize(u as usize)
+    }
+
+    #[cfg(target_pointer_width = "u32")]
+    pub fn from_u32(u: u32) -> Self {
         Self::from_usize(u as usize)
     }
 }

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -13,16 +13,39 @@ pub trait Address:
     + fmt::Debug
 {
     fn as_usize(self) -> usize;
+    fn from_usize(u: usize) -> Self;
 
     /// Aligns `self` up to `align`.
     ///
     /// The specified alignment must be a power of two.
-    fn align_up<A: Into<usize>>(self, align: A) -> Self;
+    ///
+    /// # Panics
+    ///
+    /// - If `align` is not a power of two.
+    fn align_up<A: Into<usize>>(self, align: A) -> Self {
+        let align = align.into();
+        assert!(align.is_power_of_two());
+        let aligned = self.as_usize() & !(align - 1);
+        Self::from_usize(aligned)
+    }
 
     /// Aligns `self` down to `align`.
     ///
     /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, align: A) -> Self;
+    ///
+    /// # Panics
+    ///
+    /// - If `align` is not a power of two.
+    fn align_down<A: Into<usize>>(self, align: A) -> Self {
+        let align = align.into();
+        assert!(align.is_power_of_two());
+        let mask = align - 1;
+        let u = self.as_usize();
+        if u & mask == 0 {
+            return self;
+        }
+        Self::from((u | mask) + 1)
+    }
 
     /// Offsets this address by `offset`.
     ///
@@ -132,24 +155,9 @@ impl Address for PAddr {
         self.0 as usize
     }
 
-    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Aligns `self` down to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
-        unimplemented!("eliza")
-    }
-
-    fn as_ptr(&self) -> *const () {
-        unimplemented!("eliza")
+    #[inline]
+    fn from_usize(u: usize) -> usize {
+        Self(0)
     }
 }
 
@@ -157,7 +165,7 @@ impl PAddr {
     #[cfg(target_pointer_width = "64")]
     pub fn from_u64(u: u64) -> Self {
         // TODO(eliza): ensure that this is a valid physical address?
-        PAddr(u as usize)
+        Self::from_usize(u as usize)
     }
 }
 
@@ -218,24 +226,9 @@ impl Address for VAddr {
         self.0 as usize
     }
 
-    fn align_up<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Aligns `self` down to `align`.
-    ///
-    /// The specified alignment must be a power of two.
-    fn align_down<A: Into<usize>>(self, _align: A) -> Self {
-        unimplemented!("eliza")
-    }
-
-    /// Returns `true` if `self` is aligned on the specified alignment.
-    fn is_aligned<A: Into<usize>>(self, _align: A) -> bool {
-        unimplemented!("eliza")
-    }
-
-    fn as_ptr(&self) -> *const () {
-        unimplemented!("eliza")
+    #[inline]
+    fn from_usize(u: usize) -> usize {
+        Self(0)
     }
 }
 
@@ -243,7 +236,7 @@ impl VAddr {
     #[cfg(target_pointer_width = "64")]
     pub fn from_u64(u: u64) -> Self {
         // TODO(eliza): ensure that this is a valid virtual address?
-        VAddr(u as usize)
+        Self::from_usize(u as usize)
     }
 }
 


### PR DESCRIPTION
This branch makes the following changes:

* feat(hal-core): implement Address::{align_up, align_down}

  Add generic default implementations of `align_up` and `align_down` to
  all types implementing Address. These are implemented using a new 
  required `from_usize` constructor.

* feat(hal-core): `Address::as_ptr` returns typed mut ptr

  As discussed in [this comment][1], `as_ptr` now returns a `*mut T`
  rather than a `*const ()`. It will now assert that the address is
  correctly aligned for a `T`, using a new `is_aligned_for::<T>` 
  convenience method.

* feat(hal-core): validate/canonicalize x86_64 addrs 

  Add `#[cfg(target_arch = "x86_64")]` implementations of 
  `Address::from_usize` for `PAddr`/`VAddr` that assert the address
  is sign-extended/canonicalized when compiled in debug mode. 
  Additionally, add `from_usize_checked` constructors that return
  `Result` and always validate that the constructed addresses are 
   valid.

* feat(hal-core): add inherent versions of address trait methods