### PR TITLE
chore: bump nightly to 2022-02-15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 [[package]]
 name = "wasmi"
 version = "0.9.0"
-source = "git+https://github.com/mystor/wasmi?branch=mycelium-v0.9.0#4a97fd6005bf6f10c753178f69cd60290f485973"
+source = "git+https://github.com/hawkw/wasmi?branch=mycelium-v0.9.0#5caff845d5dbfdbdb82c624f470c55c71bfbe453"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "wasmi-validation"
 version = "0.4.0"
-source = "git+https://github.com/mystor/wasmi?branch=mycelium-v0.9.0#4a97fd6005bf6f10c753178f69cd60290f485973"
+source = "git+https://github.com/hawkw/wasmi?branch=mycelium-v0.9.0#5caff845d5dbfdbdb82c624f470c55c71bfbe453"
 dependencies = [
  "parity-wasm",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bootloader"
-version = "0.10.9"
+version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ee1938693d0a8a0b8398328d5632254e84ef42c095ef0b585fd903a8e19d20"
+checksum = "f2d9b14b92a825ecc3b24e4c163a578af473fbba5f190bfaf48092b29b604504"
 
 [[package]]
 name = "bootloader-locator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["attributes", "alloc"]
 git = "https://github.com/tokio-rs/tracing"
 
 [dependencies.wasmi]
-git = "https://github.com/mystor/wasmi"
+git = "https://github.com/hawkw/wasmi"
 branch = "mycelium-v0.9.0"
 default-features = false
 features = ["core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rlibc = "1.0"
 # NOTE FOR FUTURE ELIZAS WHO ARE MESSING WITH THIS: the bootloader crate's build
 # script is not that good, and breaks if you put this in `cfg(...).dependencies`
 # instead of normal [dependencies]. don't move this.
-bootloader = { version = "0.10.6" }
+bootloader = { version = "0.10.12" }
 embedded-graphics = "0.7"
 
 [dev-dependencies]

--- a/hal-x86_64/src/control_regs.rs
+++ b/hal-x86_64/src/control_regs.rs
@@ -1,5 +1,6 @@
 pub mod cr3 {
     use crate::{mm::size::Size4Kb, PAddr};
+    use core::arch::asm;
     use hal_core::{mem::page::Page, Address};
 
     #[derive(Copy, Clone, Eq, PartialEq)]

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-use core::mem;
+use core::{arch::asm, fmt, mem};
 
 pub mod intrinsics;
 

--- a/hal-x86_64/src/cpu/intrinsics.rs
+++ b/hal-x86_64/src/cpu/intrinsics.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 /// Perform one x86 `hlt` instruction.
 ///
 /// # Safety

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -1,7 +1,7 @@
 pub mod idt;
 pub mod pic;
 use crate::{segment, VAddr};
-use core::{fmt, marker::PhantomData};
+use core::{arch::asm, fmt, marker::PhantomData};
 pub use idt::Idt;
 pub use pic::CascadedPic;
 

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -1,5 +1,5 @@
 use crate::{cpu, segment};
-use core::fmt;
+use core::{arch::asm, fmt};
 use mycelium_util::bits;
 
 #[repr(C)]

--- a/hal-x86_64/src/lib.rs
+++ b/hal-x86_64/src/lib.rs
@@ -1,6 +1,5 @@
 //! Implementation of the Mycelium HAL for 64-bit x86 platforms.
 #![cfg_attr(not(test), no_std)]
-#![feature(asm)]
 // Allow const operands in asm.
 #![feature(asm_const)]
 #![feature(abi_x86_interrupt)]

--- a/hal-x86_64/src/mm.rs
+++ b/hal-x86_64/src/mm.rs
@@ -881,6 +881,7 @@ pub mod level {
 pub(crate) mod tlb {
     use crate::control_regs::cr3;
     use crate::VAddr;
+    use core::arch::asm;
     use hal_core::Address;
 
     #[allow(dead_code)] // we'll need this later

--- a/hal-x86_64/src/segment.rs
+++ b/hal-x86_64/src/segment.rs
@@ -1,5 +1,5 @@
 use crate::cpu;
-use core::fmt;
+use core::{arch::asm, fmt};
 use mycelium_util::bits::Pack16;
 
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,9 @@
 [toolchain]
-channel = "nightly-2022-03-03"
+channel = "nightly-2022-02-15"
 components = [
     "clippy",
     "rustfmt",
     "rust-src",
     "llvm-tools-preview",
 ]
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,8 @@
 [toolchain]
-channel = "nightly-2021-11-12"
+channel = "nightly-2022-03-03"
 components = [
     "clippy",
     "rustfmt",
     "rust-src",
     "llvm-tools-preview",
 ]
-profile = "minimal"


### PR DESCRIPTION
This branch updates Mycelium to build on Rust nightly 2022-02-15. This
appears to be the latest nightly that currently builds Mycelium; later
nightlies appear to introduce some weird issue where `rust-lld` attempts
to link with `libstdc++.so` and everything blows up. I don't super want
to figure that out right now.

In addition, this PR makes the following changes:

+ Update the use of the `asm!` macro to import it from `core::arch`,
  which is now required.
+ Update the `wasmi` dep's use of the `asm!` macro to `core::arch::asm!`
  (hawkw/wasmi@5caff845d5dbfdbdb82c624f470c55c71bfbe453)
+ Update the `bootloader` crate to v0.10.12, to ensure that it uses the
  `asm!` macro correctly

Closes #132