### PR TITLE
feat(inoculate): add subcommand for launching gdb

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,7 +3,7 @@ runner = "cargo run --package inoculate --"
 
 [alias]
 run-x64 = "run -Z build-std=core,alloc --target=x86_64-mycelium.json -- run"
-debug-x64 = "run -Z build-std=core,alloc --target=x86_64-mycelium.json -- run -- -gdb tcp::1234 -S"
+debug-x64 = "run -Z build-std=core,alloc --target=x86_64-mycelium.json -- run --serial --gdb"
 test-x64 = "test -Z build-std=core,alloc --target=x86_64-mycelium.json -- test"
 clippy-x64 = "clippy -Z build-std=core,alloc --target=x86_64-mycelium.json"
 build-x64 = "run -Z build-std=core,alloc --target=x86_64-mycelium.json --"

--- a/inoculate/src/gdb.rs
+++ b/inoculate/src/gdb.rs
@@ -1,0 +1,49 @@
+use crate::{cargo_log, Result};
+use color_eyre::eyre::WrapErr;
+use std::{
+    path::Path,
+    process::{Command, ExitStatus},
+};
+
+#[tracing::instrument]
+pub fn run_gdb(binary: &Path, gdb_port: u16) -> Result<ExitStatus> {
+    let gdb_path = wheres_gdb().context("failed to find gdb executable")?;
+    cargo_log!("Found", "{}", gdb_path);
+    let mut gdb = Command::new(gdb_path);
+
+    // Set the file, and connect to the given remote, then advance to `kernel_main`.
+    //
+    // The `-ex` command provides a gdb command to which is run by gdb
+    // before handing control over to the user, and we can use it to
+    // configure the gdb session to connect to the gdb remote.
+    gdb.arg("-ex").arg(format!("file {}", binary.display()));
+    gdb.arg("-ex").arg(format!("target remote :{}", gdb_port));
+
+    // Set a temporary breakpoint on `kernel_main` and continue to it to
+    // skip the non-mycelium boot process.
+    // XXX: Add a flag to skip doing this to allow debugging the boot process.
+    gdb.arg("-ex").arg("tbreak mycelium_kernel::kernel_main");
+    gdb.arg("-ex").arg("continue");
+
+    cargo_log!("Running", "{:?}", gdb);
+    // Try to run gdb.
+    let status = gdb.status().context("failed to run gdb")?;
+
+    tracing::debug!("gdb exited with status {:?}", status);
+    Ok(status)
+}
+
+fn wheres_gdb() -> Result<String> {
+    let output = Command::new("which")
+        .arg("rust-gdb")
+        .output()
+        .context("running `which rust-gdb` failed")?;
+    let mut which_gdb =
+        String::from_utf8(output.stdout).context("`which rust-gdb` output was not a string")?;
+    which_gdb.truncate(which_gdb.trim_end().len());
+    if which_gdb.ends_with("not found") {
+        return Ok(String::from("gdb"));
+    }
+
+    Ok(which_gdb)
+}

--- a/inoculate/src/main.rs
+++ b/inoculate/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
         .init();
 
     tracing::info! {
-        ?opts.qemu,
+        ?opts.cmd,
         ?opts.kernel_bin,
         ?opts.bootloader_manifest,
         ?opts.kernel_manifest,
@@ -44,8 +44,8 @@ fn main() -> Result<()> {
         .note("this sucks T_T")?;
     tracing::info!(image = %image.display());
 
-    if let Some(qemu) = opts.qemu {
-        return qemu.run_qemu(image.as_ref(), kernel_bin.as_ref());
+    if let Some(cmd) = opts.cmd {
+        return cmd.run(image.as_ref(), kernel_bin.as_ref());
     }
 
     Ok(())


### PR DESCRIPTION
This branch adds a separate subcommand to `inoculate` for launching
`gdb` and connecting to a running QEMU on the default port. This is
intended for when the QEMU has already been launched, and you want to
connect to it a second terminal. I've found this useful for running a
debug session while looking at serial output in the QEMU terminal.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>