### PR TITLE
chore: make CI run more stuff in parallel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,6 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
-    needs: check-host
     steps:
     - uses: actions-rs/toolchain@v1
       with:
@@ -77,7 +76,6 @@ jobs:
   check-x64:
     name: cargo check (cross x64)
     runs-on: ubuntu-latest
-    needs: check-host
     steps:
     - name: install rust toolchain
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR changes the rustfmt and x86_64-mycelium `cargo check` CI steps
to not require the host `cargo check` step to pass before starting. This
way, we can run them in parallel, hopefully making CI builds complete a
little faster.