### PR TITLE
feat(kernel): use buddy block allocator for kernel malloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,18 +128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +165,7 @@ checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
 dependencies = [
  "once_cell",
  "owo-colors 1.3.0",
- "tracing-core",
+ "tracing-core 0.1.21",
  "tracing-error 0.1.2",
 ]
 
@@ -271,7 +259,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-graphics-core",
  "mycelium-util",
- "tracing",
+ "tracing 0.2.0",
 ]
 
 [[package]]
@@ -281,7 +269,7 @@ dependencies = [
  "hal-core",
  "mycelium-trace",
  "mycelium-util",
- "tracing",
+ "tracing 0.2.0",
 ]
 
 [[package]]
@@ -320,17 +308,11 @@ dependencies = [
  "mycotest",
  "owo-colors 2.1.0",
  "structopt",
- "tracing",
+ "tracing 0.1.29",
  "tracing-error 0.2.0",
  "tracing-subscriber 0.3.1",
  "wait-timeout",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "json"
@@ -393,15 +375,6 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -443,7 +416,7 @@ version = "0.1.0"
 dependencies = [
  "hal-core",
  "mycelium-util",
- "tracing",
+ "tracing 0.2.0",
 ]
 
 [[package]]
@@ -460,7 +433,7 @@ dependencies = [
  "mycotest",
  "parity-wasm",
  "rlibc",
- "tracing",
+ "tracing 0.2.0",
  "wasmi",
  "wat",
  "yaxpeax-arch",
@@ -474,8 +447,8 @@ dependencies = [
  "embedded-graphics",
  "hal-core",
  "mycelium-util",
- "tracing",
- "tracing-core",
+ "tracing 0.2.0",
+ "tracing-core 0.2.0",
 ]
 
 [[package]]
@@ -484,15 +457,15 @@ version = "0.1.0"
 dependencies = [
  "loom",
  "proptest",
- "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing 0.2.0",
+ "tracing-subscriber 0.3.0",
 ]
 
 [[package]]
 name = "mycotest"
 version = "0.1.0"
 dependencies = [
- "tracing",
+ "tracing 0.1.29",
 ]
 
 [[package]]
@@ -766,33 +739,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
-name = "serde"
-version = "1.0.130"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
-
-[[package]]
-name = "serde_json"
-version = "1.0.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
 
 [[package]]
 name = "sharded-slab"
@@ -889,10 +839,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes 0.1.18",
+ "tracing-core 0.1.21",
+]
+
+[[package]]
+name = "tracing"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
+ "tracing-attributes 0.2.0",
+ "tracing-core 0.2.0",
 ]
 
 [[package]]
@@ -900,6 +861,16 @@ name = "tracing-attributes"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -916,12 +887,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-core"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "tracing-error"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
 dependencies = [
- "tracing",
+ "tracing 0.1.29",
  "tracing-subscriber 0.2.25",
 ]
 
@@ -931,7 +910,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
- "tracing",
+ "tracing 0.1.29",
  "tracing-subscriber 0.3.1",
 ]
 
@@ -943,17 +922,17 @@ checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
- "tracing-core",
+ "tracing-core 0.1.21",
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+name = "tracing-log"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
 dependencies = [
- "serde",
- "tracing-core",
+ "lazy_static",
+ "log",
+ "tracing-core 0.2.0",
 ]
 
 [[package]]
@@ -962,20 +941,22 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core 0.1.21",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.0"
+source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+dependencies = [
  "ansi_term 0.12.1",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
+ "tracing-core 0.2.0",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -986,14 +967,14 @@ checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
- "matchers 0.1.0",
+ "matchers",
  "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
+ "tracing 0.1.29",
+ "tracing-core 0.1.21",
+ "tracing-log 0.1.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ yaxpeax-x86 = { version = "1.0.0", default-features = false, features = ["fmt"] 
 yaxpeax-arch = { version = "0.2.0", default-features = false }
 
 [dependencies.tracing]
-version = "0.1"
 default_features = false
-features = ["attributes"]
+features = ["attributes", "alloc"]
+git = "https://github.com/tokio-rs/tracing"
 
 [dependencies.wasmi]
 git = "https://github.com/mystor/wasmi"
@@ -74,3 +74,7 @@ map-page-table-recursively = true
 [package.metadata.target.'cfg(target_arch = "x86_64")'.cargo-xbuild]
 memcpy = true
 sysroot_path = "target/x86_64/sysroot"
+
+[patch.crates-io]
+tracing = { git = "https://github.com/tokio-rs/tracing" }
+tracing-core = { git = "https://github.com/tokio-rs/tracing" }

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -12,6 +12,6 @@ bump = []
 buddy = ["hal-core", "mycelium-util", "tracing"]
 
 [dependencies]
-tracing = { version = "0.1", default_features = false, optional = true }
+tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, optional = true }
 mycelium-util = { path = "../util", optional = true }
 hal-core = { path = "../hal-core", optional = true }

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -226,14 +226,14 @@ where
         }
 
         for (order, list) in self.free_lists.as_ref().iter().enumerate() {
-            let _span = tracing::debug_span!("free_list", order).entered();
+            let _span = tracing::info_span!("free_list", order).entered();
             match list.try_lock() {
                 Some(list) => {
-                    tracing::trace!(?list);
+                    tracing::info!(?list);
                     tracing::debug!(entries = ?ListEntries(&*list));
                 }
                 None => {
-                    tracing::debug!("<THIS IS THE ONE WHERE THE PANIC HAPPENED LOL>");
+                    tracing::info!("<THIS IS THE ONE WHERE THE PANIC HAPPENED LOL>");
                 }
             }
         }
@@ -686,14 +686,26 @@ impl Free {
     }
 
     pub fn split_front(&mut self, size: usize, offset: usize) -> Option<ptr::NonNull<Self>> {
-        debug_assert_eq!(self.magic, Self::MAGIC);
+        debug_assert_eq!(
+            self.magic,
+            Self::MAGIC,
+            "MY MAGIC WAS MESSED UP! self={:#?}, self.magic={:#x}",
+            self,
+            self.magic
+        );
         let new_meta = self.meta.split_front(size)?;
         let new_free = unsafe { Self::new(new_meta, offset) };
         Some(new_free)
     }
 
     pub fn split_back(&mut self, size: usize, offset: usize) -> Option<ptr::NonNull<Self>> {
-        debug_assert_eq!(self.magic, Self::MAGIC);
+        debug_assert_eq!(
+            self.magic,
+            Self::MAGIC,
+            "MY MAGIC WAS MESSED UP! self={:#?}, self.magic={:#x}",
+            self,
+            self.magic
+        );
 
         let new_meta = self.meta.split_back(size)?;
         debug_assert_ne!(new_meta, self.meta);
@@ -706,8 +718,20 @@ impl Free {
     }
 
     pub fn merge(&mut self, other: &mut Self) {
-        debug_assert_eq!(self.magic, Self::MAGIC, "self.magic={:x}", self.magic);
-        debug_assert_eq!(other.magic, Self::MAGIC, "self.magic={:x}", self.magic);
+        debug_assert_eq!(
+            self.magic,
+            Self::MAGIC,
+            "MY MAGIC WAS MESSED UP! self={:#?}, self.magic={:#x}",
+            self,
+            self.magic
+        );
+        debug_assert_eq!(
+            self.magic,
+            Self::MAGIC,
+            "THEIR MAGIC WAS MESSED UP! self={:#?}, self.magic={:#x}",
+            self,
+            self.magic
+        );
         assert!(!other.links.is_linked());
         self.meta.merge(&mut other.meta)
     }

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -46,7 +46,6 @@ pub struct Alloc<L = [spin::Mutex<List<Free>>; 32]> {
 
 type Result<T> = core::result::Result<T, AllocErr>;
 
-#[derive(Debug)]
 pub struct Free {
     magic: usize,
     links: list::Links<Self>,
@@ -783,6 +782,16 @@ unsafe impl list::Linked for Free {
     #[inline]
     unsafe fn links(ptr: ptr::NonNull<Self>) -> ptr::NonNull<list::Links<Self>> {
         ptr::NonNull::from(&ptr.as_ref().links)
+    }
+}
+
+impl fmt::Debug for Free {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Free")
+            .field("magic", &fmt::hex(&self.magic))
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .finish()
     }
 }
 

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -475,17 +475,6 @@ where
         let span = tracing::trace_span!("alloc_range", size = size.as_usize(), len);
         let _e = span.enter();
 
-        // Determine the layout to allocate this page range...
-        if size.as_usize() > self.min_size {
-            // TODO(eliza): huge pages should work!
-            tracing::error!(
-                requested.size = size.as_usize(),
-                requested.len = len,
-                "cannot allocate; huge pages are not currently supported!"
-            );
-            return Err(AllocErr::oom());
-        }
-
         debug_assert!(
             size.as_usize().is_power_of_two(),
             "page size must be a power of 2; size={}",

--- a/alloc/src/bump.rs
+++ b/alloc/src/bump.rs
@@ -13,8 +13,8 @@ macro_rules! try_null {
     };
 }
 
-// 640k is enough for anyone
-const HEAP_SIZE: usize = 1 * 1024;
+// 1k is enough for anyone
+const HEAP_SIZE: usize = 1024;
 
 #[repr(align(16))]
 struct Heap(UnsafeCell<MaybeUninit<[u8; HEAP_SIZE]>>);

--- a/alloc/src/bump.rs
+++ b/alloc/src/bump.rs
@@ -14,7 +14,7 @@ macro_rules! try_null {
 }
 
 // 640k is enough for anyone
-const HEAP_SIZE: usize = 640 * 1024;
+const HEAP_SIZE: usize = 1 * 1024;
 
 #[repr(align(16))]
 struct Heap(UnsafeCell<MaybeUninit<[u8; HEAP_SIZE]>>);
@@ -71,6 +71,14 @@ unsafe impl GlobalAlloc for Alloc {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         dealloc(ptr, layout)
+    }
+}
+
+impl Alloc {
+    pub fn owns(&self, addr: *mut u8) -> bool {
+        let start_addr = HEAP.0.get() as *mut u8 as usize;
+        let end_addr = start_addr + HEAP_SIZE;
+        (addr as usize) < end_addr
     }
 }
 

--- a/hal-core/Cargo.toml
+++ b/hal-core/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = { version = "0.1", default_features = false }
+tracing = { git = "https://github.com/tokio-rs/tracing",  default_features = false }
 mycelium-util = { path = "../util" }
 embedded-graphics-core = { version = "0.3", optional = true }

--- a/hal-x86_64/Cargo.toml
+++ b/hal-x86_64/Cargo.toml
@@ -11,4 +11,4 @@ log = ["tracing/log"]
 hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
 mycelium-trace = { path = "../trace" }
-tracing = {version = "0.1", default_features = false, features = ["attributes"] }
+tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes"] }

--- a/hal-x86_64/src/serial.rs
+++ b/hal-x86_64/src/serial.rs
@@ -390,4 +390,8 @@ impl<'a> mycelium_trace::writer::MakeWriter<'a> for &'static Port {
     fn make_writer(&'a self) -> Self::Writer {
         self.lock()
     }
+
+    fn line_len(&self) -> usize {
+        120
+    }
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -406,7 +406,7 @@ pub fn run_tests() {
         if (test.run)() {
             writeln!(
                 &mut com1.lock(),
-                "{}{} {}",
+                "{} {} {}",
                 mycotest::PASS_TEST,
                 test.module,
                 test.name
@@ -416,8 +416,9 @@ pub fn run_tests() {
         } else {
             writeln!(
                 &mut com1.lock(),
-                "{}{} {}",
+                "{} {} {} {}",
                 mycotest::FAIL_TEST,
+                mycotest::Failure::Fail.as_str(),
                 test.module,
                 test.name
             )

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -339,6 +339,8 @@ pub fn oops(
     }
     let _ = vga.write_str("\n  it will never be safe to turn off your computer.");
 
+    crate::PAGE_ALLOCATOR.dump_free_lists();
+
     #[cfg(test)]
     {
         if let Some(test) = ptr::NonNull::new(CURRENT_TEST.load(Ordering::Acquire)) {

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -286,7 +286,7 @@ pub fn oops(
     // code, which (it turns out) is surprisingly janky...
     tracing::debug!(
         %cause,
-        registers = fault.as_ref().map(|cx| tracing::field::debug(cx.registers())),
+        registers = ?fault.as_ref().map(|cx| tracing::field::debug(cx.registers())),
         "oops"
     );
     // okay, we've dumped the oops to serial, now try to log a nicer event at

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -351,7 +351,7 @@ pub fn oops(
     }
     let _ = vga.write_str("\n  it will never be safe to turn off your computer.");
 
-    crate::PAGE_ALLOCATOR.dump_free_lists();
+    crate::ALLOC.dump_free_lists();
 
     #[cfg(test)]
     {
@@ -491,45 +491,45 @@ mycelium_util::decl_test! {
     fn alloc_some_4k_pages() -> Result<(), hal_core::mem::page::AllocErr> {
         use hal_core::mem::page::Alloc;
         let page1 = tracing::info_span!("alloc page 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         let page2 = tracing::info_span!("alloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         assert_ne!(page1, page2);
         tracing::info_span!("dealloc page 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page1);
+            let res = crate::ALLOC.dealloc(page1);
             tracing::info!(?res, "deallocated page 1");
             res
         })?;
         let page3 = tracing::info_span!("alloc page 3").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         assert_ne!(page2, page3);
         tracing::info_span!("dealloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page2);
+            let res = crate::ALLOC.dealloc(page2);
             tracing::info!(?res, "deallocated page 2");
             res
         })?;
         let page4 = tracing::info_span!("alloc page 4").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         assert_ne!(page3, page4);
         tracing::info_span!("dealloc page 3").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page3);
+            let res = crate::ALLOC.dealloc(page3);
             tracing::info!(?res, "deallocated page 3");
             res
         })?;
         tracing::info_span!("dealloc page 4").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page4);
+            let res = crate::ALLOC.dealloc(page4);
             tracing::info!(?res, "deallocated page 4");
             res
         })
@@ -540,42 +540,42 @@ mycelium_util::decl_test! {
     fn alloc_4k_pages_and_ranges() -> Result<(), hal_core::mem::page::AllocErr> {
         use hal_core::mem::page::Alloc;
         let range1 = tracing::info_span!("alloc range 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc_range(mm::size::Size4Kb, 16);
+            let res = crate::ALLOC.alloc_range(mm::size::Size4Kb, 16);
             tracing::info!(?res);
             res
         })?;
         let page2 = tracing::info_span!("alloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         tracing::info_span!("dealloc range 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc_range(range1);
+            let res = crate::ALLOC.dealloc_range(range1);
             tracing::info!(?res, "deallocated range 1");
             res
         })?;
         let range3 = tracing::info_span!("alloc range 3").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc_range(mm::size::Size4Kb, 10);
+            let res = crate::ALLOC.alloc_range(mm::size::Size4Kb, 10);
             tracing::info!(?res);
             res
         })?;
         tracing::info_span!("dealloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page2);
+            let res = crate::ALLOC.dealloc(page2);
             tracing::info!(?res, "deallocated page 2");
             res
         })?;
         let range4 = tracing::info_span!("alloc range 4").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc_range(mm::size::Size4Kb, 8);
+            let res = crate::ALLOC.alloc_range(mm::size::Size4Kb, 8);
             tracing::info!(?res);
             res
         })?;
         tracing::info_span!("dealloc range 3").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc_range(range3);
+            let res = crate::ALLOC.dealloc_range(range3);
             tracing::info!(?res, "deallocated range 3");
             res
         })?;
         tracing::info_span!("dealloc range 4").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc_range(range4);
+            let res = crate::ALLOC.dealloc_range(range4);
             tracing::info!(?res, "deallocated range 4");
             res
         })
@@ -586,47 +586,47 @@ mycelium_util::decl_test! {
     fn alloc_some_pages() -> Result<(), hal_core::mem::page::AllocErr> {
         use hal_core::mem::page::Alloc;
         let page1 = tracing::info_span!("alloc page 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         let page2 = tracing::info_span!("alloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size4Kb);
+            let res = crate::ALLOC.alloc(mm::size::Size4Kb);
             tracing::info!(?res);
             res
         })?;
         assert_ne!(page1, page2);
         tracing::info_span!("dealloc page 1").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page1);
+            let res = crate::ALLOC.dealloc(page1);
             tracing::info!(?res, "deallocated page 1");
             res
         })?;
         // TODO(eliza): when 2mb pages work, test that too...
         // let page3 = tracing::info_span!("alloc page 3").in_scope(|| {
-        //     let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size2Mb);
+        //     let res = crate::ALLOC.alloc(mm::size::Size2Mb);
         //     tracing::info!(?res);
         //     res
         // })?;
         tracing::info_span!("dealloc page 2").in_scope(|| {
-            let res = crate::PAGE_ALLOCATOR.dealloc(page2);
+            let res = crate::ALLOC.dealloc(page2);
             tracing::info!(?res, "deallocated page 2");
             res
         })?;
         // let page4 = tracing::info_span!("alloc page 4").in_scope(|| {
-        //     let res = crate::PAGE_ALLOCATOR.alloc(mm::size::Size2Mb);
+        //     let res = crate::ALLOC.alloc(mm::size::Size2Mb);
         //     tracing::info!(?res);
         //     res
         // })?;
         // tracing::info_span!("dealloc page 3").in_scope(|| {
-        //     let res = crate::PAGE_ALLOCATOR.dealloc(page3);
+        //     let res = crate::ALLOC.dealloc(page3);
         //     tracing::info!(?res, "deallocated page 3");
         //     res
         // })?;
         // tracing::info_span!("dealloc page 4").in_scope(|| {
-        //     let res = crate::PAGE_ALLOCATOR.dealloc(page4);
+        //     let res = crate::ALLOC.dealloc(page4);
         //     tracing::info!(?res, "deallocated page 4");
         //     res
-        // })
+        // })?;
         Ok(())
     }
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,66 @@
+use alloc::alloc::{GlobalAlloc, Layout};
+use mycelium_alloc::{buddy, bump};
+use mycelium_util::fmt;
+
+pub struct Heap {
+    bump_region: bump::Alloc,
+    allocator: &'static buddy::Alloc,
+}
+
+impl Heap {
+    pub const fn new(allocator: &'static buddy::Alloc) -> Self {
+        Self {
+            bump_region: bump::Alloc,
+            allocator,
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for Heap {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let bump_ptr = self.bump_region.alloc(layout);
+        if bump_ptr.is_null() {
+            return self.allocator.alloc(layout);
+        }
+
+        tracing::trace!(?layout, ptr = ?fmt::ptr(bump_ptr), "allocated from bump pointer region");
+        bump_ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if self.bump_region.owns(ptr) {
+            tracing::debug!(?layout, ptr = ?fmt::ptr(ptr), "deallocating bump region pointer, doing nothing lol");
+            return;
+        }
+
+        self.allocator.dealloc(ptr, layout)
+    }
+}
+
+mycelium_util::decl_test! {
+    fn basic_alloc() {
+        // Let's allocate something, for funsies
+        use alloc::vec::Vec;
+        let mut v = Vec::new();
+        tracing::info!(vec = ?v, vec.addr = ?v.as_ptr());
+        v.push(5u64);
+        tracing::info!(vec = ?v, vec.addr = ?v.as_ptr());
+        v.push(10u64);
+        tracing::info!(vec=?v, vec.addr=?v.as_ptr());
+        assert_eq!(v.pop(), Some(10));
+        assert_eq!(v.pop(), Some(5));
+    }
+}
+
+mycelium_util::decl_test! {
+    fn alloc_big() {
+        use alloc::vec::Vec;
+        let mut v = Vec::new();
+
+        for i in 0..2048 {
+            v.push(i);
+        }
+
+        tracing::info!(vec = ?v);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use mycelium_alloc::buddy;
 
 mod wasm;
 
-static PAGE_ALLOCATOR: buddy::Alloc = buddy::Alloc::new_default(arch::mm::MIN_PAGE_SIZE);
+static PAGE_ALLOCATOR: buddy::Alloc = buddy::Alloc::new_default(32);
 
 pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     let mut writer = bootinfo.writer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(all(target_os = "none", test), no_main)]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
-#![cfg_attr(target_os = "none", feature(panic_info_message))]
+#![feature(panic_info_message)]
 #![allow(unused_unsafe)]
 
 extern crate alloc;
@@ -158,20 +158,17 @@ mycelium_util::decl_test! {
     }
 }
 
-#[global_allocator]
-#[cfg(target_os = "none")]
+#[cfg_attr(target_os = "none", global_allocator)]
 pub static GLOBAL: heap::Heap = heap::Heap::new(&PAGE_ALLOCATOR);
 
-#[alloc_error_handler]
-#[cfg(target_os = "none")]
-fn alloc_error(layout: core::alloc::Layout) -> ! {
+#[cfg_attr(target_os = "none", alloc_error_handler)]
+pub fn alloc_error(layout: core::alloc::Layout) -> ! {
     panic!("alloc error: {:?}", layout);
 }
 
-#[cfg(target_os = "none")]
-#[panic_handler]
+#[cfg_attr(target_os = "none", panic_handler)]
 #[cold]
-fn panic(panic: &core::panic::PanicInfo) -> ! {
+pub fn panic(panic: &core::panic::PanicInfo) -> ! {
     use core::fmt;
     struct PrettyPanic<'a>(&'a core::panic::PanicInfo<'a>);
     impl<'a> fmt::Display for PrettyPanic<'a> {

--- a/trace/Cargo.toml
+++ b/trace/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing-core = { version = "0.1.20", default_features = false }
-tracing = { version = "0.1", default_features = false }
+tracing-core = {git = "https://github.com/tokio-rs/tracing", default_features = false }
+tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false }
 hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
 

--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -104,7 +104,7 @@ impl<D, S> Subscriber<D, S> {
     }
 }
 
-impl<D, S> tracing_core::Subscriber for Subscriber<D, S>
+impl<D, S> tracing_core::Collect for Subscriber<D, S>
 where
     for<'a> D: MakeWriter<'a> + 'static,
     for<'a> S: MakeWriter<'a> + 'static,
@@ -168,6 +168,11 @@ where
         let bits = span.into_u64();
         self.display.exit(bits);
         self.serial.exit(bits);
+    }
+
+    fn current_span(&self) -> tracing_core::span::Current {
+        // TODO(eliza): fix
+        tracing_core::span::Current::none()
     }
 }
 

--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -12,7 +12,7 @@ use mycelium_util::fmt::{self, Write, WriteExt};
 use tracing_core::{field, span, Event, Level, Metadata};
 
 #[derive(Debug)]
-pub struct Subscriber<D, S = writer::NoWriter> {
+pub struct Subscriber<D, S = Option<writer::NoWriter>> {
     display: Output<D, VGA_BIT>,
     serial: Output<S, SERIAL_BIT>,
     next_id: AtomicU64,
@@ -67,19 +67,21 @@ const SERIAL_BIT: u64 = 1 << 62;
 const VGA_BIT: u64 = 1 << 63;
 const _ACTUAL_ID_BITS: u64 = !(SERIAL_BIT | VGA_BIT);
 
-impl<D> Subscriber<D> {
+impl<D, S> Subscriber<D, S> {
     pub fn display_only(display: D) -> Self
     where
         for<'a> D: MakeWriter<'a>,
+        for<'a> S: MakeWriter<'a>,
+        S: Default,
     {
         Self {
             display: Output::new(display, " "),
-            serial: Output::new(writer::none(), " |"),
+            serial: Output::new(S::default(), " |"),
             next_id: AtomicU64::new(0),
         }
     }
 
-    pub fn with_serial<S>(self, port: S) -> Subscriber<D, S>
+    pub fn with_serial(self, port: S) -> Subscriber<D, S>
     where
         for<'a> S: MakeWriter<'a>,
     {

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 alloc = []
 
 [dependencies]
-tracing = { version = "0.1.29", default_features = false, features = ["attributes"] }
+tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes"] }
 
 [dev-dependencies]
 loom = "0.4"
 proptest = "1"
-tracing-subscriber = "0.2"
-tracing = { version = "0.1.29", default_features = false, features = ["attributes", "std"] }
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing" }
+tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes", "std"] }

--- a/util/src/intrusive/list.rs
+++ b/util/src/intrusive/list.rs
@@ -1,5 +1,5 @@
+use crate::fmt;
 use core::{
-    fmt,
     marker::PhantomPinned,
     mem::ManuallyDrop,
     ptr::{self, NonNull},
@@ -250,6 +250,13 @@ impl<T: Linked + ?Sized> List<T> {
             list: self,
         }
     }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            _list: self,
+            curr: self.head,
+        }
+    }
 }
 
 unsafe impl<T: Linked + ?Sized> Send for List<T> where T::Node: Send {}
@@ -258,8 +265,8 @@ unsafe impl<T: Linked + ?Sized> Sync for List<T> where T::Node: Sync {}
 impl<T: Linked + ?Sized> fmt::Debug for List<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("List")
-            .field("head", &self.head)
-            .field("tail", &self.tail)
+            .field("head", &fmt::opt(&self.head).or_else("None"))
+            .field("tail", &fmt::opt(&self.head).or_else("None"))
             .finish()
     }
 }
@@ -339,8 +346,8 @@ impl<T: ?Sized> fmt::Debug for Links<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Links")
             .field("self", &format_args!("{:p}", self))
-            .field("next", &self.next)
-            .field("prev", &self.prev)
+            .field("next", &fmt::opt(&self.next).or_else("None"))
+            .field("prev", &fmt::opt(&self.prev).or_else("None"))
             .finish()
     }
 }

--- a/util/src/intrusive/list.rs
+++ b/util/src/intrusive/list.rs
@@ -196,20 +196,11 @@ impl<T: Linked + ?Sized> List<T> {
             );
 
             if let Some(prev) = tail_links.as_mut().prev {
-                debug_assert_ne!(
-                    self.head,
-                    Some(tail),
-                    "a node with a previous link should not be the list head"
-                );
                 T::links(prev).as_mut().next = None;
             } else {
-                debug_assert_eq!(
-                    self.head,
-                    Some(tail),
-                    "if the tail has no previous link, it must be the head"
-                );
                 self.head = None;
             }
+
             tail_links.as_mut().unlink();
             tracing::trace!(?self, tail.links = ?tail_links, "pop_back: popped");
             Some(T::from_ptr(tail))

--- a/util/src/intrusive/list.rs
+++ b/util/src/intrusive/list.rs
@@ -513,6 +513,8 @@ mod tests {
         tracing_subscriber::fmt()
             .with_test_writer()
             .with_max_level(tracing::Level::TRACE)
+            .with_target(false)
+            .with_timer(())
             .set_default()
     }
 

--- a/util/src/intrusive/list.rs
+++ b/util/src/intrusive/list.rs
@@ -508,7 +508,7 @@ mod tests {
         const _: List<&Entry> = List::new();
     }
 
-    fn trace_init() -> tracing::dispatcher::DefaultGuard {
+    fn trace_init() -> tracing::dispatch::DefaultGuard {
         use tracing_subscriber::prelude::*;
         tracing_subscriber::fmt()
             .with_test_writer()
@@ -796,7 +796,8 @@ mod tests {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {
             let _trace = trace_init();
-            let _span = tracing::info_span!("fuzz", ?ops).entered();
+            let _span = tracing::info_span!("fuzz").entered();
+            tracing::info!(?ops);
             run_fuzz(ops);
         }
     }
@@ -827,6 +828,7 @@ mod tests {
         let entries: Vec<_> = (0..ops.len()).map(|i| entry(i as i32)).collect();
 
         for (i, op) in ops.iter().enumerate() {
+            let _span = tracing::info_span!("op", ?i, ?op).entered();
             match op {
                 Op::Push => {
                     reference.push_front(i as i32);
@@ -858,6 +860,7 @@ mod tests {
                     }
                 }
             }
+            ll.assert_valid();
         }
     }
 }

--- a/util/src/intrusive/list.rs
+++ b/util/src/intrusive/list.rs
@@ -167,7 +167,7 @@ impl<T: Linked + ?Sized> List<T> {
             let mut links = T::links(ptr);
             links.as_mut().next = self.head;
             links.as_mut().prev = None;
-
+            tracing::trace!(?links);
             if let Some(head) = self.head {
                 T::links(head).as_mut().prev = Some(ptr);
                 tracing::trace!(head.links = ?T::links(head).as_ref(), "set head prev ptr",);


### PR DESCRIPTION
## Motivation

Currently, mycelium contains two separate memory allocators: a bump
pointer allocator which is used as the kernel's heap allocator, and a
buddy-block allocator which is used to allocate physical pages for the
paging subsystem.

This is not ideal. The bump pointer allocator was intended primarily as
an interim solution until a better allocation scheme can be implemented
(and, secondarily, for potential use in early kernel initialization
before we can cut over to a proper allocator). It has a few significant
limitations: currently, it is limited in size to 640 KB, and (more
importantly) it cannot reclaim freed allocations. So, once those 640 KB
are used up, we are --- to use a technical term here --- "totally
fucked". If we want to make a number of heap allocations over the
kernel's lifetime, such as for an (eventual) async task executor, we
need a kernel heap that supports reclaiming deallocated memory.

## Solution

This branch changes mycelium to use the buddy-block allocator both for
allocating page frames *and* for allocating kernel heap objects. The
bump pointer allocator is no longer used.

In the process of switching over to the buddy-block allocator, I
uncovered a number of bugs in the allocator implementation which didn't
occur when the allocator was only used to allocate 4KB pages. In
particular

* The buddy-block allocator will allow constructing a heap where the
  minimum region size is too low to fit all the free block metadata.
  This is uh, quite bad, since it means that some free block metadata
  may become corrupted if an adjacent region is allocated. So, I've
  fixed this by having the allocator round up the minimum allocated size
  to ensure the free block metadata fits in it.

* There were a couple assertions in the intrusive linked list and in the
  allocator that were just flat-out wrong. I've fixed and/or removed
  these.

* When freeing an allocation, the free-block metadata was incorrectly
  constructed with the size of the _requested allocation_, not the size
  of the block that was allocated for that allocation request. These may
  differ, since the buddy block allocator only allocates power-of-two
  sized blocks, and an allocation request might not be a power of two.
  Of course, this wasn't a problem when only allocating 4 KB page
  frames, but it quickly became a problem when trying to malloc random
  kernel objects.

* The use of `tracing` in the buddy-block allocator is problematic when
  using it as the kernel's heap. When a `tracing` span or event is hit
  for the first time, it will register the callsite in the global
  callsite registry, which is a `Vec`. If there's not enough space in
  the callsite registry for the new callsite, it may reallocate. When
  the event that caused the reallocation is inside of malloc...well, you
  can imagine what happens next. In order to fix this, I've switched
  mycelium to use a Git dependency on `tracing` 0.2.x. In 0.2,
  `tracing-core`'s global callsite registry was replaced with an atomic
  linked list implemented in the callsite statics, so the global
  callsite registry no longer allocates. In fact, mycelium is now able
  to use `tracing` without any allocations.

I also added some code for dumping the current heap state to the serial
port when the kernel oopses. This should help to debug heap-related
panics.

## Future Work

This is *also* kind of an interim solution. In the long term, we
probably *don't* actually want to use the same buddy block allocator to
allocate both page frames and kernel heap objects. Allocating small
kernel heap objects at the same level as 4 KB (and 2 MB or 1 GB) page
frames can cause memory fragmentation over long runtimes, which is not
ideal.

Instead, we probably want to use a tiered allocation scheme, where the
heap requests an entire physical page from the page allocator, and
performs allocations within that page. When all of the currently
allocated pages are full, the kernel heap would request more pages from
the page allocator. When all the allocations on a given page are
deallocated, that page might be released back to the page allocator, so
that it can then be allocated as a page frame _or_ as a new kernel heap
page.

However, this is more complex than just using one allocator for
everything, and I wanted to get to the point where we could reasonably
use malloc in the kernel. In follow-up changes, I intend to implement a
new slab allocator for heap objects that requests pages from the page
allocator.

Another advantage of a tiered approach is that pages given to the kernel
heap allocator can be mapped to arbitrary addresses in the virtual
address space. This would allow us to say things like, "the kernel heap
starts at `0xFFFF_FFFF_0000_0000`" or something, so that heap pointers can
be immediately identified by their addresses. But, the approach in this
branch at least lets us malloc things, so I'm calling that a significant
improvement.