### PR TITLE
chore: update to nightly-2021-12-31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -54,9 +45,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "az"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6dff4a1892b54d70af377bf7a17064192e822865791d812957f21e3108c325"
+checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
 
 [[package]]
 name = "backtrace"
@@ -96,9 +87,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bootloader"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ee1938693d0a8a0b8398328d5632254e84ef42c095ef0b585fd903a8e19d20"
+checksum = "139ac6df0135b3beae225d7b8fb970c188941b5cad088f2e2f93463286281750"
 
 [[package]]
 name = "bootloader-locator"
@@ -129,11 +120,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -310,7 +301,7 @@ dependencies = [
  "structopt",
  "tracing 0.1.29",
  "tracing-error 0.2.0",
- "tracing-subscriber 0.3.1",
+ "tracing-subscriber 0.3.5",
  "wait-timeout",
 ]
 
@@ -334,9 +325,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.107"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libm"
@@ -509,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "owo-colors"
@@ -533,15 +524,15 @@ checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -569,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -610,9 +601,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -722,9 +713,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "rusty-fork"
@@ -791,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -847,7 +838,7 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+source = "git+https://github.com/tokio-rs/tracing#84bbbea2726d2ba5ea84eb4aad4666ab1439832c"
 dependencies = [
  "cfg-if",
  "log",
@@ -870,7 +861,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+source = "git+https://github.com/tokio-rs/tracing#84bbbea2726d2ba5ea84eb4aad4666ab1439832c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -889,7 +880,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+source = "git+https://github.com/tokio-rs/tracing#84bbbea2726d2ba5ea84eb4aad4666ab1439832c"
 dependencies = [
  "lazy_static",
 ]
@@ -911,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing 0.1.29",
- "tracing-subscriber 0.3.1",
+ "tracing-subscriber 0.3.5",
 ]
 
 [[package]]
@@ -928,7 +919,7 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+source = "git+https://github.com/tokio-rs/tracing#84bbbea2726d2ba5ea84eb4aad4666ab1439832c"
 dependencies = [
  "lazy_static",
  "log",
@@ -949,9 +940,9 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.0"
-source = "git+https://github.com/tokio-rs/tracing#2d3a60763dfab6ad88b96cc84baf3ec93d9c2ed6"
+source = "git+https://github.com/tokio-rs/tracing#84bbbea2726d2ba5ea84eb4aad4666ab1439832c"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -961,11 +952,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
+checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "lazy_static",
  "matchers",
  "regex",
@@ -1003,9 +994,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -1096,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "yaxpeax-x86"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112bc187570a8d998084e0594071a07db0d04977a073ae04ce488fe46ad45951"
+checksum = "4af6a58c702d3941e8712d3a49eae86a8c15553129e75212f828bf6cc9485f34"
 dependencies = [
  "num-traits",
  "yaxpeax-arch",

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -23,6 +23,7 @@ pub trait Address:
     /// # Panics
     ///
     /// - If `align` is not a power of two.
+    #[must_use]
     fn align_up<A: Into<usize>>(self, align: A) -> Self {
         let align = align.into();
         assert!(align.is_power_of_two());
@@ -45,6 +46,7 @@ pub trait Address:
     /// # }
     /// ````
     #[inline]
+    #[must_use]
     fn align_up_for<T>(self) -> Self {
         self.align_up(core::mem::align_of::<T>())
     }
@@ -56,6 +58,7 @@ pub trait Address:
     /// # Panics
     ///
     /// - If `align` is not a power of two.
+    #[must_use]
     fn align_down<A: Into<usize>>(self, align: A) -> Self {
         let align = align.into();
         assert!(align.is_power_of_two());
@@ -73,6 +76,7 @@ pub trait Address:
     /// # }
     /// ````
     #[inline]
+    #[must_use]
     fn align_down_for<T>(self) -> Self {
         self.align_down(core::mem::align_of::<T>())
     }
@@ -80,6 +84,8 @@ pub trait Address:
     /// Offsets this address by `offset`.
     ///
     /// If the specified offset would overflow, this function saturates instead.
+
+    #[must_use]
     fn offset(self, offset: i32) -> Self {
         if offset > 0 {
             self + offset as usize
@@ -90,6 +96,7 @@ pub trait Address:
     }
 
     /// Returns the difference between `self` and `other`.
+    #[must_use]
     fn difference(self, other: Self) -> isize {
         if self > other {
             -(self.as_usize() as isize - other.as_usize() as isize)
@@ -102,6 +109,7 @@ pub trait Address:
     ///
     /// # Notes
     /// `align` must be a power of two. This is asserted in debug builds.
+    #[must_use]
     fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
         let align = align.into();
         debug_assert!(
@@ -115,6 +123,7 @@ pub trait Address:
     /// Returns `true` if `self` is aligned on the alignment of the specified
     /// type.
     #[inline]
+    #[must_use]
     fn is_aligned_for<T>(self) -> bool {
         self.is_aligned(core::mem::align_of::<T>())
     }
@@ -123,6 +132,7 @@ pub trait Address:
     ///
     /// - If `self` is not aligned for a `T`-typed value.
     #[track_caller]
+    #[must_use]
     fn as_ptr<T>(self) -> *mut T {
         // Some architectures permit unaligned reads, but Rust considers
         // dereferencing a pointer that isn't type-aligned to be UB.
@@ -261,6 +271,7 @@ macro_rules! impl_addrs {
                 /// * If debug assertions are enabled and the address is not
                 ///   valid for the target architecture.
                 #[cfg(target_pointer_width = "64")]
+                #[must_use]
                 pub fn from_u64(u: u64) -> Self {
                     Self::from_usize(u as usize)
                 }
@@ -270,6 +281,7 @@ macro_rules! impl_addrs {
                 /// * If debug assertions are enabled and the address is not
                 ///   valid for the target architecture.
                 #[cfg(target_pointer_width = "u32")]
+                #[must_use]
                 pub fn from_u32(u: u32) -> Self {
                     Self::from_usize(u as usize)
                 }
@@ -284,6 +296,7 @@ macro_rules! impl_addrs {
                 /// * If debug assertions are enabled and the aligned address is
                 ///   not valid for the target architecture.
                 #[inline]
+                #[must_use]
                 pub fn align_up<A: Into<usize>>(self, align: A) -> Self {
                     Address::align_up(self, align)
                 }
@@ -298,6 +311,7 @@ macro_rules! impl_addrs {
                 /// * If debug assertions are enabled and the aligned address is
                 ///   not valid for the target architecture.
                 #[inline]
+                #[must_use]
                 pub fn align_down<A: Into<usize>>(self, align: A) -> Self {
                     Address::align_down(self, align)
                 }
@@ -306,18 +320,21 @@ macro_rules! impl_addrs {
                 ///
                 /// If the specified offset would overflow, this function saturates instead.
                 #[inline]
+                #[must_use]
                 pub fn offset(self, offset: i32) -> Self {
                     Address::offset(self, offset)
                 }
 
                 /// Returns the difference between `self` and `other`.
                 #[inline]
+                #[must_use]
                 pub fn difference(self, other: Self) -> isize {
                     Address::difference(self, other)
                 }
 
                 /// Returns `true` if `self` is aligned on the specified alignment.
                 #[inline]
+                #[must_use]
                 pub fn is_aligned<A: Into<usize>>(self, align: A) -> bool {
                     Address::is_aligned(self, align)
                 }
@@ -325,6 +342,7 @@ macro_rules! impl_addrs {
                 /// Returns `true` if `self` is aligned on the alignment of the specified
                 /// type.
                 #[inline]
+                #[must_use]
                 pub fn is_aligned_for<T>(self) -> bool {
                     Address::is_aligned_for::<T>(self)
                 }
@@ -333,6 +351,7 @@ macro_rules! impl_addrs {
                 ///
                 /// - If `self` is not aligned for a `T`-typed value.
                 #[inline]
+                #[must_use]
                 pub fn as_ptr<T>(self) -> *mut T {
                     Address::as_ptr(self)
                 }

--- a/hal-x86_64/src/control_regs.rs
+++ b/hal-x86_64/src/control_regs.rs
@@ -1,5 +1,6 @@
 pub mod cr3 {
     use crate::{mm::size::Size4Kb, PAddr};
+    use core::arch::asm;
     use hal_core::{mem::page::Page, Address};
 
     #[derive(Copy, Clone, Eq, PartialEq)]

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-use core::mem;
+use core::{arch::asm, fmt, mem};
 
 pub mod intrinsics;
 

--- a/hal-x86_64/src/cpu/intrinsics.rs
+++ b/hal-x86_64/src/cpu/intrinsics.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 /// Perform one x86 `hlt` instruction.
 ///
 /// # Safety

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -1,7 +1,7 @@
 pub mod idt;
 pub mod pic;
 use crate::{segment, VAddr};
-use core::{fmt, marker::PhantomData};
+use core::{arch::asm, fmt, marker::PhantomData};
 pub use idt::Idt;
 pub use pic::CascadedPic;
 

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -1,5 +1,5 @@
 use crate::{cpu, segment};
-use core::fmt;
+use core::{arch::asm, fmt};
 use mycelium_util::bits;
 
 #[repr(C)]

--- a/hal-x86_64/src/mm.rs
+++ b/hal-x86_64/src/mm.rs
@@ -894,7 +894,7 @@ pub(crate) mod tlb {
     // supporting 80386s from 1985?
     pub(crate) unsafe fn flush_page(addr: VAddr) {
         tracing::trace!(?addr, "flush_page");
-        asm!("invlpg [{0}]", in(reg) addr.as_usize() as u64);
+        core::arch::asm!("invlpg [{0}]", in(reg) addr.as_usize() as u64);
     }
 }
 

--- a/hal-x86_64/src/segment.rs
+++ b/hal-x86_64/src/segment.rs
@@ -1,5 +1,5 @@
 use crate::cpu;
-use core::fmt;
+use core::{arch::asm, fmt};
 use mycelium_util::bits::Pack16;
 
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-11-12"
+channel = "nightly-2021-12-31"
 components = [
     "clippy",
     "rustfmt",

--- a/util/src/fmt.rs
+++ b/util/src/fmt.rs
@@ -165,6 +165,7 @@ impl<W> WriteExt for W where W: Write {}
 // === impl FmtOption ===
 
 impl<'a, T> FmtOption<'a, T> {
+    #[must_use]
     pub fn new(opt: &'a Option<T>) -> Self {
         Self {
             opt: opt.as_ref(),
@@ -172,6 +173,7 @@ impl<'a, T> FmtOption<'a, T> {
         }
     }
 
+    #[must_use]
     pub fn or_else(self, or_else: &'a str) -> Self {
         Self { or_else, ..self }
     }

--- a/util/src/math.rs
+++ b/util/src/math.rs
@@ -1,5 +1,6 @@
 pub trait Log2 {
     /// Returns `ceiling(log2(self))`.
+    #[must_use]
     fn log2_ceil(self) -> Self;
 }
 


### PR DESCRIPTION
This branch updates mycelium to build with the latest nightly, Rust
2021-12-31. This was a pretty easy upgrade. I made the following
changes:

- import the `asm!` macro from `core::arch::asm`, which is where it
  lives now
- stick a bunch of `must_use` attributes on basically every function
  that returns a `Self` and doesn't mutate the receiver (clippy whines
  about this now)
- update dependencies