### PR TITLE
feat(inoculate): nicer CLI output

### DIFF
--- a/inoculate/src/main.rs
+++ b/inoculate/src/main.rs
@@ -25,27 +25,16 @@ fn main() -> Result<()> {
         "inoculating...",
     };
 
-    let bootloader_manifest = opts.wheres_bootloader()?;
-    tracing::info!(path = %bootloader_manifest.display(), "found bootloader manifest");
-
-    let kernel_manifest = opts.wheres_the_kernel()?;
-    tracing::info!(path = %kernel_manifest.display(), "found kernel manifest");
-
-    let kernel_bin = opts.wheres_the_kernel_bin()?;
-    tracing::info!(path = %kernel_bin.display(), "found kernel binary");
+    let paths = opts.paths()?;
 
     let image = opts
-        .make_image(
-            bootloader_manifest.as_ref(),
-            kernel_manifest.as_ref(),
-            kernel_bin.as_ref(),
-        )
+        .make_image(&paths)
         .context("making the mycelium image didnt work")
         .note("this sucks T_T")?;
     tracing::info!(image = %image.display());
 
     if let Some(cmd) = opts.cmd {
-        return cmd.run(image.as_ref(), kernel_bin.as_ref());
+        return cmd.run(image.as_ref(), &paths);
     }
 
     Ok(())

--- a/inoculate/src/qemu.rs
+++ b/inoculate/src/qemu.rs
@@ -232,28 +232,30 @@ impl Cmd {
                     Some(status) => {
                         if let Some(code) = status.code() {
                             if code == 33 {
-                                println!("tests completed successfully");
-                                return Ok(());
+                                Ok(())
+                            } else {
+                                Err(format_err!("QEMU exited with status code {}", code))
                             }
-
-                            Err(format_err!("QEMU exited with status code {}", code))
                         } else {
                             Err(format_err!("QEMU exited without a status code, wtf?"))
                         }
                     }
                 }
                 .context("tests failed");
+                tracing::debug!("tests done");
+
                 if let Some(res) = stdout {
                     tracing::trace!("collecting stdout");
                     let res = res.join().unwrap()?;
                     eprintln!("{}", res);
-
                     // exit with an error if the tests failed.
                     if !res.failed.is_empty() {
                         std::process::exit(1);
                     }
+
                     Ok(())
                 } else {
+                    tracing::warn!("no stdout from QEMU process?");
                     res
                 }
             }


### PR DESCRIPTION
This branch includes a couple `inoculate` improvements:
- print paths in stderr output more like how cargo does, including stripping prefixes when possible
- fixed an issue where test summaries aren't printed due to an accidental early return