### PR TITLE
chore: don't use `add-path` for caching tools on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,8 +75,8 @@ jobs:
       uses: actions-rs/cargo@v1.0.1
       with:
         command: check
-        args:-Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
-        
+        args: -Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
+
   clippy-x64:
     name: cargo clippy (cross x64)
     needs: check-x64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,23 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features
 
+  rustfmt:
+    runs-on: ubuntu-latest
+    needs: check-host
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rustfmt
+        override: true
+    - uses: actions/checkout@v2
+    - name: run rustfmt
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: fmt
+        args: --all -- --check
+
   test-host:
     runs-on: ubuntu-latest
     name: cargo test (host)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
     - name: install cargo-bootimage
-      uses: actions-rs/install
+      uses: actions-rs/install@v0.1.2
       with:
         crate: bootimage
         version: latest
@@ -89,7 +89,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
     - name: install cargo-bootimage
-      uses: actions-rs/install
+      uses: actions-rs/install@v0.1.2
       with:
         crate: bootimage
         version: latest
@@ -113,7 +113,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
     - name: install cargo-bootimage
-      uses: actions-rs/install
+      uses: actions-rs/install@v0.1.2
       with:
         crate: bootimage
         version: latest
@@ -136,7 +136,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
     - name: install cargo-bootimage
-      uses: actions-rs/install
+      uses: actions-rs/install@v0.1.2
       with:
         crate: bootimage
         version: latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,8 @@ name: CI
 on: [push]
 
 jobs:
-  build-x64:
+  check-host:
+    name: cargo check (host)
     runs-on: ubuntu-latest
     steps:
     - name: install rust toolchain
@@ -11,21 +12,52 @@ jobs:
       with:
         profile: minimal
         toolchain: nightly
-        components: rust-src, llvm-tools-preview
-    - name: install cargo-bootimage
-      uses: actions-rs/install
-      with:
-        crate: bootimage
-        version: latest
-        use-tool-cache: true
     - uses: actions/checkout@v2
-    - name: x86_64 boot image
+    - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
       with:
-        command: bootimage-x64
+        command: check
+        args: --all --all-features
 
-  test-x64:
+  clippy-host:
+    name: cargo clippy (host)
     runs-on: ubuntu-latest
+    needs: check-host
+    steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: clippy
+    - uses: actions/checkout@v2
+    - name: run clippy
+      uses: actions-rs/clippy-check@v1.0.5
+      with:
+        name: clippy-host
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-features
+
+  test-host:
+    runs-on: ubuntu-latest
+    name: cargo test (host)
+    needs: check-host
+    steps:
+    - name: install rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+    - uses: actions/checkout@v2
+    - name: run host tests
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: test
+        args: --all --all-features
+
+  check-x64:
+    name: cargo check (cross x64)
+    runs-on: ubuntu-latest
+    needs: check-host
     steps:
     - name: install rust toolchain
       uses: actions-rs/toolchain@v1
@@ -39,15 +71,15 @@ jobs:
         crate: bootimage
         version: latest
         use-tool-cache: true
-    - uses: actions/checkout@v2
-    - name: install qemu
-      run: sudo apt-get update && sudo apt-get install qemu
-    - name: run tests
+    - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
       with:
-        command: test-x64
+        command: check
+        args:-Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
 
   clippy-x64:
+    name: cargo clippy (cross x64)
+    needs: check-x64
     runs-on: ubuntu-latest
     steps:
     - name: install rust toolchain
@@ -69,34 +101,51 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: -Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
 
-  test-host:
+  build-x64:
+    name: cargo bootimage (cross x64)
     runs-on: ubuntu-latest
+    needs: check-x64
     steps:
     - name: install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: nightly
+        components: rust-src, llvm-tools-preview
+    - name: install cargo-bootimage
+      uses: actions-rs/install
+      with:
+        crate: bootimage
+        version: latest
+        use-tool-cache: true
     - uses: actions/checkout@v2
-    - name: run host tests
+    - name: x86_64 boot image
       uses: actions-rs/cargo@v1.0.1
       with:
-        command: test
-        args: --all --all-features
+        command: bootimage-x64
 
-  clippy-host:
+  test-x64:
+    name: cargo test (cross x64)
     runs-on: ubuntu-latest
-    needs: test-host
+    needs: check-x64
     steps:
-    - uses: actions-rs/toolchain@v1
+    - name: install rust toolchain
+      uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: nightly
-        components: clippy
-    - uses: actions/checkout@v2
-    - name: rust-clippy-check
-      uses: actions-rs/clippy-check@v1.0.5
+        components: rust-src, llvm-tools-preview
+    - name: install cargo-bootimage
+      uses: actions-rs/install
       with:
-        name: clippy-host
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
+        crate: bootimage
+        version: latest
+        use-tool-cache: true
+    - uses: actions/checkout@v2
+    - name: install qemu
+      run: sudo apt-get update && sudo apt-get install qemu
+    - name: run tests
+      uses: actions-rs/cargo@v1.0.1
+      with:
+        command: test-x64
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview
         override: true
+    - uses: actions/checkout@v2
     - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -104,6 +105,7 @@ jobs:
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
         override: true
+    - uses: actions/checkout@v2
     - name: run cargo clippy
       uses: actions-rs/clippy-check@v1.0.5
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,16 +65,11 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
-    - name: install cargo-bootimage
-      uses: actions-rs/install@v0.1.2
-      with:
-        crate: bootimage
-        version: latest
-        use-tool-cache: true
     - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
       with:
         command: check
+        toolchain: nightly
         args: -Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
 
   clippy-x64:
@@ -88,13 +83,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
-    - name: install cargo-bootimage
-      uses: actions-rs/install@v0.1.2
-      with:
-        crate: bootimage
-        version: latest
-        use-tool-cache: true
-    - name: rust-clippy-check
+    - name: run cargo clippy
       uses: actions-rs/clippy-check@v1.0.5
       with:
         name: clippy-x64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ jobs:
       with:
         profile: minimal
         toolchain: nightly
+        override: true
     - uses: actions/checkout@v2
     - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
@@ -29,6 +30,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: clippy
+        override: true
     - uses: actions/checkout@v2
     - name: run clippy
       uses: actions-rs/clippy-check@v1.0.5
@@ -47,6 +49,7 @@ jobs:
       with:
         profile: minimal
         toolchain: nightly
+        override: true
     - uses: actions/checkout@v2
     - name: run host tests
       uses: actions-rs/cargo@v1.0.1
@@ -65,11 +68,11 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
+        override: true
     - name: run cargo check
       uses: actions-rs/cargo@v1.0.1
       with:
         command: check
-        toolchain: nightly
         args: -Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
 
   clippy-x64:
@@ -83,6 +86,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
+        override: true
     - name: run cargo clippy
       uses: actions-rs/clippy-check@v1.0.5
       with:
@@ -101,6 +105,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
+        override: true
     - name: install cargo-bootimage
       uses: actions-rs/install@v0.1.2
       with:
@@ -124,6 +129,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
+        override: true
     - name: install cargo-bootimage
       uses: actions-rs/install@v0.1.2
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,13 +6,13 @@ jobs:
   build-x64:
     runs-on: ubuntu-latest
     steps:
-    - &install-toolchain name: install rust toolchain
+    - name: install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
-    - &install-bootimage name: install cargo-bootimage
+    - name: install cargo-bootimage
       uses: actions-rs/install
       with:
         crate: bootimage
@@ -27,8 +27,18 @@ jobs:
   test-x64:
     runs-on: ubuntu-latest
     steps:
-    - *install-toolchain
-    - *install-bootimage
+    - name: install rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rust-src, llvm-tools-preview
+    - name: install cargo-bootimage
+      uses: actions-rs/install
+      with:
+        crate: bootimage
+        version: latest
+        use-tool-cache: true
     - uses: actions/checkout@v2
     - name: install qemu
       run: sudo apt-get update && sudo apt-get install qemu
@@ -46,7 +56,12 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
-    - *install-bootimage
+    - name: install cargo-bootimage
+      uses: actions-rs/install
+      with:
+        crate: bootimage
+        version: latest
+        use-tool-cache: true
     - name: rust-clippy-check
       uses: actions-rs/clippy-check@v1.0.5
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         command: check
         args:-Z build-std=core,alloc --target=x86_64-mycelium.json --all-features
-
+        
   clippy-x64:
     name: cargo clippy (cross x64)
     needs: check-x64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,25 +6,19 @@ jobs:
   build-x64:
     runs-on: ubuntu-latest
     steps:
-    - name: install rust toolchain
+    - &install-toolchain name: install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview
+    - &install-bootimage name: install cargo-bootimage
+      uses: actions-rs/install
+      with:
+        crate: bootimage
+        version: latest
+        use-tool-cache: true
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      id: toolcache
-      with:
-        path: _devtools
-        key: devtools-${{ runner.os }}-v0
-    - name: install dev env
-      if: steps.toolcache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: dev-env
-        args: --root=_devtools
-    - run: echo "::add-path::_devtools/bin"
     - name: x86_64 boot image
       uses: actions-rs/cargo@v1.0.1
       with:
@@ -33,25 +27,9 @@ jobs:
   test-x64:
     runs-on: ubuntu-latest
     steps:
-    - name: install rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        components: rust-src, llvm-tools-preview
+    - *install-toolchain
+    - *install-bootimage
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      id: toolcache
-      with:
-        path: _devtools
-        key: devtools-${{ runner.os }}-v0
-    - name: install dev env
-      if: steps.toolcache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: dev-env
-        args: --root=_devtools
-    - run: echo "::add-path::_devtools/bin"
     - name: install qemu
       run: sudo apt-get update && sudo apt-get install qemu
     - name: run tests
@@ -68,19 +46,7 @@ jobs:
         profile: minimal
         toolchain: nightly
         components: rust-src, llvm-tools-preview, clippy
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      id: toolcache
-      with:
-        path: _devtools
-        key: devtools-${{ runner.os }}-v0
-    - name: install dev env
-      if: steps.toolcache.outputs.cache-hit != 'true'
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: dev-env
-        args: --root=_devtools
-    - run: echo "::add-path::_devtools/bin"
+    - *install-bootimage
     - name: rust-clippy-check
       uses: actions-rs/clippy-check@v1.0.5
       with:


### PR DESCRIPTION
GitHub Actions has [deprecated the `add-path` command][1] which we are
currently using for caching `cargo install` binaries. This means our CI
builds are now failing.

This branch updates CI to use `actions-rs/install` for installing and
caching `cargo install` binaries instead. Hopefully this fixes CI.

Additionally, I've used YAML anchros to reduce repetition in the CI
configs.

Signed-off-by: Eliza Weisman <eliza@elizas.website>