### PR TITLE
fix(x86_64): forcibly unlock COM1 when oopsing

### DIFF
--- a/hal-x86_64/Cargo.toml
+++ b/hal-x86_64/Cargo.toml
@@ -11,4 +11,4 @@ log = ["tracing/log"]
 hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
 lazy_static = { version = "1.4", features = ["spin_no_std"]}
-tracing = {version = "0.1", default_features = false }
+tracing = {version = "0.1", default_features = false, features = ["attributes"] }

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -46,7 +46,7 @@ pub struct Registers {
 static mut IDT: idt::Idt = idt::Idt::new();
 static mut PIC: pic::CascadedPic = pic::CascadedPic::new();
 
-pub fn init<H: Handlers>() -> Control {
+pub fn init<H: Handlers<Registers>>() -> Control {
     use hal_core::interrupt::Control;
 
     let span = tracing::info_span!("interrupts::init");
@@ -125,6 +125,7 @@ impl<'a> Context<'a, PageFaultCode> {
 
 impl hal_core::interrupt::Control for Idt {
     // type Vector = u8;
+    type Registers = Registers;
 
     unsafe fn disable(&mut self) {
         asm!("cli" :::: "volatile");
@@ -140,40 +141,40 @@ impl hal_core::interrupt::Control for Idt {
 
     fn register_handlers<H>(&mut self) -> Result<(), hal_core::interrupt::RegistrationError>
     where
-        H: Handlers,
+        H: Handlers<Registers>,
     {
         let span = tracing::debug_span!("Idt::register_handlers");
         let _enter = span.enter();
 
-        extern "x86-interrupt" fn page_fault_isr<H: Handlers>(
+        extern "x86-interrupt" fn page_fault_isr<H: Handlers<Registers>>(
             registers: &mut Registers,
             code: PageFaultCode,
         ) {
             H::page_fault(Context { registers, code });
         }
 
-        extern "x86-interrupt" fn double_fault_isr<H: Handlers>(
+        extern "x86-interrupt" fn double_fault_isr<H: Handlers<Registers>>(
             registers: &mut Registers,
             code: u64,
         ) {
             H::double_fault(Context { registers, code });
         }
 
-        extern "x86-interrupt" fn timer_isr<H: Handlers>(_regs: &mut Registers) {
+        extern "x86-interrupt" fn timer_isr<H: Handlers<Registers>>(_regs: &mut Registers) {
             H::timer_tick();
             unsafe {
                 PIC.end_interrupt(0x20);
             }
         }
 
-        extern "x86-interrupt" fn keyboard_isr<H: Handlers>(_regs: &mut Registers) {
+        extern "x86-interrupt" fn keyboard_isr<H: Handlers<Registers>>(_regs: &mut Registers) {
             H::keyboard_controller();
             unsafe {
                 PIC.end_interrupt(0x21);
             }
         }
 
-        extern "x86-interrupt" fn test_isr<H: Handlers>(registers: &mut Registers) {
+        extern "x86-interrupt" fn test_isr<H: Handlers<Registers>>(registers: &mut Registers) {
             H::test_interrupt(Context {
                 registers,
                 code: (),

--- a/hal-x86_64/src/interrupt/pic.rs
+++ b/hal-x86_64/src/interrupt/pic.rs
@@ -48,9 +48,10 @@ impl CascadedPic {
 }
 
 impl hal_core::interrupt::Control for CascadedPic {
+    type Registers = super::Registers;
     fn register_handlers<H>(&mut self) -> Result<(), hal_core::interrupt::RegistrationError>
     where
-        H: Handlers,
+        H: Handlers<super::Registers>,
     {
         Err(RegistrationError::other(
             "x86_64 handlers must be registered via the IDT, not to the PIC interrupt component",

--- a/hal-x86_64/src/serial.rs
+++ b/hal-x86_64/src/serial.rs
@@ -122,6 +122,10 @@ impl Port {
             _is_blocking: PhantomData,
         }
     }
+
+    pub unsafe fn force_unlock(&self) {
+        self.inner.force_unlock();
+    }
 }
 
 impl Registers {

--- a/hal-x86_64/src/serial.rs
+++ b/hal-x86_64/src/serial.rs
@@ -123,6 +123,12 @@ impl Port {
         }
     }
 
+    /// Forcibly unlock the serial port, releasing any locks held by other cores
+    /// or in other functions.
+    ///
+    /// # Safety
+    ///
+    /// Don't.
     pub unsafe fn force_unlock(&self) {
         self.inner.force_unlock();
     }

--- a/hal-x86_64/src/serial.rs
+++ b/hal-x86_64/src/serial.rs
@@ -128,7 +128,7 @@ impl Port {
     ///
     /// # Safety
     ///
-    /// Don't.
+    ///  /!\ only call this when oopsing!!! /!\
     pub unsafe fn force_unlock(&self) {
         self.inner.force_unlock();
     }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,7 +1,6 @@
 use bootloader::bootinfo;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use hal_core::{boot::BootInfo, mem, PAddr};
-use hal_x86_64::vga;
 pub use hal_x86_64::{interrupt, NAME};
 use hal_x86_64::{serial, vga};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ fn panic(panic: &core::panic::PanicInfo) -> ! {
     let caller = core::panic::Location::caller();
     tracing::error!(%panic, ?caller);
     let pp = PrettyPanic(panic);
-    arch::oops(&pp)
+    arch::oops(&pp, None)
 }
 
 #[cfg(all(test, not(target_os = "none")))]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 alloc = []
 
 [dependencies]
-tracing = { version = "0.1", default_features = false }
+tracing = { version = "0.1", default_features = false, features = ["attributes"] }
 loom = { version = "0.2.14", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Currently, the kernel oops handler will forcibly unlock the VGA buffer
before writing the oops message. Ths prevents deadlocks if an oops
occurs while it was locked. However, we also write traces to COM1, but
we don't unlock it when oopsing.

This commit fixes this, by ensuring we forcibly unlock both VGA and
COM1 when oopsing. I also refactored the x64 ISRs a bit so that the
interrupt context for faults is printed by the oops function, rather than
by the ISR. This means we don't have to worry about force-unlocking
in multiple places.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>