### PR TITLE
fix(hal-x86_64): fix VGA buffer compile error

### DIFF
--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -118,7 +118,8 @@ impl Buffer {
             }
         }
 
-        self.buf[self.row][self.col].write(self.character(ch));
+        let ch = self.character(ch);
+        self.buf[self.row][self.col].write(ch);
         self.col += 1;
     }
 


### PR DESCRIPTION
This used to compile but now rustc doesn't like it?
```
error[E0502]: cannot borrow `*self` as immutable because it is also borrowed as mutable
   --> hal-x86_64/src/vga.rs:121:44
    |
121 |         self.buf[self.row][self.col].write(self.character(ch));
    |         ------------------           ----- ^^^^ immutable borrow occurs here
    |         |                            |
    |         |                            mutable borrow later used by call
    |         mutable borrow occurs here

error: aborting due to previous error
```