### PR TITLE
chore: update to nightly-2021-09-22, fix clippy

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-06-05"
+channel = "nightly-2021-09-22"
 components = [
     "clippy",
     "rustfmt",

--- a/util/src/io/impls.rs
+++ b/util/src/io/impls.rs
@@ -258,7 +258,7 @@ impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());
-        let (a, b) = mem::replace(self, &mut []).split_at_mut(amt);
+        let (a, b) = mem::take(self).split_at_mut(amt);
         a.copy_from_slice(&data[..amt]);
         *self = b;
         Ok(amt)


### PR DESCRIPTION
This just updates Rust to the latest nightly, and fixes a new Clippy
lint on that nightly.