### PR TITLE
chore(ci): ensure the right qemu bin is installed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,7 +155,9 @@ jobs:
         use-tool-cache: true
     - uses: actions/checkout@v2
     - name: install qemu
-      run: sudo apt-get update && sudo apt-get install qemu
+      run: |
+        sudo apt-get update
+        sudo apt-get install qemu-system-x86
     - name: run tests
       uses: actions-rs/cargo@v1.0.1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ mycelium-util = { path = "util" }
 rlibc = "1.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-bootloader = {version = "0.9.11", features = ["map_physical_memory"] }
+bootloader = {version = "0.9.16", features = ["map_physical_memory"] }
 hal-x86_64 = { path = "hal-x86_64" }
 
 [dependencies.tracing]


### PR DESCRIPTION
Apparently `apt-get install qemu` *used* to provide the
 `qemu-system-x86_64` binary, but maybe it doesn't anymore? Maybe
explicitly trying to install that package will fix CI?

Signed-off-by: Eliza Weisman <eliza@buoyant.io>