### PR TITLE
feat(hal): allow representing dynamically sized pages

### DIFF
--- a/hal-x86_64/src/control_regs.rs
+++ b/hal-x86_64/src/control_regs.rs
@@ -11,8 +11,8 @@ pub mod cr3 {
             llvm_asm!("mov %cr3, $0" : "=r"(val));
         };
         let addr = PAddr::from_u64(val);
-        let pml4_page =
-            Page::starting_at(addr).expect("PML4 physical addr not aligned! this is very bad");
+        let pml4_page = Page::starting_at_fixed(addr)
+            .expect("PML4 physical addr not aligned! this is very bad");
         (pml4_page, Flags(val))
     }
 

--- a/hal-x86_64/src/mm/mod.rs
+++ b/hal-x86_64/src/mm/mod.rs
@@ -9,7 +9,8 @@ use core::{
 };
 use hal_core::{
     mem::page::{
-        self, Map, Page, Size, TranslateAddr, TranslateError, TranslatePage, TranslateResult,
+        self, Map, Page, Size, StaticSize, TranslateAddr, TranslateError, TranslatePage,
+        TranslateResult,
     },
     Address,
 };
@@ -498,10 +499,10 @@ impl<L: level::PointsToPage> Entry<L> {
         }
 
         if self.is_huge() != L::IS_HUGE {
-            return Err(TranslateError::WrongSize(PhantomData));
+            return Err(TranslateError::WrongSize(L::Size::INSTANCE));
         }
 
-        Ok(Page::starting_at(self.phys_addr()).expect("page addr must be aligned"))
+        Ok(Page::starting_at_fixed(self.phys_addr()).expect("page addr must be aligned"))
     }
 
     fn set_phys_page(&mut self, page: Page<PAddr, L::Size>) -> &mut Self {
@@ -603,31 +604,52 @@ impl<L: Level> fmt::Debug for Entry<L> {
 }
 
 pub mod size {
-    use super::Size;
+    use core::fmt;
+    use hal_core::mem::page::StaticSize;
 
     #[derive(Copy, Clone, Eq, PartialEq)]
-    pub enum Size4Kb {}
+    pub struct Size4Kb;
 
-    impl Size for Size4Kb {
+    impl StaticSize for Size4Kb {
         const SIZE: usize = 4 * 1024;
         const PRETTY_NAME: &'static str = "4KB";
+        const INSTANCE: Self = Size4Kb;
+    }
+
+    impl fmt::Display for Size4Kb {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.pad(Self::PRETTY_NAME)
+        }
     }
 
     #[derive(Copy, Clone, Eq, PartialEq)]
-    pub enum Size2Mb {}
+    pub struct Size2Mb;
 
-    impl Size for Size2Mb {
+    impl StaticSize for Size2Mb {
         const SIZE: usize = Size4Kb::SIZE * 512;
         const PRETTY_NAME: &'static str = "2MB";
+        const INSTANCE: Self = Size2Mb;
+    }
+
+    impl fmt::Display for Size2Mb {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.pad(Self::PRETTY_NAME)
+        }
     }
 
     #[derive(Copy, Clone, Eq, PartialEq)]
-    pub enum Size1Gb {}
+    pub struct Size1Gb;
 
-    impl Size for Size1Gb {
+    impl StaticSize for Size1Gb {
         const SIZE: usize = Size2Mb::SIZE * 512;
-
         const PRETTY_NAME: &'static str = "1GB";
+        const INSTANCE: Self = Size1Gb;
+    }
+
+    impl fmt::Display for Size1Gb {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.pad(Self::PRETTY_NAME)
+        }
     }
 }
 
@@ -656,12 +678,14 @@ impl<L: Level> fmt::Debug for PageTable<L> {
 }
 
 pub mod level {
-    use super::{size::*, Level, Size, RECURSIVE_INDEX, SIGN};
+    use super::{size::*, Level, RECURSIVE_INDEX, SIGN};
     use crate::VAddr;
+    use core::fmt;
+    use hal_core::mem::page::{Size, StaticSize};
     use hal_core::Address;
 
     pub trait PointsToPage: Level {
-        type Size: Size;
+        type Size: StaticSize + fmt::Display;
         const IS_HUGE: bool;
     }
 
@@ -805,8 +829,8 @@ mycelium_util::decl_test! {
         // We shouldn't need to allocate page frames for this test.
         let mut frame_alloc = page::EmptyAlloc::default();
 
-        let frame = Page::containing(PAddr::from_usize(0xb8000));
-        let page = Page::containing(VAddr::from_usize(0));
+        let frame = Page::containing_fixed(PAddr::from_usize(0xb8000));
+        let page = Page::containing_fixed(VAddr::from_usize(0));
 
         let page = unsafe {
             let mut flags = ctrl.map_page(page, frame, &mut frame_alloc);
@@ -828,10 +852,10 @@ mycelium_util::decl_test! {
     fn identity_mapped_pages_are_reasonable() -> Result<(), ()> {
         let ctrl = PageCtrl::current();
 
-        let page = VirtPage::<Size4Kb>::containing(VAddr::from_usize(0xb8000));
+        let page = VirtPage::<Size4Kb>::containing_fixed(VAddr::from_usize(0xb8000));
 
         let frame = ctrl.translate_page(page).expect("translate");
-        let actual_frame = PhysPage::<Size4Kb>::containing(PAddr::from_usize(0xb8000));
+        let actual_frame = PhysPage::<Size4Kb>::containing_fixed(PAddr::from_usize(0xb8000));
         tracing::info!(?page, ?frame, "translated");
         assert_eq!(frame, actual_frame, "identity mapped address should translate to itself");
         Ok(())

--- a/hal-x86_64/src/mm/mod.rs
+++ b/hal-x86_64/src/mm/mod.rs
@@ -605,7 +605,7 @@ impl<L: Level> fmt::Debug for Entry<L> {
 
 pub mod size {
     use core::fmt;
-    use hal_core::mem::page::StaticSize;
+    use hal_core::mem::page::{Size, StaticSize};
 
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct Size4Kb;
@@ -649,6 +649,36 @@ pub mod size {
     impl fmt::Display for Size1Gb {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.pad(Self::PRETTY_NAME)
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, Eq)]
+    #[repr(usize)]
+    pub enum AnySize {
+        Size4Kb = Size4Kb::SIZE,
+        Size2Mb = Size2Mb::SIZE,
+        Size1Gb = Size1Gb::SIZE,
+    }
+
+    impl<S: Size> PartialEq<S> for AnySize {
+        fn eq(&self, other: &S) -> bool {
+            *self as usize == other.size()
+        }
+    }
+
+    impl fmt::Display for AnySize {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                AnySize::Size4Kb => f.pad(Size4Kb::PRETTY_NAME),
+                AnySize::Size2Mb => f.pad(Size2Mb::PRETTY_NAME),
+                AnySize::Size1Gb => f.pad(Size1Gb::PRETTY_NAME),
+            }
+        }
+    }
+
+    impl Size for AnySize {
+        fn size(&self) -> usize {
+            *self as usize
         }
     }
 }


### PR DESCRIPTION
Currently, the `Size` trait only allows representing statically known
sizes. This interface makes sense when _mapping_ pages, since the users
of that API will likely be saying things like "I want to map this 4kb
virtual page to a 4kb physical page". However, it makes less sense when
_translating_ pages/addresses. If I ask the page table "what page is
this address on?", I currently have to know in advance the size of the
page, which doesn't make sense — that's part of the information I would
be trying to _query_ by asking for the page containing an address. The
current trait does not model this nicely.

This commit updates the `Size` trait in `hal_core::mem::Page` to allow
representing dynamically sized pages, with a `Size::size()` fn rather
than an associated constant. The previous constant-only `Size` trait is
now a new trait, `StaticSize`, which _implements_ `Size`; this allows
code which requires a statically known size to bound type parameters
with `StaticSize` rather than `Size`.

Unfortunately, `size` fields on structs can no longer be `PhantomData`,
as they may in some cases be...real data; however, the current set of
types implementing `StaticSize` are still all zero-sized so this
shouldn't matter _that_ much.

Signed-off-by: Eliza Weisman <eliza@elizas.website>