### PR TITLE
clean up inline asm

### DIFF
--- a/hal-x86_64/src/control_regs.rs
+++ b/hal-x86_64/src/control_regs.rs
@@ -8,7 +8,7 @@ pub mod cr3 {
     pub fn read() -> (Page<PAddr, Size4Kb>, Flags) {
         let val: u64;
         unsafe {
-            asm!("mov %cr3, $0" : "=r"(val));
+            llvm_asm!("mov %cr3, $0" : "=r"(val));
         };
         let addr = PAddr::from_u64(val);
         let pml4_page =
@@ -19,7 +19,7 @@ pub mod cr3 {
     pub unsafe fn write(pml4: Page<PAddr, Size4Kb>, flags: Flags) {
         let addr = pml4.base_address().as_usize() as u64;
         let val = addr | flags.0;
-        asm!("mov $0, %cr3" :: "r"(val) : "memory");
+        llvm_asm!("mov $0, %cr3" :: "r"(val) : "memory");
     }
 
     impl core::fmt::Debug for Flags {

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -24,7 +24,7 @@ impl Port {
     /// Reading from a CPU port is unsafe.
     pub unsafe fn readb(&self) -> u8 {
         let result: u8;
-        asm!("in al, dx" : "={al}"(result) : "{dx}"(self.num) :: "volatile", "intel");
+        llvm_asm!("in al, dx" : "={al}"(result) : "{dx}"(self.num) :: "volatile", "intel");
         result
     }
 
@@ -32,9 +32,12 @@ impl Port {
     ///
     /// Writing to a CPU port is unsafe.
     pub unsafe fn writeb(&self, value: u8) {
-        asm!("out dx, al" :: "{dx}"(self.num), "{al}"(value) :: "volatile", "intel");
+        llvm_asm!("out dx, al" :: "{dx}"(self.num), "{al}"(value) :: "volatile", "intel");
     }
-    // TODO(ixi): anything wider than a byte lol
+
+    pub unsafe fn writew(&self, value: u32) {
+        llvm_asm!("out dx, eal" :: "{dx}"(self.num), "{eal}"(value) :: "volatile", "intel")
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -35,7 +35,10 @@ impl Port {
         llvm_asm!("out dx, al" :: "{dx}"(self.num), "{al}"(value) :: "volatile", "intel");
     }
 
-    pub unsafe fn writew(&self, value: u32) {
+    /// # Safety
+    ///
+    /// Writing to a CPU port is unsafe.
+    pub unsafe fn writel(&self, value: u32) {
         llvm_asm!("out dx, eal" :: "{dx}"(self.num), "{eal}"(value) :: "volatile", "intel")
     }
 }

--- a/hal-x86_64/src/cpu/intrinsics.rs
+++ b/hal-x86_64/src/cpu/intrinsics.rs
@@ -1,0 +1,45 @@
+/// Perform one x86 `hlt` instruction.
+///
+/// # Safety
+///
+/// Intrinsics are inherently unsafe — this is just a less ugly way of writing
+/// inline assembly.
+///
+/// Also...this halts the CPU.
+#[inline(always)]
+pub unsafe fn hlt() {
+    llvm_asm!("hlt" :::: "volatile")
+}
+
+/// Perform one x86 `cli` instruction.
+///
+/// `cli` disables CPU interrupts.
+///
+/// # Safety
+///
+/// Intrinsics are inherently unsafe — this is just a less ugly way of writing
+/// inline assembly. Also, this does not guarantee that interrupts will be
+/// re-enabled, ever.
+///
+/// Prefer the higher-level [`interrupt::Control::enter_critical`] API when
+/// possible.
+#[inline(always)]
+pub unsafe fn cli() {
+    llvm_asm!("cli" :::: "volatile")
+}
+
+/// Perform one x86 `sti` instruction.
+///
+/// `sti` enables CPU interrupts.
+///
+/// # Safety
+///
+/// Intrinsics are inherently unsafe — this is just a less ugly way of writing
+/// inline assembly.
+///
+/// Prefer the higher-level [`interrupt::Control::enter_critical`] API when
+/// possible.
+#[inline(always)]
+pub unsafe fn sti() {
+    llvm_asm!("sti" :::: "volatile")
+}

--- a/hal-x86_64/src/cpu/mod.rs
+++ b/hal-x86_64/src/cpu/mod.rs
@@ -50,6 +50,7 @@ impl Port {
 pub enum Ring {
     Ring0 = 0b00,
     Ring1 = 0b01,
+    Ring2 = 0b10,
     Ring3 = 0b11,
 }
 

--- a/hal-x86_64/src/cpu/mod.rs
+++ b/hal-x86_64/src/cpu/mod.rs
@@ -41,7 +41,7 @@ impl Port {
     ///
     /// Writing to a CPU port is unsafe.
     pub unsafe fn writel(&self, value: u32) {
-        llvm_asm!("out dx, eal" :: "{dx}"(self.num), "{eal}"(value) :: "volatile", "intel")
+        llvm_asm!("out dx, eal" :: "{dx}"(self.num), "{eax}"(value) :: "volatile", "intel")
     }
 }
 

--- a/hal-x86_64/src/cpu/mod.rs
+++ b/hal-x86_64/src/cpu/mod.rs
@@ -41,7 +41,7 @@ impl Port {
     ///
     /// Writing to a CPU port is unsafe.
     pub unsafe fn writel(&self, value: u32) {
-        llvm_asm!("out dx, eal" :: "{dx}"(self.num), "{eax}"(value) :: "volatile", "intel")
+        llvm_asm!("out dx, eax" :: "{dx}"(self.num), "{eax}"(value) :: "volatile", "intel")
     }
 }
 
@@ -50,7 +50,6 @@ impl Port {
 pub enum Ring {
     Ring0 = 0b00,
     Ring1 = 0b01,
-    Ring2 = 0b10,
     Ring3 = 0b11,
 }
 

--- a/hal-x86_64/src/cpu/mod.rs
+++ b/hal-x86_64/src/cpu/mod.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use core::mem;
 
+pub mod intrinsics;
+
 #[repr(transparent)]
 pub struct Port {
     num: u16,
@@ -76,5 +78,21 @@ impl DtablePtr {
         let base = t as *const _ as *const ();
 
         Self { limit, base }
+    }
+}
+
+/// Halt the CPU.
+///
+/// This disables interrupts and performs the `hlt` instruction in a loop,
+/// forever.
+///
+/// # Safety
+///
+/// This halts the CPU.
+#[inline(always)]
+pub unsafe fn halt() -> ! {
+    intrinsics::cli();
+    loop {
+        intrinsics::hlt();
     }
 }

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -184,7 +184,7 @@ impl Idt {
 
     pub fn load(&'static self) {
         let ptr = crate::cpu::DtablePtr::new(self);
-        unsafe { asm!("lidt [$0]" :: "r" (&ptr) : "memory" : "intel") }
+        unsafe { llvm_asm!("lidt [$0]" :: "r" (&ptr) : "memory" : "intel") }
     }
 }
 

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -127,12 +127,14 @@ impl hal_core::interrupt::Control for Idt {
     // type Vector = u8;
     type Registers = Registers;
 
+    #[inline]
     unsafe fn disable(&mut self) {
-        llvm_asm!("cli" :::: "volatile");
+        crate::cpu::intrinsics::cli();
     }
 
+    #[inline]
     unsafe fn enable(&mut self) {
-        llvm_asm!("sti" :::: "volatile");
+        crate::cpu::intrinsics::sti();
     }
 
     fn is_enabled(&self) -> bool {

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -71,7 +71,7 @@ pub fn init<H: Handlers<Registers>>() -> Control {
 
     tracing::debug!("testing interrupts...");
     unsafe {
-        asm!("int $0" :: "i"(69) :: "volatile");
+        llvm_asm!("int $0" :: "i"(69) :: "volatile");
     }
     // loop {}
     tracing::debug!("it worked");
@@ -128,11 +128,11 @@ impl hal_core::interrupt::Control for Idt {
     type Registers = Registers;
 
     unsafe fn disable(&mut self) {
-        asm!("cli" :::: "volatile");
+        llvm_asm!("cli" :::: "volatile");
     }
 
     unsafe fn enable(&mut self) {
-        asm!("sti" :::: "volatile");
+        llvm_asm!("sti" :::: "volatile");
     }
 
     fn is_enabled(&self) -> bool {

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementation of the Mycelium HAL for 64-bit x86 platforms.
 #![cfg_attr(not(test), no_std)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(abi_x86_interrupt)]
 // Oftentimes it's necessary to write to a value at a particular location in
 // memory, and these types don't implement Copy to ensure they aren't

--- a/hal-x86_64/src/mm/mod.rs
+++ b/hal-x86_64/src/mm/mod.rs
@@ -794,7 +794,7 @@ pub(crate) mod tlb {
     // XXX(eliza): can/should this be feature flagged? do we care at all about
     // supporting 80386s from 1985?
     pub(crate) unsafe fn flush_page(addr: VAddr) {
-        asm!("invlpg [$0]" :: "r"(addr.as_usize() as u64) : "memory" : "intel")
+        llvm_asm!("invlpg [$0]" :: "r"(addr.as_usize() as u64) : "memory" : "intel")
     }
 }
 

--- a/hal-x86_64/src/segment.rs
+++ b/hal-x86_64/src/segment.rs
@@ -7,7 +7,7 @@ pub struct Selector(u16);
 /// Returns the current code segment selector in `%cs`.
 pub fn code_segment() -> Selector {
     let value: u16;
-    unsafe { asm!("mov $0, cs"  : "=r" (value) ::: "intel") };
+    unsafe { llvm_asm!("mov $0, cs"  : "=r" (value) ::: "intel") };
     Selector(value)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 #![cfg_attr(target_os = "none", feature(panic_info_message, track_caller))]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
 #![cfg_attr(target_os = "none", feature(panic_info_message, track_caller))]
-#![feature(llvm_asm)]
 
 extern crate alloc;
 


### PR DESCRIPTION
This PR makes a few changes to inline assembly:

* Replace uses of the `asm!` macro, which is now deprecated, with the new `llvm_asm!` macro.
* Move inline assembly out of the kernel into HAL, adding new functions for current direct uses of inline assembly in the kernel 

The `hal-x86_64` crate now exposes a `cpu::intrinsics` module containing functions for emitting some assembly instructions without requiring inline assembly. In addition, I've added the ability to write a u32 to a `cpu::Port`, and a `cpu::halt` function for halting the CPU forever.

I'd like to make the `cpu::Port` better for writing things other than bytes, maybe w/ generics eventually....