### PR TITLE
fix(cordyceps): add miri tests, fix stacked borrows

### DIFF
--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -6,12 +6,14 @@
 #
 # Note that if other crates add loom tests in the future, they will need to be
 # added to this workflow!
-name: Loom (cordyceps)
+name: cordyceps
 
 on:
   push:
     paths:
-      - 'cordyceps/**'
+      - 'cordyceps/**.rs'
+      - 'cordyceps/Cargo.toml'
+      - .github/workflows/cordyceps.yml
 
 env:
   # disable incremental compilation.
@@ -33,15 +35,12 @@ env:
   RUSTUP_MAX_RETRIES: 10
   # don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
-  LOOM_MAX_PREEMPTIONS: 2
-  LOOM_LOG: loom=trace
-  RUSTFLAGS: "--cfg loom"
 
 jobs:
   # run loom tests
   tests:
     runs-on: ubuntu-latest
-    name: Loom tests (mycelium-util)
+    name: Loom tests (cordyceps)
     steps:
     - name: install rust toolchain
       run: rustup show
@@ -51,3 +50,16 @@ jobs:
       with:
         command: test
         args: --profile loom --lib -p cordyceps
+        env:
+          LOOM_MAX_PREEMPTIONS: 2
+          LOOM_LOG: loom=trace
+          RUSTFLAGS: "--cfg loom"
+
+  miri:
+    runs-on: ubuntu-latest
+    name: Miri tests (codyceps)
+    - name: install rust toolchain
+      run: rustup show
+    - uses: actions/checkout@v2
+    - name: run miri tests
+      run: ./bin/miri

--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -62,4 +62,4 @@ jobs:
       run: rustup show
     - uses: actions/checkout@v2
     - name: run miri tests
-      run: ./bin/miri
+      run: ./bin/miri -p cordyceps

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -769,8 +769,8 @@ unsafe impl Linked<list::Links<Self>> for Free {
     type Handle = ptr::NonNull<Free>;
 
     #[inline]
-    fn as_ptr(r: &Self::Handle) -> ptr::NonNull<Self> {
-        *r
+    fn as_ptr(r: Self::Handle) -> ptr::NonNull<Self> {
+        r
     }
 
     #[inline]

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -769,8 +769,8 @@ unsafe impl Linked<list::Links<Self>> for Free {
     type Handle = ptr::NonNull<Free>;
 
     #[inline]
-    fn into_ptr(r: Self::Handle) -> ptr::NonNull<Self> {
-        r
+    fn as_ptr(r: &Self::Handle) -> ptr::NonNull<Self> {
+        *r
     }
 
     #[inline]

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -769,8 +769,8 @@ unsafe impl Linked<list::Links<Self>> for Free {
     type Handle = ptr::NonNull<Free>;
 
     #[inline]
-    fn as_ptr(r: &Self::Handle) -> ptr::NonNull<Self> {
-        *r
+    fn into_ptr(r: Self::Handle) -> ptr::NonNull<Self> {
+        r
     }
 
     #[inline]

--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -769,7 +769,7 @@ unsafe impl Linked<list::Links<Self>> for Free {
     type Handle = ptr::NonNull<Free>;
 
     #[inline]
-    fn as_ptr(r: Self::Handle) -> ptr::NonNull<Self> {
+    fn into_ptr(r: Self::Handle) -> ptr::NonNull<Self> {
         r
     }
 

--- a/bin/miri
+++ b/bin/miri
@@ -7,4 +7,5 @@ set -x
 cd "$(dirname "$0")"/..
 
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers ${MIRIFLAGS:-}" \
+    PROPTEST_CASES="${PROPTEST_CASES:-10}" \
     cargo miri test --lib --workspace "${@}"

--- a/bin/miri
+++ b/bin/miri
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Runs `miri` tests
+set -euo pipefail
+set -x
+
+cd "$(dirname "$0")"/..
+
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers ${MIRIFLAGS:-}" \
+    cargo miri test --lib --workspace "${@}"

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -36,8 +36,8 @@ pub unsafe trait Linked<L> {
     /// The handle owning nodes in the linked list.
     type Handle;
 
-    /// Convert a `Handle` to a raw pointer.
-    fn into_ptr(r: Self::Handle) -> NonNull<Self>;
+    /// Convert a `Handle` to a raw pointer, without taking ownership of it.
+    fn as_ptr(r: &Self::Handle) -> NonNull<Self>;
 
     /// Convert a raw pointer to a `Handle`.
     ///

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -37,7 +37,7 @@ pub unsafe trait Linked<L> {
     type Handle;
 
     /// Convert a `Handle` to a raw pointer.
-    fn as_ptr(r: Self::Handle) -> NonNull<Self>;
+    fn into_ptr(r: Self::Handle) -> NonNull<Self>;
 
     /// Convert a raw pointer to a `Handle`.
     ///

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -36,10 +36,10 @@ pub unsafe trait Linked<L> {
     /// The handle owning nodes in the linked list.
     type Handle;
 
-    /// Convert a `Handle` to a raw pointer, without taking ownership of it.
-    fn as_ptr(r: &Self::Handle) -> NonNull<Self>;
+    /// Convert a `Handle` to a raw pointer, taking ownership of it in the process.
+    fn into_ptr(r: Self::Handle) -> NonNull<Self>;
 
-    /// Convert a raw pointer to a `Handle`.
+    /// Convert a raw pointer to an owning `Handle`.
     ///
     /// # Safety
     ///

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -36,9 +36,8 @@ pub unsafe trait Linked<L> {
     /// The handle owning nodes in the linked list.
     type Handle;
 
-    /// Convert a `Handle` to a raw pointer, without consuming it.
-    #[allow(clippy::wrong_self_convention)]
-    fn as_ptr(r: &Self::Handle) -> NonNull<Self>;
+    /// Convert a `Handle` to a raw pointer.
+    fn as_ptr(r: Self::Handle) -> NonNull<Self>;
 
     /// Convert a raw pointer to a `Handle`.
     ///

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -369,6 +369,7 @@ mod tests {
     use std::pin::Pin;
 
     #[derive(Debug)]
+    #[repr(C)]
     struct Entry<'a> {
         links: Links<Entry<'a>>,
         val: i32,
@@ -395,8 +396,10 @@ mod tests {
             Pin::new_unchecked(&*ptr.as_ptr())
         }
 
-        unsafe fn links(mut target: NonNull<Entry<'a>>) -> NonNull<Links<Entry<'a>>> {
-            NonNull::from(&mut target.as_mut().links)
+        unsafe fn links(target: NonNull<Entry<'a>>) -> NonNull<Links<Entry<'a>>> {
+            // Safety: this is safe because the `links` are the first field of
+            // `Entry`, and `Entry` is `repr(C)`.
+            target.cast()
         }
     }
 

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -3,7 +3,6 @@ use crate::util::FmtOption;
 use core::{
     fmt,
     marker::PhantomPinned,
-    mem::ManuallyDrop,
     ptr::{self, NonNull},
 };
 
@@ -102,7 +101,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
 
     /// Appends an item to the head of the list.
     pub fn push_front(&mut self, item: T::Handle) {
-        let ptr = T::as_ptr(item);
+        let ptr = T::into_ptr(item);
         // tracing::trace!(?self, ?ptr, "push_front");
         assert_ne!(self.head, Some(ptr));
         unsafe {
@@ -377,7 +376,7 @@ mod tests {
     unsafe impl<'a> Linked<Links<Self>> for Entry<'a> {
         type Handle = Pin<&'a Entry<'a>>;
 
-        fn as_ptr(handle: Pin<&'a Entry>) -> NonNull<Entry<'a>> {
+        fn into_ptr(handle: Pin<&'a Entry>) -> NonNull<Entry<'a>> {
             NonNull::from(handle.get_ref())
         }
 

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -102,8 +102,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
 
     /// Appends an item to the head of the list.
     pub fn push_front(&mut self, item: T::Handle) {
-        let item = ManuallyDrop::new(item);
-        let ptr = T::as_ptr(&*item);
+        let ptr = T::as_ptr(item);
         // tracing::trace!(?self, ?ptr, "push_front");
         assert_ne!(self.head, Some(ptr));
         unsafe {
@@ -378,7 +377,7 @@ mod tests {
     unsafe impl<'a> Linked<Links<Self>> for Entry<'a> {
         type Handle = Pin<&'a Entry<'a>>;
 
-        fn as_ptr(handle: &Pin<&'a Entry>) -> NonNull<Entry<'a>> {
+        fn as_ptr(handle: Pin<&'a Entry>) -> NonNull<Entry<'a>> {
             NonNull::from(handle.get_ref())
         }
 

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -112,8 +112,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
 
     /// Appends an item to the head of the list.
     pub fn push_front(&mut self, item: T::Handle) {
-        let item = mem::ManuallyDrop::new(item);
-        let ptr = T::as_ptr(&item);
+        let ptr = T::into_ptr(item);
         // tracing::trace!(?self, ?ptr, "push_front");
         assert_ne!(self.head, Some(ptr));
         unsafe {
@@ -413,7 +412,7 @@ mod tests {
     unsafe impl<'a> Linked<Links<Self>> for Entry<'a> {
         type Handle = Pin<&'a Entry<'a>>;
 
-        fn as_ptr(handle: &Pin<&'a Entry<'a>>) -> NonNull<Entry<'a>> {
+        fn into_ptr(handle: Pin<&'a Entry<'a>>) -> NonNull<Entry<'a>> {
             NonNull::from(handle.get_ref())
         }
 

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -112,7 +112,8 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
 
     /// Appends an item to the head of the list.
     pub fn push_front(&mut self, item: T::Handle) {
-        let ptr = T::into_ptr(item);
+        let item = mem::ManuallyDrop::new(item);
+        let ptr = T::as_ptr(&item);
         // tracing::trace!(?self, ?ptr, "push_front");
         assert_ne!(self.head, Some(ptr));
         unsafe {
@@ -412,8 +413,8 @@ mod tests {
     unsafe impl<'a> Linked<Links<Self>> for Entry<'a> {
         type Handle = Pin<&'a Entry<'a>>;
 
-        fn into_ptr(handle: Pin<&'a Entry<'a>>) -> NonNull<Entry<'a>> {
-            unsafe { NonNull::from(Pin::into_inner_unchecked(handle)) }
+        fn as_ptr(handle: &Pin<&'a Entry<'a>>) -> NonNull<Entry<'a>> {
+            NonNull::from(handle.get_ref())
         }
 
         unsafe fn from_ptr(ptr: NonNull<Entry<'a>>) -> Pin<&'a Entry<'a>> {

--- a/cordyceps/src/mpsc_queue.rs
+++ b/cordyceps/src/mpsc_queue.rs
@@ -378,7 +378,7 @@ impl<T: Linked<Links<T>>> Drop for MpscQueue<T> {
                 // Skip dropping the stub node; it is owned by the queue and
                 // will be dropped when the queue is dropped. If we dropped it
                 // here, that would cause a double free!
-                if node != {
+                if node != self.stub {
                     // Convert the pointer to the owning handle and drop it.
                     debug_assert!(!links.is_stub());
                     drop(T::from_ptr(node));

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,5 +5,6 @@ components = [
     "rustfmt",
     "rust-src",
     "llvm-tools-preview",
+    "miri"
 ]
 profile = "minimal"


### PR DESCRIPTION
this branch adds a configuration for running Miri tests. currently, this
is primarily useful for testing `cordyceps` and friends, as the kernel
and HAL code contains a bunch of bare-metal stuff Miri definitely won't
understand.

after running Miri tests, i've fixed a number of stacked borrows
violations in the cordyceps linked list and MPSC queue modules. in
particular, i've changed the `Linked` trait a bit --- `Linked::as_ptr`
is now `Linked::into_ptr` and takes ownership of a `Handle`. this way,
we'll never produce an owning `Handle` (such as a `Box`) from a raw
pointer that originated from a shared reference (such as a
`&Pin<Box<...>>`). shared refs can still be used when the _handle type
itself_ is a shared ref. miri is now happy with us.