### PR TITLE
feat(ci): cache cargo-xbuild and bootimage binaries when running ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,18 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
     - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      id: toolcache
+      with:
+        path: _devtools
+        key: devtools-${{ runner.os }}-v0
     - name: install dev env
+      if: steps.toolcache.outputs.cache-hit != 'true'
       uses: actions-rs/cargo@v1.0.1
       with:
         command: dev-env
+        args: --root=_devtools
+    - run: echo "::add-path::_devtools/bin"
     - name: x86_64 boot image
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -33,10 +41,17 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
     - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      id: toolcache
+      with:
+        path: _devtools
+        key: devtools-${{ runner.os }}-v0
     - name: install dev env
+      if: steps.toolcache.outputs.cache-hit != 'true'
       uses: actions-rs/cargo@v1.0.1
       with:
         command: dev-env
+        args: --root=_devtools
     - name: install qemu
       run: sudo apt-get update && sudo apt-get install qemu
     - name: run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         command: dev-env
         args: --root=_devtools
+    - run: echo "::add-path::_devtools/bin"
     - name: install qemu
       run: sudo apt-get update && sudo apt-get install qemu
     - name: run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,3 +90,31 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features
+
+  xclippy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: install rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rust-src, llvm-tools-preview, clippy
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      id: toolcache
+      with:
+        path: _devtools
+        key: devtools-${{ runner.os }}-v0
+    - name: install dev env
+      if: steps.toolcache.outputs.cache-hit != 'true'
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: dev-env
+        args: --root=_devtools
+    - run: echo "::add-path::_devtools/bin"
+    - name: cargo-xclippy
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: xclippy
+        args: --target=x86_64-mycelium.json


### PR DESCRIPTION
This is a fairly flawed system, and currently won't ever actually rebuild the generated binaries, but may be acceptable. It appears to improve the performance of CI builds by about 2 minutes, from 5 minutes to 3 minutes.