### PR TITLE
feat(inoculate): `cargo`-style logs with `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "atty",
  "bootloader-locator",
  "color-eyre",
+ "heck",
  "locate-cargo-manifest",
  "mycotest",
  "owo-colors 2.1.0",

--- a/inoculate/Cargo.toml
+++ b/inoculate/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.3"
 tracing = "0.1.23"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 tracing-error = "0.2"
 color-eyre = "0.5"
 bootloader-locator = "0.0.4"
@@ -18,3 +18,4 @@ wait-timeout = "0.2"
 owo-colors = "2.0.0"
 atty = "0.2"
 mycotest = { path = "../mycotest", features = ["alloc"] }
+heck = "0.3.3"

--- a/inoculate/src/gdb.rs
+++ b/inoculate/src/gdb.rs
@@ -5,7 +5,7 @@ use std::{
     process::{Command, ExitStatus},
 };
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 pub fn run_gdb(binary: &Path, gdb_port: u16) -> Result<ExitStatus> {
     let gdb_path = wheres_gdb().context("failed to find gdb executable")?;
     tracing::info!("Found {}", gdb_path);

--- a/inoculate/src/gdb.rs
+++ b/inoculate/src/gdb.rs
@@ -1,4 +1,4 @@
-use crate::{cargo_log, Result};
+use crate::Result;
 use color_eyre::eyre::WrapErr;
 use std::{
     path::Path,
@@ -8,7 +8,7 @@ use std::{
 #[tracing::instrument]
 pub fn run_gdb(binary: &Path, gdb_port: u16) -> Result<ExitStatus> {
     let gdb_path = wheres_gdb().context("failed to find gdb executable")?;
-    cargo_log!("Found", "{}", gdb_path);
+    tracing::info!("Found {}", gdb_path);
     let mut gdb = Command::new(gdb_path);
 
     // Set the file, and connect to the given remote, then advance to `kernel_main`.
@@ -25,7 +25,7 @@ pub fn run_gdb(binary: &Path, gdb_port: u16) -> Result<ExitStatus> {
     gdb.arg("-ex").arg("tbreak mycelium_kernel::kernel_main");
     gdb.arg("-ex").arg("continue");
 
-    cargo_log!("Running", "{:?}", gdb);
+    tracing::info!("Running {:?}", gdb);
     // Try to run gdb.
     let status = gdb.status().context("failed to run gdb")?;
 

--- a/inoculate/src/lib.rs
+++ b/inoculate/src/lib.rs
@@ -93,6 +93,10 @@ impl Subcommand {
 }
 
 impl Options {
+    pub fn trace_init(&self) -> Result<()> {
+        trace::try_init(self)
+    }
+
     pub fn is_test(&self) -> bool {
         matches!(self.cmd, Some(Subcommand::Qemu(qemu::Cmd::Test { .. })))
     }

--- a/inoculate/src/main.rs
+++ b/inoculate/src/main.rs
@@ -10,20 +10,24 @@ fn main() -> Result<()> {
     let color = opts.color;
     color.set_global();
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_ansi(color.should_color_stdout()))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .event_format(inoculate::trace::CargoFormatter::default()),
+        )
         .with(tracing_error::ErrorLayer::default())
         .with(opts.log.parse::<tracing_subscriber::EnvFilter>()?)
         .init();
 
-    tracing::info! {
+    tracing::info!("inoculating mycelium!");
+    tracing::debug!(
         ?opts.cmd,
         ?opts.kernel_bin,
         ?opts.bootloader_manifest,
         ?opts.kernel_manifest,
         ?opts.target_dir,
         ?opts.out_dir,
-        "inoculating...",
-    };
+        "inoculate configuration"
+    );
 
     let paths = opts.paths()?;
 
@@ -31,7 +35,6 @@ fn main() -> Result<()> {
         .make_image(&paths)
         .context("making the mycelium image didnt work")
         .note("this sucks T_T")?;
-    tracing::info!(image = %image.display());
 
     if let Some(cmd) = opts.cmd {
         return cmd.run(image.as_ref(), &paths);

--- a/inoculate/src/main.rs
+++ b/inoculate/src/main.rs
@@ -3,20 +3,12 @@ use inoculate::{Options, Result};
 use structopt::StructOpt;
 
 fn main() -> Result<()> {
-    use tracing_subscriber::prelude::*;
     color_eyre::install()?;
 
     let opts = Options::from_args();
     let color = opts.color;
     color.set_global();
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .event_format(inoculate::trace::CargoFormatter::default()),
-        )
-        .with(tracing_error::ErrorLayer::default())
-        .with(opts.log.parse::<tracing_subscriber::EnvFilter>()?)
-        .init();
+    inoculate::trace::try_init(&opts)?;
 
     tracing::info!("inoculating mycelium!");
     tracing::debug!(

--- a/inoculate/src/main.rs
+++ b/inoculate/src/main.rs
@@ -6,12 +6,12 @@ fn main() -> Result<()> {
     color_eyre::install()?;
 
     let opts = Options::from_args();
+    opts.trace_init()?;
     let color = opts.color;
     color.set_global();
-    inoculate::trace::try_init(&opts)?;
 
     tracing::info!("inoculating mycelium!");
-    tracing::debug!(
+    tracing::trace!(
         ?opts.cmd,
         ?opts.kernel_bin,
         ?opts.bootloader_manifest,

--- a/inoculate/src/qemu.rs
+++ b/inoculate/src/qemu.rs
@@ -102,7 +102,7 @@ impl Cmd {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), level = "debug")]
     fn spawn_qemu(&self, qemu: &mut Command, binary: &Path) -> Result<Child> {
         let (Cmd::Run { qemu_settings, .. } | Cmd::Test { qemu_settings, .. }) = self;
 
@@ -129,7 +129,7 @@ impl Cmd {
         Ok(child)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, paths), level = "debug")]
     pub fn run_qemu(&self, image: &Path, paths: &crate::Paths) -> Result<()> {
         let mut qemu = Command::new("qemu-system-x86_64");
         qemu.arg("-drive")

--- a/inoculate/src/qemu.rs
+++ b/inoculate/src/qemu.rs
@@ -1,5 +1,5 @@
 use crate::term::{ColorMode, OwoColorize};
-use crate::{cargo_log, Result};
+use crate::Result;
 use color_eyre::{
     eyre::{ensure, format_err, WrapErr},
     Help, SectionExt,
@@ -141,12 +141,10 @@ impl Cmd {
                 serial,
                 qemu_settings,
             } => {
-                cargo_log!(
-                    "Running",
-                    "mycelium in QEMU ({})",
+                tracing::info!(
+                    "running mycelium in QEMU ({})",
                     paths.relative(image).display()
                 );
-                tracing::info!("running QEMU in normal mode");
                 if *serial {
                     tracing::debug!("configured QEMU to output serial on stdio");
                     qemu.arg("-serial").arg("stdio");
@@ -198,12 +196,7 @@ impl Cmd {
                     "-serial",
                     "stdio",
                 ];
-                cargo_log!(
-                    "Running",
-                    "kernel tests ({})",
-                    paths.relative(image).display()
-                );
-                tracing::info!("running QEMU in test mode");
+                tracing::info!("running kernel tests ({})", paths.relative(image).display());
                 qemu_settings.configure(&mut qemu);
                 qemu.args(TEST_ARGS);
 
@@ -268,12 +261,13 @@ impl Cmd {
 impl Settings {
     fn configure(&self, cmd: &mut Command) {
         if self.gdb {
-            tracing::debug!(gdb_port = self.gdb_port, "configured QEMU to wait for GDB");
+            tracing::debug!(gdb_port = self.gdb_port, "configuring QEMU to wait for GDB");
             cmd.arg("-S")
                 .arg("-gdb")
                 .arg(format!("tcp::{}", self.gdb_port));
         }
 
+        tracing::debug!(qemu.args = ?self.qemu_args, "configuring qemu");
         cmd.args(&self.qemu_args[..]);
     }
 }
@@ -315,7 +309,7 @@ impl TestResults {
             if let Some(test) = Test::parse_start(&line) {
                 let _span =
                     tracing::debug_span!("test", "{}::{}", test.module(), test.name()).entered();
-                tracing::debug!(?test, "found a test...");
+                tracing::debug!(?test, "found a test");
                 eprint!("test {} ...", test);
                 results.tests += 1;
 
@@ -342,7 +336,7 @@ impl TestResults {
                                 test,
                                 outcome,
                             );
-                            tracing::debug!(?outcome);
+                            tracing::trace!(?outcome);
                             curr_outcome = Some(outcome);
                             break;
                         }

--- a/inoculate/src/term.rs
+++ b/inoculate/src/term.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 pub const CARGO_LOG_WIDTH: usize = 12;
-pub use owo_colors::{style, OwoColorize};
+pub use owo_colors::{style, OwoColorize, Style};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]

--- a/inoculate/src/term.rs
+++ b/inoculate/src/term.rs
@@ -7,17 +7,6 @@ use std::{
 
 pub const CARGO_LOG_WIDTH: usize = 12;
 pub use owo_colors::{style, OwoColorize};
-#[macro_export]
-macro_rules! cargo_log {
-    ($tag:expr, $($arg:tt)+) => {
-        if $crate::term::ColorMode::default().should_color_stderr() {
-            use $crate::term::OwoColorize;
-            eprintln!("{:>width$} {}", $tag.green().bold(), format_args!($($arg)+), width = $crate::term::CARGO_LOG_WIDTH);
-        } else {
-            eprintln!("{:>width$} {}", $tag, format_args!($($arg)+), width = $crate::term::CARGO_LOG_WIDTH);
-        }
-    };
-}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]

--- a/inoculate/src/trace.rs
+++ b/inoculate/src/trace.rs
@@ -131,13 +131,13 @@ impl<'styles, 'writer> Visit for Visitor<'styles, 'writer> {
         // If we're writing the first field of the event, either emit cargo
         // formatting, or a level header.
         if self.is_empty {
-            // If the level is `INFO` or `DEBUG` and it has a message that's
+            // If the level is `INFO` and it has a message that's
             // shaped like a cargo log tag, emit the cargo tag followed by the
             // rest of the message.
-            if self.level >= Level::INFO && field.name() == Self::MESSAGE {
+            if self.level == Level::INFO && field.name() == Self::MESSAGE {
                 let message = format!("{:?}", value);
                 if let Some((tag, message)) = message.as_str().split_once(' ') {
-                    if tag.len() <= Self::INDENT && tag.ends_with("ing") || tag.ends_with('d') {
+                    if tag.len() <= Self::INDENT {
                         let tag = tag.to_title_case();
                         let style = match self.level {
                             Level::DEBUG => self.styles.debug,

--- a/inoculate/src/trace.rs
+++ b/inoculate/src/trace.rs
@@ -1,0 +1,128 @@
+use crate::term::{style, ColorMode, OwoColorize};
+use heck::TitleCase;
+use std::fmt;
+use tracing::{field::Field, Event, Level, Subscriber};
+use tracing_subscriber::{
+    field::Visit,
+    fmt::{format::Writer, FmtContext, FormatEvent, FormatFields},
+    registry::LookupSpan,
+};
+
+#[derive(Default)]
+pub struct CargoFormatter(());
+
+impl<S, N> FormatEvent<S, N> for CargoFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let level = event.metadata().level();
+
+        let mut visitor = Visitor::new(*level, writer.by_ref());
+        event.record(&mut visitor);
+
+        writer.write_char('\n')?;
+
+        Ok(())
+    }
+}
+
+struct Visitor<'writer> {
+    level: Level,
+    writer: Writer<'writer>,
+    is_empty: bool,
+    color: bool,
+}
+
+impl<'writer> Visitor<'writer> {
+    const MESSAGE: &'static str = "message";
+    const INDENT: usize = 12;
+
+    fn new(level: Level, writer: Writer<'writer>) -> Self {
+        Self {
+            level,
+            writer,
+            is_empty: true,
+            color: ColorMode::default().should_color_stdout(),
+        }
+    }
+}
+
+impl Visit for Visitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if self.is_empty {
+            if matches!(self.level, Level::INFO | Level::DEBUG) && field.name() == Self::MESSAGE {
+                let message = format!("{:?}", value);
+                if let Some((tag, message)) = message.as_str().split_once(' ') {
+                    let tag = tag.to_title_case();
+                    if tag.len() <= Self::INDENT {
+                        let style = match (self.level, self.color) {
+                            (Level::DEBUG, true) => style().bright_blue().bold(),
+                            (_, true) => style().green().bold(),
+                            (_, false) => style(),
+                        };
+
+                        let _ = write!(
+                            self.writer,
+                            "{:>indent$} ",
+                            tag.style(style),
+                            indent = Self::INDENT
+                        );
+
+                        let _ = self.writer.write_str(message);
+                        self.is_empty = false;
+                        return;
+                    }
+                }
+            }
+
+            let _ = match (self.level, self.color) {
+                (Level::ERROR, true) => {
+                    write!(self.writer, "{}{} ", "error".red().bold(), ":".bold())
+                }
+                (Level::WARN, true) => {
+                    write!(self.writer, "{}{} ", "warning".yellow().bold(), ":".bold())
+                }
+                (Level::INFO, true) => {
+                    write!(self.writer, "{}{} ", "info".green().bold(), ":".bold())
+                }
+                (Level::DEBUG, true) => {
+                    write!(self.writer, "{}{} ", "debug".blue().bold(), ":".bold())
+                }
+                (Level::TRACE, true) => {
+                    write!(self.writer, "{}{} ", "trace".purple().bold(), ":".bold())
+                }
+                (Level::ERROR, false) => self.writer.write_str("error: "),
+                (Level::WARN, false) => self.writer.write_str("warning: "),
+                (Level::INFO, false) => self.writer.write_str("info: "),
+                (Level::DEBUG, false) => self.writer.write_str("debug: "),
+                (Level::TRACE, false) => self.writer.write_str("TRACE: "),
+            };
+        }
+
+        if !self.is_empty {
+            let _ = self.writer.write_str(", ");
+        }
+
+        if field.name() == Self::MESSAGE {
+            let _ = write!(self.writer, "{:?}", value);
+        } else {
+            let bold = if self.color { style().bold() } else { style() };
+            let _ = write!(
+                self.writer,
+                "{}{} {:?}",
+                field.name().style(bold),
+                ":".style(bold),
+                value
+            );
+        }
+
+        self.is_empty = false;
+    }
+}

--- a/mycotest/src/lib.rs
+++ b/mycotest/src/lib.rs
@@ -13,7 +13,7 @@ pub const PASS_TEST: &str = "MYCELIUM_TEST_PASS:";
 extern crate alloc;
 
 use core::{cmp, fmt, marker::PhantomData};
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Test<'a, S = &'a str> {
     name: S,
     module: S,
@@ -112,6 +112,16 @@ impl<S: Ord> cmp::Ord for Test<'_, S> {
         self.module
             .cmp(&other.module)
             .then_with(|| self.name.cmp(&other.name))
+    }
+}
+
+// Custom impl to skip `PhantomData` field.
+impl<S: fmt::Debug> fmt::Debug for Test<'_, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Test")
+            .field("name", &self.name)
+            .field("module", &self.module)
+            .finish()
     }
 }
 


### PR DESCRIPTION
This branch adds a hacked-together `tracing` formatter for
cargo-esque logging in `inoculate`.

Some screenshots:
![image](https://user-images.githubusercontent.com/2796466/141657572-f1e91a32-e45d-41a0-9db0-cc7422cc97af.png)
![image](https://user-images.githubusercontent.com/2796466/141657589-3816361a-6510-4f74-9dca-48e715a73bc5.png)
![image](https://user-images.githubusercontent.com/2796466/141657592-58819153-0ec9-4596-9488-f8dee8d6df1b.png)
