### PR TITLE
chore: update nightly to 2021-09-22

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-06-05"
+channel = "nightly-2021-09-22"
 components = [
     "clippy",
     "rustfmt",

--- a/util/src/io/impls.rs
+++ b/util/src/io/impls.rs
@@ -258,7 +258,7 @@ impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());
-        let (a, b) = mem::replace(self, &mut []).split_at_mut(amt);
+        let (a, b) = mem::take(self).split_at_mut(amt);
         a.copy_from_slice(&data[..amt]);
         *self = b;
         Ok(amt)

--- a/x86_64-mycelium.json
+++ b/x86_64-mycelium.json
@@ -8,8 +8,7 @@
     "code-model": "kernel",
     "os": "none",
     "executables": true,
-    "linker-flavor": "ld.lld",
-    "linker": "rust-lld",
+    "linker-flavor": "ld",
     "panic-strategy": "abort",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float"

--- a/x86_64-mycelium.json
+++ b/x86_64-mycelium.json
@@ -8,7 +8,14 @@
     "code-model": "kernel",
     "os": "none",
     "executables": true,
-    "linker-flavor": "ld",
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "post-link-args": {
+        "ld.lld": [
+            "-z",
+            "nostart-stop-gc"
+        ]
+    },
     "panic-strategy": "abort",
     "disable-redzone": true,
     "features": "-mmx,-sse,+soft-float"


### PR DESCRIPTION
so, per @mystor, the nightly bump works if we switch to linking with GNU `ld`.

i spent a while struggling with trying to get rust-lld to work by passing the `-z nostart-stop-gc` argument, but `rust-lld` claims it doesn't know about that.

after adding this to the target JSON:
```json
    "linker-flavor": "ld.lld",
    "linker": "rust-lld",
    "post-link-args": {
        "ld.lld": [
            "-z nostart-stop-gc"
        ]
    },
```
i get
```
 <...massive horrible linker invocation> "--gc-sections" "-z nostart-stop-gc"
  = note: rust-lld: error: unknown -z value:  nostart-stop-gc


error: could not compile `mycelium-kernel` due to previous error
```
which seems surprising given that
> Require -z start-stop-gc, which is available in trunk ld.lld (https://reviews.llvm.org/D96914) and GNU ld newer than 2021-03-01 (https://sourceware.org/bugzilla/show_bug.cgi?id=27451)
(per some random googling i did https://reviews.llvm.org/D96914)

so, whatever, GNU `ld` works. but it would be nice if we could make rust-lld work again...