### PR TITLE
feat(util): add packing pairs, other bit packing improvements

### DIFF
--- a/util/src/bits.rs
+++ b/util/src/bits.rs
@@ -291,7 +291,7 @@ macro_rules! make_packers {
                 /// The packing pair can be used to pack bits from one location
                 /// into another location, and vice versa.
                 pub const fn pair_at(&self, at: u32) -> $Pair {
-                    let dst = Pair::starting_at(at, self.bits());
+                    let dst = Self::starting_at(at, self.bits());
                     let at = at.saturating_sub(1);
                     // TODO(eliza): validate that `at + self.bits() < N_BITS` in
                     // const fn somehow lol
@@ -394,7 +394,7 @@ macro_rules! make_packers {
                 /// a unit test to ensure that the spec is valid.
                 #[track_caller]
                 pub fn assert_valid(&self) {
-                    self.assert_valid_inner("")
+                    self.assert_valid_inner(&"")
                 }
 
                 #[track_caller]
@@ -402,7 +402,7 @@ macro_rules! make_packers {
                     assert!(
                         self.shift < Self::SIZE_BITS,
                         "shift may not exceed maximum bits for {} (would wrap)\n\
-                         -> while checking validity of {:?}{}"
+                         -> while checking validity of {:?}{}",
                         stringify!($Bits),
                         self,
                         cx,
@@ -410,8 +410,8 @@ macro_rules! make_packers {
                     assert!(
                         self.bits() <= Self::SIZE_BITS,
                         "number of bits ({}) may not exceed maximum bits for {} (would wrap)\n\
-                        -> while checking validity of {:?}{}"
-                        self.bits()
+                        -> while checking validity of {:?}{}",
+                        self.bits(),
                         stringify!($Bits),
                         self,
                         cx,
@@ -419,9 +419,9 @@ macro_rules! make_packers {
                     assert!(
                         self.bits() + self.shift <= Self::SIZE_BITS,
                         "shift + number of bits ({} + {} = {}) may not exceed maximum bits for {} (would wrap)\n\
-                        -> while checking validity of {:?}{}"
+                        -> while checking validity of {:?}{}",
                         self.shift,
-                        self.bits()
+                        self.bits(),
                         self.bits() + self.shift,
                         stringify!($Bits),
                         self,
@@ -582,9 +582,6 @@ macro_rules! make_packers {
                     (val >> self.dst_shl) << self.dst_shr
                 }
 
-                const fn src_mask(&self) -> $Bits {
-                    self.src.mask
-                }
 
                 /// Returns the "source" member of the packing pair.
                 pub const fn src(&self) -> &$Pack {
@@ -602,9 +599,9 @@ macro_rules! make_packers {
                 pub const fn pack_from_src(&self, src: $Bits, dst: $Bits) -> $Bits {
                     // extract the bit range from `dst` and shift it over to the
                     // target range in `src`.
-                    let bits = self.shift_src(dst & self.dst_mask);
+                    let bits = self.shift_src(dst & self.dst.mask);
                     // zero packed range in `src`.
-                    let src = src & !self.src_mask();
+                    let src = src & !self.src.mask;
                     src | bits
                 }
 
@@ -613,9 +610,9 @@ macro_rules! make_packers {
                 pub const fn pack_from_dst(&self, src: $Bits, dst: $Bits) -> $Bits {
                     // extract the bit range from `src` and shift it over to
                     // the target range in `dst`.
-                    let bits = self.shift_dst(src & self.src_mask());
+                    let bits = self.shift_dst(src & self.src.mask);
                     // zero the target range in `dst`.
-                    let dst = dst & !self.dst_mask;
+                    let dst = dst & !self.dst.mask;
                     dst | bits
                 }
 
@@ -640,8 +637,8 @@ macro_rules! make_packers {
                         -> while checking validity of {:?}",
                         self
                     );
-                    self.dst.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self))
-                    self.src.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self))
+                    self.dst.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self));
+                    self.src.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self));
                 }
             }
 

--- a/util/src/bits.rs
+++ b/util/src/bits.rs
@@ -136,66 +136,71 @@ use core::{
 };
 
 macro_rules! make_packers {
-    ($(pub struct $name:ident { bits: $bits:ty, packing: $packing:ident, pair: $ident })+) => {
+    ($(pub struct $Pack:ident { bits: $Bits:ty, packing: $Packing:ident, pair: $Pair:ident $(,)? })+) => {
         $(
 
             #[doc = concat!(
                 "A spec for packing values into selected bit ranges of [`",
-                stringify!($bits),
+                stringify!($Bits),
                 "`] values."
             )]
             #[derive(Copy, Clone, PartialEq, Eq)]
-            pub struct $name {
-                mask: $bits,
+            pub struct $Pack {
+                mask: $Bits,
                 shift: u32,
             }
 
             #[doc = concat!(
                 "Wraps a [`",
-                stringify!($bits),
+                stringify!($Bits),
                 "`] to add methods for packing bit ranges specified by [`",
-                stringify!($name),
+                stringify!($Pack),
                 "`]."
             )]
             #[derive(Copy, Clone, PartialEq, Eq)]
-            pub struct $packing($bits);
+            pub struct $Packing($Bits);
 
-            #[derive(Copy, Clone, PartialEq, Eq)]
-            pub struct $pair {
-                src: $name,
-                dst_shl: $bits,
-                dst_shr: $bits,
+            #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+            pub struct $Pair {
+                src: $Pack,
+                dst: $Pack,
+                dst_shl: $Bits,
+                dst_shr: $Bits,
             }
 
-            impl $name {
+            impl $Pack {
                 // XXX(eliza): why is this always `u32`? ask the stdlib i guess...
-                const SIZE_BITS: u32 = <$bits>::MAX.leading_ones();
+                const SIZE_BITS: u32 = <$Bits>::MAX.leading_ones();
 
                 /// Returns a value with the first `n` bits set.
-                const fn mask(n: u32) -> $bits {
+                const fn mask(n: u32) -> $Bits {
                     if n == 0 {
                         return 0
                     };
-                    let one: $bits = 1; // lolmacros
+                    let one: $Bits = 1; // lolmacros
                     let shift = one.wrapping_shl(n - 1);
                     shift | (shift.saturating_sub(1))
                 }
 
+                const fn shift_next(&self) -> u32 {
+                    Self::SIZE_BITS - self.mask.leading_zeros()
+                }
+
                 #[doc = concat!(
                     "Wrap a [`",
-                    stringify!($bits),
+                    stringify!($Bits),
                     "`] to add methods for packing bit ranges using [`",
-                    stringify!($name),
+                    stringify!($Pack),
                     "`]."
                 )]
                 #[doc = ""]
                 #[doc = concat!(
                     "This is equivalent to calling [`",
-                    stringify!($packing),
+                    stringify!($Packing),
                     "::new`], but only requires importing the packer type."
                 )]
-                pub const fn pack_in(value: $bits) -> $packing {
-                    $packing::new(value)
+                pub const fn pack_in(value: $Bits) -> $Packing {
+                    $Packing::new(value)
                 }
 
                 /// Returns a packer for packing a value into the first `bits` bits.
@@ -209,11 +214,10 @@ macro_rules! make_packers {
                 /// Returns a packer for packing a value into the next more-significant
                 /// `n` from `self`.
                 pub const fn next(&self, n: u32) -> Self {
-                    let shift = Self::SIZE_BITS - self.mask.leading_zeros();
+                    let shift = self.shift_next();
                     let mask = Self::mask(n) << shift;
                     Self { mask, shift }
                 }
-
 
                 /// Returns a packer for packing a value into the next `n` more-significant
                 ///  after the `bit`th bit.
@@ -224,7 +228,7 @@ macro_rules! make_packers {
                 }
 
                 /// Returns a packer that will pack a value into the provided mask.
-                pub const fn from_mask(mask: $bits) -> Self {
+                pub const fn from_mask(mask: $Bits) -> Self {
                     let shift = mask.leading_zeros();
                     let mask = mask >> shift;
                     Self { mask, shift }
@@ -280,16 +284,45 @@ macro_rules! make_packers {
                     Self::starting_at(start, end.saturating_sub(start))
                 }
 
-                pub const fn pair_at(&self, at: u32) -> $pair {
-                    
-                } 
+                /// Returns a pair type for packing bits from the range
+                /// specified by `self` at the specified offset `at`, which may
+                /// differ from `self`'s offset.
+                ///
+                /// The packing pair can be used to pack bits from one location
+                /// into another location, and vice versa.
+                pub const fn pair_at(&self, at: u32) -> $Pair {
+                    let dst = Pair::starting_at(at, self.bits());
+                    let at = at.saturating_sub(1);
+                    // TODO(eliza): validate that `at + self.bits() < N_BITS` in
+                    // const fn somehow lol
+                    let (dst_shl, dst_shr) = if at > self.shift {
+                        // If the destination is greater than `self`, we need to
+                        // shift left.
+                        ((at - self.shift) as $Bits, 0)
+                    } else {
+                        // Otherwise, shift down.
+                        (0, (self.shift - at) as $Bits)
+                    };
+                    $Pair {
+                        src: *self,
+                        dst,
+                        dst_shl,
+                        dst_shr,
+                    }
+                }
+
+                /// Returns a pair type for packing bits from the range
+                /// specified by `self` after the specified packing spec.
+                pub const fn pair_after(&self, after: &Self) -> $Pair {
+                    self.pair_at(after.shift_next())
+                }
 
                 /// Returns the number of bits needed to pack this value.
                 pub const fn bits(&self) -> u32 {
                     Self::SIZE_BITS - (self.mask >> self.shift).leading_zeros()
                 }
 
-                pub const fn max_value(&self) -> $bits {
+                pub const fn max_value(&self) -> $Bits {
                     (1 << self.bits()) - 1
                 }
 
@@ -298,7 +331,7 @@ macro_rules! make_packers {
                 /// Any bits more significant than the [`self.bits()`]-th bit are ignored.
                 ///
                 /// [`self.bits()`]: Self::bits
-                pub const fn pack_truncating(&self, value: $bits, base: $bits) -> $bits {
+                pub const fn pack_truncating(&self, value: $Bits, base: $Bits) -> $Bits {
                     let value = value & self.max_value();
                     // other bits from `base` we don't want to touch
                     let rest = base & !self.mask;
@@ -313,7 +346,7 @@ macro_rules! make_packers {
                 /// in `value`.
                 ///
                 /// [`self.bits()`]: Self::bits
-                pub fn pack(&self, value: $bits, base: $bits) -> $bits {
+                pub fn pack(&self, value: $Bits, base: $Bits) -> $Bits {
                     assert!(
                         value <= self.max_value(),
                         "bits outside of packed range are set!\n     value: {:0x},\n max_value: {:0x}",
@@ -329,7 +362,7 @@ macro_rules! make_packers {
                 /// ```rust,ignore
                 /// self.pack(self.max_value(), base)
                 /// ```
-                pub const fn set_all(&self, base: $bits) -> $bits {
+                pub const fn set_all(&self, base: $Bits) -> $Bits {
                     // Note: this will never truncate (the reason why is left
                     // as an exercise to the reader).
                     self.pack_truncating(self.max_value(), base)
@@ -341,55 +374,100 @@ macro_rules! make_packers {
                 /// ```rust,ignore
                 /// self.pack(0, base)
                 /// ```
-                pub const fn unset_all(&self, base: $bits) -> $bits {
+                pub const fn unset_all(&self, base: $Bits) -> $Bits {
                     // may be slightly faster than actually calling
                     // `self.pack(0, base)` when not const-evaling
                     base & !self.mask
                 }
 
                 /// Unpack this packer's bits from `source`.
-                pub const fn unpack(&self, src: $bits) -> $bits {
+                pub const fn unpack(&self, src: $Bits) -> $Bits {
                     (src & self.mask) >> self.shift
+                }
+
+                /// Asserts that this packing pair is valid.
+                ///
+                /// Because assertions cannot be made in `const fn`, this
+                /// performs validating assertions that would ideally be made
+                /// when constructing a new instance of this type. When packing
+                /// specs are declared as `const`s, this method can be called in
+                /// a unit test to ensure that the spec is valid.
+                #[track_caller]
+                pub fn assert_valid(&self) {
+                    self.assert_valid_inner("")
+                }
+
+                #[track_caller]
+                fn assert_valid_inner(&self, cx: &impl fmt::Display) {
+                    assert!(
+                        self.shift < Self::SIZE_BITS,
+                        "shift may not exceed maximum bits for {} (would wrap)\n\
+                         -> while checking validity of {:?}{}"
+                        stringify!($Bits),
+                        self,
+                        cx,
+                    );
+                    assert!(
+                        self.bits() <= Self::SIZE_BITS,
+                        "number of bits ({}) may not exceed maximum bits for {} (would wrap)\n\
+                        -> while checking validity of {:?}{}"
+                        self.bits()
+                        stringify!($Bits),
+                        self,
+                        cx,
+                    );
+                    assert!(
+                        self.bits() + self.shift <= Self::SIZE_BITS,
+                        "shift + number of bits ({} + {} = {}) may not exceed maximum bits for {} (would wrap)\n\
+                        -> while checking validity of {:?}{}"
+                        self.shift,
+                        self.bits()
+                        self.bits() + self.shift,
+                        stringify!($Bits),
+                        self,
+                        cx,
+                    );
+
                 }
             }
 
-            impl fmt::Debug for $name {
+            impl fmt::Debug for $Pack {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_struct(stringify!($name))
+                    f.debug_struct(stringify!($Pack))
                         .field("mask", &format_args!("{:#b}", self.mask))
                         .field("shift", &self.shift)
                         .finish()
                 }
             }
 
-            impl fmt::UpperHex for $name {
+            impl fmt::UpperHex for $Pack {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_struct(stringify!($name))
+                    f.debug_struct(stringify!($Pack))
                         .field("mask", &format_args!("{:#X}", self.mask))
                         .field("shift", &self.shift)
                         .finish()
                 }
             }
 
-            impl fmt::LowerHex for $name {
+            impl fmt::LowerHex for $Pack {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_struct(stringify!($name))
+                    f.debug_struct(stringify!($Pack))
                         .field("mask", &format_args!("{:#x}", self.mask))
                         .field("shift", &self.shift)
                         .finish()
                 }
             }
 
-            impl fmt::Binary for $name {
+            impl fmt::Binary for $Pack {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_struct(stringify!($name))
+                    f.debug_struct(stringify!($Pack))
                         .field("mask", &format_args!("{:#b}", self.mask))
                         .field("shift", &self.shift)
                         .finish()
                 }
             }
 
-            impl<R: RangeBounds<u32>> From<R> for $name {
+            impl<R: RangeBounds<u32>> From<R> for $Pack {
                 fn from(range: R) -> Self {
                     Self::from_range(range)
                 }
@@ -397,15 +475,15 @@ macro_rules! make_packers {
 
             // === packing type ===
 
-            impl $packing {
+            impl $Packing {
                 #[doc = concat!(
                     "Wrap a [`",
-                    stringify!($bits),
+                    stringify!($Bits),
                     "`] to add methods for packing bit ranges using [`",
-                    stringify!($name),
+                    stringify!($Pack),
                     "`]."
                 )]
-                pub const fn new(bits: $bits) -> Self {
+                pub const fn new(bits: $Bits) -> Self {
                     Self(bits)
                 }
 
@@ -415,7 +493,7 @@ macro_rules! make_packers {
                 /// Any bits in `value` outside the range specified by `packer`
                 /// are ignored.
                 #[inline]
-                pub const fn pack_truncating(self, value: $bits, packer: &$name) -> Self {
+                pub const fn pack_truncating(self, value: $Bits, packer: &$Pack) -> Self {
                     Self(packer.pack_truncating(value, self.0))
                 }
 
@@ -425,72 +503,178 @@ macro_rules! make_packers {
                 /// # Panics
                 ///
                 /// If `value` contains bits outside the range specified by `packer`.
-                pub fn pack(self, value: $bits, packer: &$name) -> Self {
+                pub fn pack(self, value: $Bits, packer: &$Pack) -> Self {
                     Self(packer.pack(value, self.0))
                 }
 
                 /// Set _all_ bits in the range specified by `packer` to 1 in `self`.
                 #[inline]
-                pub const fn set_all(self, packer: &$name) -> Self {
+                pub const fn set_all(self, packer: &$Pack) -> Self {
                     Self(packer.set_all(self.0))
                 }
 
                 /// Set _all_ bits in the range specified by `packer` to 0 in
                 /// `self`.
                 #[inline]
-                pub const fn unset_all(self, packer: &$name) -> Self {
+                pub const fn unset_all(self, packer: &$Pack) -> Self {
                     Self(packer.unset_all(self.0))
                 }
 
                 /// Finish packing bits into `self`, returning the wrapped
                 /// value.
                 #[inline]
-                pub const fn bits(self) -> $bits {
+                pub const fn bits(self) -> $Bits {
                     self.0
                 }
             }
 
-            impl fmt::Debug for $packing {
+            impl fmt::Debug for $Packing {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_tuple(stringify!($packing))
+                    f.debug_tuple(stringify!($Packing))
                         .field(&format_args!("{:#b}", self.0))
                         .finish()
                 }
             }
 
-            impl fmt::UpperHex for $packing {
+            impl fmt::UpperHex for $Packing {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_tuple(stringify!($packing))
+                    f.debug_tuple(stringify!($Packing))
                         .field(&format_args!("{:X}", self.0))
                         .finish()
                 }
             }
 
-            impl fmt::LowerHex for $packing {
+            impl fmt::LowerHex for $Packing {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_tuple(stringify!($packing))
+                    f.debug_tuple(stringify!($Packing))
                     .field(&format_args!("{:#x}", self.0))
                     .finish()
                 }
             }
 
-            impl fmt::Binary for $packing {
+            impl fmt::Binary for $Packing {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    f.debug_tuple(stringify!($packing))
+                    f.debug_tuple(stringify!($Packing))
                         .field(&format_args!("{:#b}", self.0))
                         .finish()
                 }
             }
 
-            impl From<$bits> for $packing {
-                fn from(bits: $bits) -> Self {
+            impl From<$Bits> for $Packing {
+                fn from(bits: $Bits) -> Self {
                     Self(bits)
                 }
             }
 
-            impl From<$packing> for $bits {
-                fn from(packing: $packing) -> Self {
+            impl From<$Packing> for $Bits {
+                fn from(packing: $Packing) -> Self {
                     packing.0
+                }
+            }
+
+            // ==== impl Pair ===
+            impl $Pair {
+                const fn shift_dst(&self, val: $Bits) -> $Bits {
+                    (val << self.dst_shl) >> self.dst_shr
+                }
+
+                const fn shift_src(&self, val: $Bits) -> $Bits {
+                    (val >> self.dst_shl) << self.dst_shr
+                }
+
+                const fn src_mask(&self) -> $Bits {
+                    self.src.mask
+                }
+
+                /// Returns the "source" member of the packing pair.
+                pub const fn src(&self) -> &$Pack {
+                    &self.src
+                }
+
+
+                /// Returns the "destination" member of the packing pair.
+                pub const fn dst(&self) -> &$Pack {
+                    &self.dst
+                }
+
+                /// Pack bits from the source location in `src` into the
+                /// destination location in `dst`.
+                pub const fn pack_from_src(&self, src: $Bits, dst: $Bits) -> $Bits {
+                    // extract the bit range from `dst` and shift it over to the
+                    // target range in `src`.
+                    let bits = self.shift_src(dst & self.dst_mask);
+                    // zero packed range in `src`.
+                    let src = src & !self.src_mask();
+                    src | bits
+                }
+
+                /// Pack bits from the destination location in `dst` into the
+                /// source location in `src`.
+                pub const fn pack_from_dst(&self, src: $Bits, dst: $Bits) -> $Bits {
+                    // extract the bit range from `src` and shift it over to
+                    // the target range in `dst`.
+                    let bits = self.shift_dst(src & self.src_mask());
+                    // zero the target range in `dst`.
+                    let dst = dst & !self.dst_mask;
+                    dst | bits
+                }
+
+                /// Asserts that this packing pair is valid.
+                ///
+                /// Because assertions cannot be made in `const fn`, this
+                /// performs validating assertions that would ideally be made
+                /// when constructing a new instance of this type. When packing
+                /// specs are declared as `const`s, this method can be called in
+                /// a unit test to ensure that the spec is valid.
+                #[track_caller]
+                pub fn assert_valid(&self) {
+                    assert_eq!(
+                        self.src.bits(), self.dst.bits(),
+                        "source and destination packing specs must be the same number of bits wide\n\
+                        -> while checking validity of {:?}",
+                        self
+                    );
+                    assert!(
+                        self.dst_shl == 0 || self.dst_shr == 0,
+                        "destination bits must not be shifted both left and right\n\
+                        -> while checking validity of {:?}",
+                        self
+                    );
+                    self.dst.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self))
+                    self.src.assert_valid_inner(&format_args!("\n-> while checking validity of {:?}", self))
+                }
+            }
+
+            impl fmt::UpperHex for $Pair {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.debug_struct(stringify!($Pair))
+                        .field("src", &self.src)
+                        .field("dst", &self.dst)
+                        .field("dst_shl", &self.dst_shl)
+                        .field("dst_shr", &self.dst_shr)
+                        .finish()
+                }
+            }
+
+            impl fmt::LowerHex for $Pair {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.debug_struct(stringify!($Pair))
+                        .field("src", &self.src)
+                        .field("dst", &self.dst)
+                        .field("dst_shl", &self.dst_shl)
+                        .field("dst_shr", &self.dst_shr)
+                        .finish()
+                }
+            }
+
+            impl fmt::Binary for $Pair {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.debug_struct(stringify!($Pair))
+                        .field("src", &self.src)
+                        .field("dst", &self.dst)
+                        .field("dst_shl", &self.dst_shl)
+                        .field("dst_shr", &self.dst_shr)
+                        .finish()
                 }
             }
         )+
@@ -499,18 +683,38 @@ macro_rules! make_packers {
 
 make_packers! {
     pub struct Pack64 { bits: u64, packing: Packing64, pair: Pair64, }
-    pub struct Pack32 { bits: u32, packing: Packing32, pair: Pair32 }
-    pub struct Pack16 { bits: u16, packing: Packing16, pair: Pair16 }
-    pub struct Pack8 { bits: u8, packing: Packing8, pair: Pair8 }
+    pub struct Pack32 { bits: u32, packing: Packing32, pair: Pair32, }
+    pub struct Pack16 { bits: u16, packing: Packing16, pair: Pair16, }
+    pub struct Pack8 { bits: u8, packing: Packing8, pair: Pair8, }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    macro_rules! prop_assert_bits_eq {
+        ($left:expr, $right:expr, $state:expr) => {
+            let left = $left;
+            let right = $right;
+            let lstr = stringify!($left);
+            let rstr = stringify!($right);
+            let expr_len = std::cmp::max(lstr.len(), rstr.len()) + 2;
+            let val_len = 80 - (expr_len + 4);
+            proptest::prop_assert_eq!(
+                left,
+                right,
+                "\n{:>expr_len$} = {:#0val_len$b}\n{:>expr_len$} = {:#0val_len$b}\n{state}",
+                lstr, left, rstr, right, expr_len = expr_len, val_len = val_len,
+                state = $state
+            );
+        };
+        ($left:expr, $right:expr) => {
+            prop_assert_bits_eq!($left, $right, "")
+        }
+    }
 
     macro_rules! test_pack_unpack {
-        ($(fn $fn:ident<$typ:ident, $bits_ty:ty>($max:expr);)+) => {
+        ($(fn $fn:ident<$Pack:ident, $Bits:ty>($max:expr);)+) => {
             proptest! {
                 $(
                     #[test]
@@ -519,23 +723,23 @@ mod tests {
                             Just(nbits),
                             proptest::bits::u64::between(0, nbits as usize - 1),
                             proptest::bits::u64::between(0, nbits as usize - 1),
-                            any::<$bits_ty>(),
+                            any::<$Bits>(),
                         )),
                     ) {
-                        let val1 = val1 as $bits_ty;
-                        let val2 = val2 as $bits_ty;
-                        let pack1 = $typ::least_significant(nbits);
+                        let val1 = val1 as $Bits;
+                        let val2 = val2 as $Bits;
+                        let pack1 = $Pack::least_significant(nbits);
                         let pack2 = pack1.next(nbits);
 
                         let packed1 = pack1.pack(val1, base);
-                        prop_assert_eq!(pack1.unpack(packed1), val1);
+                        prop_assert_bits_eq!(pack1.unpack(packed1), val1);
 
                         let packed2 = pack2.pack(val1, base);
-                        prop_assert_eq!(pack2.unpack(packed2), val1);
+                        prop_assert_bits_eq!(pack2.unpack(packed2), val1);
 
                         let packed3 = pack1.pack(val1, pack2.pack(val2, base));
-                        prop_assert_eq!(pack1.unpack(packed3), val1);
-                        prop_assert_eq!(pack2.unpack(packed3), val2);
+                        prop_assert_bits_eq!(pack1.unpack(packed3), val1);
+                        prop_assert_bits_eq!(pack2.unpack(packed3), val2);
                     }
                 )+
             }
@@ -543,7 +747,7 @@ mod tests {
     }
 
     macro_rules! test_pack_methods {
-        ($(fn $fn:ident<$typ:ident, $bits_ty:ty>($max:expr);)+) => {
+        ($(fn $fn:ident<$Pack:ident, $Bits:ty>($max:expr);)+) => {
             proptest! {
                 $(
                     #[test]
@@ -552,21 +756,21 @@ mod tests {
                             Just(nbits),
                             proptest::bits::u64::between(0, nbits as usize - 1),
                             proptest::bits::u64::between(0, nbits as usize - 1),
-                            any::<$bits_ty>(),
+                            any::<$Bits>(),
                         )),
                     ) {
-                        let val1 = val1 as $bits_ty;
-                        let val2 = val2 as $bits_ty;
-                        let pack1 = $typ::least_significant(nbits);
+                        let val1 = val1 as $Bits;
+                        let val2 = val2 as $Bits;
+                        let pack1 = $Pack::least_significant(nbits);
                         let pack2 = pack1.next(nbits);
 
 
-                        let packed_methods = $typ::pack_in(base)
+                        let packed_methods = $Pack::pack_in(base)
                             .pack(val1, &pack1)
                             .pack(val2, &pack2)
                             .bits();
                         let packed_calls = pack1.pack(val1, pack2.pack(val2, base));
-                        prop_assert_eq!(packed_methods, packed_calls);
+                        prop_assert_bits_eq!(packed_methods, packed_calls);
                     }
                 )+
             }
@@ -574,7 +778,7 @@ mod tests {
     }
 
     macro_rules! test_from_range {
-        ($(fn $fn:ident<$typ:ident, $bits_ty:ty>($max:expr);)+) => {
+        ($(fn $fn:ident<$Pack:ident>($max:expr);)+) => {
             proptest! {
                 $(
                     #[test]
@@ -586,14 +790,89 @@ mod tests {
                     ) {
                         let range_inclusive = start..=(start + len);
                         let range_exclusive = start..(start + len + 1);
-                        println!("start={}; len={}; range_inclusive={:?}, range_exclusive={:?}", start, len, range_inclusive, range_exclusive);
-                        let least_sig = $typ::least_significant(start - 1);
+                        let state = format!(
+                            "start={}; len={}; range_inclusive={:?}, range_exclusive={:?}",
+                            start, len, range_inclusive, range_exclusive,
+                        );
+                        let least_sig = $Pack::least_significant(start - 1);
                         let pack_next = least_sig.next(len);
-                        let pack_range_inclusive = $typ::from_range(range_inclusive);
-                        let pack_range_exclusive = $typ::from_range(range_exclusive);
+                        let pack_range_inclusive = $Pack::from_range(range_inclusive);
+                        let pack_range_exclusive = $Pack::from_range(range_exclusive);
 
-                        prop_assert_eq!(pack_next, pack_range_inclusive);
-                        prop_assert_eq!(pack_next, pack_range_exclusive);
+                        prop_assert_bits_eq!(pack_next, pack_range_inclusive, &state);
+                        prop_assert_bits_eq!(pack_next, pack_range_exclusive, &state);
+                    }
+                )+
+            }
+        };
+    }
+
+    // Test packing and unpacking through a pair with other bits zeroed.
+    // This just tests that the shift calculations are reasonable.
+    macro_rules! test_pair_least_sig_zeroed {
+        ($(fn $fn:ident<$Pack:ident, $Bits:ty>($max:expr);)+) => {
+            proptest! {
+                $(
+                    #[test]
+                    fn $fn(
+                        (src_len, dst_at) in (1u32..($max/2)).prop_flat_map(|nbits| (
+                            Just(nbits),
+                            (0..$max-nbits),
+                        )),
+                    ) {
+                        let pack_from_src = $Pack::least_significant(src_len);
+                        let src = 0;
+                        let pack_from_dst = $Pack::starting_at(dst_at, src_len);
+                        let dst = pack_from_dst.set_all(0);
+                        let pair = pack_from_src.pair_at(dst_at);
+                        let state = format!(
+                            "src_len={}; dst_at={}; src={:#x}; dst={:#x};\npack_from_dst={:#?}\npair={:#?}",
+                            src_len, dst_at, src, dst, pack_from_dst, pair,
+                        );
+
+                        let packed = pair.pack_from_src(src, dst);
+                        prop_assert_bits_eq!(packed, pack_from_src.set_all(0), state);
+                        prop_assert_bits_eq!(pack_from_src.unpack(packed), pack_from_dst.unpack(dst), &state);
+
+                        let dst = <$Bits>::max_value();
+                        let packed = pair.pack_from_src(src, dst);
+                        prop_assert_bits_eq!(packed, pack_from_src.set_all(0), state);
+                        prop_assert_bits_eq!(pack_from_src.unpack(packed), pack_from_dst.unpack(dst), &state);
+                    }
+                )+
+            }
+        };
+    }
+
+
+    // Test packing and unpacking through a pair with arbitrary src/dst values.
+    // This tests that we don't leave behind unwanted bits, etc.
+    macro_rules! test_pair_least_sig_arbitrary {
+        ($(fn $fn:ident<$Pack:ident, $Bits:ty>($max:expr);)+) => {
+            proptest! {
+                $(
+                    #[test]
+                    fn $fn(
+                        (src_len, dst_at, src, dst) in (1u32..($max/2)).prop_flat_map(|nbits| (
+                            Just(nbits),
+                            (0..$max-nbits),
+                            any::<$Bits>(),
+                            any::<$Bits>(),
+                        )),
+                    ) {
+                        let pack_from_src = $Pack::least_significant(src_len);
+                        let pack_from_dst = $Pack::starting_at(dst_at, src_len);
+                        let pair = pack_from_src.pair_at(dst_at);
+                        let state = format!(
+                            "src_len={}; dst_at={}; src={:#x}; dst={:#x};\npack_from_dst={:#?}\npair={:#?}",
+                            src_len, dst_at, src, dst, pack_from_dst, pair,
+                        );
+
+                        let packed = pair.pack_from_src(src, dst);
+                        prop_assert_bits_eq!(pack_from_src.unpack(packed), pack_from_dst.unpack(dst), &state);
+
+                        let dst_unset = pack_from_dst.unset_all(dst);
+                        prop_assert_bits_eq!(pair.pack_from_dst(packed, dst_unset), dst, &state);
                     }
                 )+
             }
@@ -615,9 +894,24 @@ mod tests {
     }
 
     test_from_range! {
-        fn pack_from_range_64<Pack64, u64>(64);
-        fn pack_from_range_32<Pack32, u32>(32);
-        fn pack_from_range_16<Pack16, u16>(16);
-        fn pack_from_range_8<Pack8, u8>(8);
+        fn pack_from_src_range_64<Pack64>(64);
+        fn pack_from_src_range_32<Pack32>(32);
+        fn pack_from_src_range_16<Pack16>(16);
+        fn pack_from_src_range_8<Pack8>(8);
     }
+
+    test_pair_least_sig_zeroed! {
+        fn pair_least_sig_zeroed_64<Pack64, u64>(64);
+        fn pair_least_sig_zeroed_32<Pack32, u32>(32);
+        fn pair_least_sig_zeroed_16<Pack16, u16>(16);
+        fn pair_least_sig_zeroed_8<Pack8, u8>(8);
+    }
+
+    test_pair_least_sig_arbitrary! {
+        fn pair_least_sig_arbitrary_64<Pack64, u64>(64);
+        fn pair_least_sig_arbitrary_32<Pack32, u32>(32);
+        fn pair_least_sig_arbitrary_16<Pack16, u16>(16);
+        fn pair_least_sig_arbitrary_8<Pack8, u8>(8);
+    }
+
 }

--- a/util/src/bits.rs
+++ b/util/src/bits.rs
@@ -136,7 +136,7 @@ use core::{
 };
 
 macro_rules! make_packers {
-    ($(pub struct $name:ident { bits: $bits:ty, packing: $packing:ident })+) => {
+    ($(pub struct $name:ident { bits: $bits:ty, packing: $packing:ident, pair: $ident })+) => {
         $(
 
             #[doc = concat!(
@@ -144,7 +144,7 @@ macro_rules! make_packers {
                 stringify!($bits),
                 "`] values."
             )]
-            #[derive(Copy, Clone, PartialEq)]
+            #[derive(Copy, Clone, PartialEq, Eq)]
             pub struct $name {
                 mask: $bits,
                 shift: u32,
@@ -159,6 +159,13 @@ macro_rules! make_packers {
             )]
             #[derive(Copy, Clone, PartialEq, Eq)]
             pub struct $packing($bits);
+
+            #[derive(Copy, Clone, PartialEq, Eq)]
+            pub struct $pair {
+                src: $name,
+                dst_shl: $bits,
+                dst_shr: $bits,
+            }
 
             impl $name {
                 // XXX(eliza): why is this always `u32`? ask the stdlib i guess...
@@ -272,6 +279,10 @@ macro_rules! make_packers {
                     );
                     Self::starting_at(start, end.saturating_sub(start))
                 }
+
+                pub const fn pair_at(&self, at: u32) -> $pair {
+                    
+                } 
 
                 /// Returns the number of bits needed to pack this value.
                 pub const fn bits(&self) -> u32 {
@@ -487,10 +498,10 @@ macro_rules! make_packers {
 }
 
 make_packers! {
-    pub struct Pack64 { bits: u64, packing: Packing64 }
-    pub struct Pack32 { bits: u32, packing: Packing32 }
-    pub struct Pack16 { bits: u16, packing: Packing16 }
-    pub struct Pack8 { bits: u8, packing: Packing8 }
+    pub struct Pack64 { bits: u64, packing: Packing64, pair: Pair64, }
+    pub struct Pack32 { bits: u32, packing: Packing32, pair: Pair32 }
+    pub struct Pack16 { bits: u16, packing: Packing16, pair: Pair16 }
+    pub struct Pack8 { bits: u8, packing: Packing8, pair: Pair8 }
 }
 
 #[cfg(test)]

--- a/util/src/bits.rs
+++ b/util/src/bits.rs
@@ -704,13 +704,18 @@ mod tests {
                 left,
                 right,
                 "\n{:>expr_len$} = {:#0val_len$b}\n{:>expr_len$} = {:#0val_len$b}\n{state}",
-                lstr, left, rstr, right, expr_len = expr_len, val_len = val_len,
+                lstr,
+                left,
+                rstr,
+                right,
+                expr_len = expr_len,
+                val_len = val_len,
                 state = $state
             );
         };
         ($left:expr, $right:expr) => {
             prop_assert_bits_eq!($left, $right, "")
-        }
+        };
     }
 
     macro_rules! test_pack_unpack {
@@ -844,7 +849,6 @@ mod tests {
         };
     }
 
-
     // Test packing and unpacking through a pair with arbitrary src/dst values.
     // This tests that we don't leave behind unwanted bits, etc.
     macro_rules! test_pair_least_sig_arbitrary {
@@ -913,5 +917,4 @@ mod tests {
         fn pair_least_sig_arbitrary_16<Pack16, u16>(16);
         fn pair_least_sig_arbitrary_8<Pack8, u8>(8);
     }
-
 }


### PR DESCRIPTION
This commit adds new "packing pair" APIs to `util::bits` to allow
packing from a bit range in one value to a bit range in a different
value (at a different offset), without shifting to the least significant
bit and back.

This does still perform two shifts (a shift right and a shift left).
However, one of those shifts will always be by 0 bits. When the packing
pair is a const, we expect that the release mode compiler will hopefully
eliminate the zero-bit shift. When the pair is _not_ a const, two shifts
is probably more efficient than storing a bool for whether we should
perform a shift left or a shift right and branching on it.

I also cleaned up some stuff in the bit packing code.