### PR TITLE
chore(ci): unbreak warnings thing

### DIFF
--- a/.github/workflows/ci_warnings.yml
+++ b/.github/workflows/ci_warnings.yml
@@ -39,7 +39,6 @@ jobs:
   clippy-host:
     name: cargo clippy (host)
     runs-on: ubuntu-latest
-    needs: check-host
     steps:
     - name: install rust toolchain
       run: rustup show


### PR DESCRIPTION
The CI (warnings) job is broken because i copied and pasted in a check
from the main CI job, which still depends on another check in that
file. This fixes that, so the warnings job can run again.