### PR TITLE
page range, page, and mem region API tweaks & fixes

### DIFF
--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -64,12 +64,14 @@ impl<A: Address> Region<A> {
     /// Returns `true` if `self` contains the specified address.
     pub fn contains(&self, addr: impl Into<A>) -> bool {
         let addr = addr.into();
-        addr > self.base && addr < self.end_addr()
+        addr >= self.base && addr < self.end_addr()
     }
 
-    /// Returns the last address (inclusive) of the memory region.
+    /// Returns the end address (exclusive) of the memory region.
+    ///
+    /// This is the start address of the next memory region.
     pub fn end_addr(&self) -> A {
-        self.base + (self.size - 1)
+        self.base + self.size
     }
 
     pub fn kind(&self) -> RegionKind {
@@ -81,7 +83,7 @@ impl<A: Address> Region<A> {
         size: S,
     ) -> Result<page::PageRange<A, S>, page::NotAligned<S>> {
         let start = page::Page::starting_at(self.base, size)?;
-        let end = page::Page::starting_at(self.end_addr() + 1, size)?;
+        let end = page::Page::starting_at(self.end_addr(), size)?;
         Ok(start.range_to(end))
     }
 

--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -67,9 +67,9 @@ impl<A: Address> Region<A> {
         addr > self.base && addr < self.end_addr()
     }
 
-    /// Returns the end address of the memory region.
+    /// Returns the last address (inclusive) of the memory region.
     pub fn end_addr(&self) -> A {
-        self.base + self.size
+        self.base + (self.size - 1)
     }
 
     pub fn kind(&self) -> RegionKind {

--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -76,8 +76,22 @@ impl<A: Address> Region<A> {
         self.kind
     }
 
-    pub fn page_range<S: page::Size>(&self) -> page::PageRange<A, S> {
-        unimplemented!("eliza")
+    pub fn page_range<S: page::Size>(
+        &self,
+        size: S,
+    ) -> Result<page::PageRange<A, S>, page::NotAligned<S>> {
+        let start = page::Page::starting_at(self.base, size)?;
+        let end = page::Page::starting_at(self.end_addr() + 1, size)?;
+        Ok(start.range_to(end))
+    }
+
+    pub fn from_page_range<S: page::Size>(range: page::PageRange<A, S>, kind: RegionKind) -> Self {
+        let base = range.start().base_addr();
+        Self {
+            base,
+            size: range.page_size().in_bytes(),
+            kind,
+        }
     }
 }
 

--- a/hal-core/src/mem/mod.rs
+++ b/hal-core/src/mem/mod.rs
@@ -91,7 +91,7 @@ impl<A: Address> Region<A> {
         let base = range.start().base_addr();
         Self {
             base,
-            size: range.page_size().in_bytes(),
+            size: range.page_size().as_usize(),
             kind,
         }
     }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -445,7 +445,7 @@ impl<S> Size for S
 where
     S: StaticSize,
 {
-    fn size(&self) -> usize {
+    fn in_bytes(&self) -> usize {
         Self::SIZE
     }
 }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -2,13 +2,13 @@ use crate::{Address, PAddr, VAddr};
 use core::{cmp, fmt, ops, slice};
 
 pub trait Size: Copy + Eq + PartialEq + fmt::Display {
-    /// The size (in bits) of this page.
-    fn size(&self) -> usize;
+    /// Returns the size (in bytes) of this page.
+    fn in_bytes(&self) -> usize;
 }
 
 /// A statically known page size.
 pub trait StaticSize: Copy + Eq + PartialEq + fmt::Display {
-    /// The size (in bits) of this page.
+    /// The size (in bytes) of this page.
     const SIZE: usize;
     const PRETTY_NAME: &'static str;
     const INSTANCE: Self;
@@ -223,7 +223,7 @@ impl<A: Address, S: Size> Page<A, S> {
     /// Returns a page starting at the given address.
     pub fn starting_at(addr: impl Into<A>, size: S) -> Result<Self, NotAligned<S>> {
         let addr = addr.into();
-        if !addr.is_aligned(size.size()) {
+        if !addr.is_aligned(size.in_bytes()) {
             return Err(NotAligned { size });
         }
         Ok(Self::containing(addr, size))
@@ -231,7 +231,7 @@ impl<A: Address, S: Size> Page<A, S> {
 
     /// Returns the page that contains the given address.
     pub fn containing(addr: impl Into<A>, size: S) -> Self {
-        let base = addr.into().align_down(size.size());
+        let base = addr.into().align_down(size.in_bytes());
         Self { base, size }
     }
 
@@ -243,7 +243,7 @@ impl<A: Address, S: Size> Page<A, S> {
     ///
     /// `end_addr() + 1` will be the base address of the next page.
     pub fn end_addr(&self) -> A {
-        self.base + (self.size.size() - 1)
+        self.base + (self.size.in_bytes() - 1)
     }
 
     pub fn size(&self) -> S {
@@ -274,7 +274,7 @@ impl<A: Address, S: Size> Page<A, S> {
     /// concurrently, including by user code.
     pub unsafe fn as_slice(&self) -> &[u8] {
         let start = self.base.as_ptr() as *const u8;
-        slice::from_raw_parts::<u8>(start, self.size.size())
+        slice::from_raw_parts::<u8>(start, self.size.in_bytes())
     }
 
     /// Returns the entire contents of the page as a mutable slice.
@@ -285,7 +285,7 @@ impl<A: Address, S: Size> Page<A, S> {
     /// concurrently, including by user code.
     pub unsafe fn as_slice_mut(&mut self) -> &mut [u8] {
         let start = self.base.as_ptr::<u8>() as *mut _;
-        slice::from_raw_parts_mut::<u8>(start, self.size.size())
+        slice::from_raw_parts_mut::<u8>(start, self.size.in_bytes())
     }
 }
 
@@ -293,7 +293,7 @@ impl<A: Address, S: Size> ops::Add<usize> for Page<A, S> {
     type Output = Self;
     fn add(self, rhs: usize) -> Self {
         Page {
-            base: self.base + (self.size.size() * rhs),
+            base: self.base + (self.size.in_bytes() * rhs),
             ..self
         }
     }
@@ -303,7 +303,7 @@ impl<A: Address, S: Size> ops::Sub<usize> for Page<A, S> {
     type Output = Self;
     fn sub(self, rhs: usize) -> Self {
         Page {
-            base: self.base - (self.size.size() * rhs),
+            base: self.base - (self.size.in_bytes() * rhs),
             ..self
         }
     }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -239,8 +239,11 @@ impl<A: Address, S: Size> Page<A, S> {
         self.base
     }
 
+    /// Returns the last address in the page, inclusive.
+    ///
+    /// `end_addr() + 1` will be the base address of the next page.
     pub fn end_addr(&self) -> A {
-        self.base + self.size.size()
+        self.base + (self.size.size() - 1)
     }
 
     pub fn size(&self) -> S {

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -119,7 +119,7 @@ where
     /// Identity map the provided physical page to the virtual page with the
     /// same address.
     fn identity_map(&'mapper mut self, phys: Page<PAddr, S>, frame_alloc: &mut A) -> Self::Handle {
-        let base_paddr = phys.base_address().as_usize();
+        let base_paddr = phys.base_addr().as_usize();
         let virt = Page::containing(VAddr::from_usize(base_paddr), phys.size());
         unsafe { self.map_page(virt, phys, frame_alloc) }
     }
@@ -235,11 +235,11 @@ impl<A: Address, S: Size> Page<A, S> {
         Self { base, size }
     }
 
-    pub fn base_address(&self) -> A {
+    pub fn base_addr(&self) -> A {
         self.base
     }
 
-    pub fn end_address(&self) -> A {
+    pub fn end_addr(&self) -> A {
         self.base + self.size.size()
     }
 
@@ -249,7 +249,7 @@ impl<A: Address, S: Size> Page<A, S> {
 
     pub fn contains(&self, addr: impl Into<A>) -> bool {
         let addr = addr.into();
-        addr >= self.base && addr <= self.end_address()
+        addr >= self.base && addr <= self.end_addr()
     }
 
     pub fn range_inclusive(self, end: Page<A, S>) -> PageRange<A, S> {

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -239,9 +239,9 @@ impl<A: Address, S: Size> Page<A, S> {
         self.base
     }
 
-    /// Returns the last address in the page, inclusive.
+    /// Returns the last address in the page, exclusive.
     ///
-    /// `end_addr() + 1` will be the base address of the next page.
+    /// The returned address will be the base address of the next page.
     pub fn end_addr(&self) -> A {
         self.base + (self.size.in_bytes() - 1)
     }
@@ -252,7 +252,7 @@ impl<A: Address, S: Size> Page<A, S> {
 
     pub fn contains(&self, addr: impl Into<A>) -> bool {
         let addr = addr.into();
-        addr >= self.base && addr <= self.end_addr()
+        addr >= self.base && addr < self.end_addr()
     }
 
     pub fn range_inclusive(self, end: Page<A, S>) -> PageRange<A, S> {
@@ -353,7 +353,9 @@ impl<A: Address, S: Size> PageRange<A, S> {
         self.start.base_addr()
     }
 
-    /// Returns the last address on the last page in the range.
+    /// Returns the end address on the last page in the range.
+    ///
+    /// This is the base address of the page immediately following this range.
     pub fn end_addr(&self) -> A {
         self.end.end_addr()
     }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -348,6 +348,23 @@ impl<A: Address, S: Size> PageRange<A, S> {
         self.end
     }
 
+    /// Returns the base address of the first page in the range.
+    pub fn base_addr(&self) -> A {
+        self.start.base_addr()
+    }
+
+    /// Returns the last address on the last page in the range.
+    pub fn end_addr(&self) -> A {
+        self.end.end_addr()
+    }
+
+    /// Returns the size of the pages in the range. All pages in a page range
+    /// have the same size.
+    pub fn page_size(&self) -> S {
+        debug_assert_eq!(self.start.size().in_bytes(), self.end.size().in_bytes());
+        self.start.size()
+    }
+
     pub fn len(&self) -> usize {
         unimplemented!("eliza")
     }

--- a/hal-x86_64/src/control_regs.rs
+++ b/hal-x86_64/src/control_regs.rs
@@ -20,7 +20,7 @@ pub mod cr3 {
     ///
     /// Writing cr3 can break pretty much everything.
     pub unsafe fn write(pml4: Page<PAddr, Size4Kb>, flags: Flags) {
-        let addr = pml4.base_address().as_usize() as u64;
+        let addr = pml4.base_addr().as_usize() as u64;
         let val = addr | flags.0;
         asm!("mov cr3, {0}", in(reg) val);
     }

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -55,7 +55,7 @@ pub fn init<H: Handlers<Registers>>() -> Control {
     tracing::info!("configuring 8259 PIC interrupts...");
 
     unsafe {
-        PIC.set_irq_addres(0x20, 0x28);
+        PIC.set_irq_address(0x20, 0x28);
         // functionally a no-op, since interrupts from PC/AT PIC are enabled at boot, just being
         // clear for you, the reader, that at this point they are definitely intentionally enabled.
         PIC.enable();

--- a/hal-x86_64/src/interrupt/mod.rs
+++ b/hal-x86_64/src/interrupt/mod.rs
@@ -55,7 +55,7 @@ pub fn init<H: Handlers<Registers>>() -> Control {
     tracing::info!("configuring 8259 PIC interrupts...");
 
     unsafe {
-        PIC.set_irq_addresses(0x20, 0x28);
+        PIC.set_irq_addres(0x20, 0x28);
         // functionally a no-op, since interrupts from PC/AT PIC are enabled at boot, just being
         // clear for you, the reader, that at this point they are definitely intentionally enabled.
         PIC.enable();

--- a/hal-x86_64/src/interrupt/pic.rs
+++ b/hal-x86_64/src/interrupt/pic.rs
@@ -76,7 +76,7 @@ impl hal_core::interrupt::Control for CascadedPic {
 }
 
 impl CascadedPic {
-    pub(crate) unsafe fn set_irq_addres(&mut self, primary_start: u8, secondary_start: u8) {
+    pub(crate) unsafe fn set_irq_address(&mut self, primary_start: u8, secondary_start: u8) {
         // iowait and its uses below are guidance from the osdev wiki for compatibility with "older
         // machines". it is not entirely clear what "older machines" exactly means, or where this
         // is or is not necessary precisely. this code happens to work in qemu without `iowait()`,

--- a/hal-x86_64/src/interrupt/pic.rs
+++ b/hal-x86_64/src/interrupt/pic.rs
@@ -76,7 +76,7 @@ impl hal_core::interrupt::Control for CascadedPic {
 }
 
 impl CascadedPic {
-    pub(crate) unsafe fn set_irq_addresses(&mut self, primary_start: u8, secondary_start: u8) {
+    pub(crate) unsafe fn set_irq_addres(&mut self, primary_start: u8, secondary_start: u8) {
         // iowait and its uses below are guidance from the osdev wiki for compatibility with "older
         // machines". it is not entirely clear what "older machines" exactly means, or where this
         // is or is not necessary precisely. this code happens to work in qemu without `iowait()`,

--- a/hal-x86_64/src/mm/mod.rs
+++ b/hal-x86_64/src/mm/mod.rs
@@ -665,7 +665,7 @@ pub mod size {
 
     impl<S: Size> PartialEq<S> for AnySize {
         fn eq(&self, other: &S) -> bool {
-            *self as usize == other.in_bytes()
+            *self as usize == other.as_usize()
         }
     }
 
@@ -680,7 +680,7 @@ pub mod size {
     }
 
     impl Size for AnySize {
-        fn in_bytes(&self) -> usize {
+        fn as_usize(&self) -> usize {
             *self as usize
         }
     }

--- a/hal-x86_64/src/mm/mod.rs
+++ b/hal-x86_64/src/mm/mod.rs
@@ -665,7 +665,7 @@ pub mod size {
 
     impl<S: Size> PartialEq<S> for AnySize {
         fn eq(&self, other: &S) -> bool {
-            *self as usize == other.size()
+            *self as usize == other.in_bytes()
         }
     }
 
@@ -680,7 +680,7 @@ pub mod size {
     }
 
     impl Size for AnySize {
-        fn size(&self) -> usize {
+        fn in_bytes(&self) -> usize {
             *self as usize
         }
     }


### PR DESCRIPTION
This fixes some annoying stuff in the mem APIs, makes end addrs
inclusive as expected, and implements a couple missing APIs. Factored
this out of [my page allocator PR][1], which will eventually be rebased
onto this.

[1]: https://github.com/hawkw/mycelium/tree/eliza/page-alloc