### PR TITLE
chore(nix): switch `qemu-full` to `qemu`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let env = (import ./default.nix scope);
 
 in pkgs.mkShell {
   # also install qemu into the dev shell, for testing
-  packages = with pkgs; [ qemu_full gdb direnv ];
+  packages = with pkgs; [ qemu gdb direnv ];
 
   LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
Apparently, the only difference between `qemu-full` and `qemu` is that
"full" enables ceph, smbd, and glusterfs support (see
https://twitter.com/witchof0x20/status/1477412443777294344?s=20). We
don't need any of that stuff; I had added `qemu-full` to the dev
nix-shell environment because I foolishly assumed "full" meant "all
architectures" or something.

This commit switches our `shell.nix` to just depend on `qemu` instead,
so we don't pull in all this other stuff we don't need.