### PR TITLE
chore: add gdb to nix config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 **/*.rs.bk
 
 # End of https://www.gitignore.io/api/rust
+
+### GDB ###
+
+.gdb_history

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,6 @@ pkgs.buildEnv {
     [
       git
       bash
-      direnv
       binutils
       stdenv
       bashInteractive

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let env = (import ./default.nix scope);
 
 in pkgs.mkShell {
   # also install qemu into the dev shell, for testing
-  packages = [ pkgs.qemu_full ];
+  packages = with pkgs; [ qemu_full gdb direnv ];
 
   LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
It's nice to have gdb for debugging the kernel. This changes the
`nix-shell` config to ensure it's present in nix-shell, if the user
hasn't installed it globally.

I also added `.gdb_history` files to the gitignore.