### PR TITLE
feat(util): add exponential backoffs to spin loops

### DIFF
--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -19,13 +19,16 @@ impl Backoff {
     pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
 
     pub(crate) const fn new() -> Self {
-        Self { exp: 0, max: 8 }
+        Self {
+            exp: 0,
+            max: Self::DEFAULT_MAX_EXPONENT,
+        }
     }
 
     /// Returns a new exponential backoff with the provided max exponent.
     #[allow(dead_code)]
     pub(crate) fn with_max_exponent(max: u8) -> Self {
-        assert!(max <= 8);
+        assert!(max <= Self::DEFAULT_MAX_EXPONENT);
         Self { exp: 0, max }
     }
 

--- a/util/src/sync/mod.rs
+++ b/util/src/sync/mod.rs
@@ -7,3 +7,44 @@ pub use loom::sync::atomic;
 pub use core::sync::atomic;
 
 pub mod spin;
+
+/// An exponential backoff for spin loops
+#[derive(Debug, Clone)]
+pub(crate) struct Backoff {
+    exp: u8,
+    max: u8,
+}
+
+impl Backoff {
+    pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
+
+    pub(crate) const fn new() -> Self {
+        Self { exp: 0, max: 8 }
+    }
+
+    /// Returns a new exponential backoff with the provided max exponent.
+    #[allow(dead_code)]
+    pub(crate) fn with_max_exponent(max: u8) -> Self {
+        assert!(max <= 8);
+        Self { exp: 0, max }
+    }
+
+    /// Perform one spin, squarin the backoff
+    #[inline(always)]
+    pub(crate) fn spin(&mut self) {
+        // Issue 2^exp pause instructions.
+        for _ in 0..(1 << self.exp) {
+            atomic::spin_loop_hint();
+        }
+
+        if self.exp < self.max {
+            self.exp += 1
+        }
+    }
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/util/src/sync/spin.rs
+++ b/util/src/sync/spin.rs
@@ -33,9 +33,10 @@ impl<T> Mutex<T> {
     }
 
     pub fn lock(&self) -> MutexGuard<'_, T> {
+        let mut boff = super::Backoff::default();
         while self.locked.compare_and_swap(false, true, Ordering::Acquire) {
             while self.locked.load(Ordering::Relaxed) {
-                spin_loop_hint();
+                boff.spin();
             }
         }
         MutexGuard { mutex: self }


### PR DESCRIPTION
This PR adds exponential backoffs to spin loops. When backing off, we
will issue an exponentially increasing number of `spin_loop_hint`s
(`pause` instructions on x86), up to 2^8 times per spin.

This may improve power consumption while spinning.