### PR TITLE
refac(x86_64): use `volatile` crate for MMIO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "mycelium-trace",
  "mycelium-util",
  "tracing 0.2.0",
+ "volatile",
 ]
 
 [[package]]
@@ -1022,6 +1023,11 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "volatile"
+version = "0.4.4"
+source = "git+https://github.com/hawkw/volatile?branch=eliza/update-features#9894588aa7158e5d2267cd8aa37e42a2e341811c"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,13 @@ memcpy = true
 sysroot_path = "target/x86_64/sysroot"
 
 [patch.crates-io]
+# use `tracing` 0.2 from git
 tracing = { git = "https://github.com/tokio-rs/tracing" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing" }
+# temporary patch to use my branch of `volatile` until PR
+# https://github.com/rust-osdev/volatile/pull/25 merges upstream. this is
+# necessary to build with unstable features on recent nightlies.
+volatile = { git = "https://github.com/hawkw/volatile", branch = "eliza/update-features" }
 
 # Custom profile for Loom tests: enable release optimizations so that the loom
 # tests are less slow, but don't disable debug assertions.

--- a/hal-x86_64/Cargo.toml
+++ b/hal-x86_64/Cargo.toml
@@ -12,3 +12,4 @@ hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
 mycelium-trace = { path = "../trace" }
 tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes"] }
+volatile = { version = "0.4.4", features = ["unstable"] }

--- a/src/arch/x86_64/framebuf.rs
+++ b/src/arch/x86_64/framebuf.rs
@@ -1,0 +1,98 @@
+use bootloader::boot_info::{self, BootInfo};
+use core::{
+    mem,
+    ops::{Deref, DerefMut},
+};
+use hal_x86_64::framebuffer::{self, Framebuffer};
+use mycelium_util::sync::{spin, InitOnce};
+
+#[derive(Debug)]
+pub struct FramebufGuard(spin::MutexGuard<'static, boot_info::FrameBuffer>);
+pub type FramebufWriter = Framebuffer<'static, FramebufGuard>;
+
+/// Locks the framebuffer and returns a [`FramebufWriter`].
+///
+/// # Safety
+///
+/// In release mode, this function *assumes* the frame buffer has been
+/// initialized by [`init`]. If this is ever called before [`init`] has been
+/// called and returned `true`, this may read uninitialized memory!
+pub(super) unsafe fn mk_framebuf() -> FramebufWriter {
+    let (cfg, buf) = unsafe {
+        // Safety: we can reasonably assume this will only be called
+        // after `arch_entry`, so if we've failed to initialize the
+        // framebuffer...things have gone horribly wrong...
+        FRAMEBUFFER.get_unchecked()
+    };
+    Framebuffer::new(cfg, FramebufGuard(buf.lock()))
+}
+
+/// Forcibly unlock the framebuffer mutex.
+///
+/// # Safety
+///
+/// This forcibly unlocks a potentially-locked mutex, violating mutual
+/// exclusion! This should only be called in conditions where no other CPU core
+/// will *ever* attempt to access the framebuffer again (such as while oopsing).
+pub(super) unsafe fn force_unlock() {
+    if let Some((_, fb)) = FRAMEBUFFER.try_get() {
+        fb.force_unlock();
+    }
+}
+
+/// Try to initialize the framebuffer based on the provided [`BootInfo`].
+///
+/// Returns `true` if the framebuffer is available, or `false` if there is no
+/// framebuffer enabled.
+///
+/// If the framebuffer has already been initialized, this does nothing.
+pub(super) fn init(bootinfo: &mut BootInfo) -> bool {
+    use boot_info::Optional;
+    // Has the framebuffer already been initialized?
+    if FRAMEBUFFER.try_get().is_some() {
+        return true;
+    }
+
+    // Okay, try to initialize the framebuffer
+    let framebuffer = match mem::replace(&mut bootinfo.framebuffer, Optional::None) {
+        Optional::Some(framebuffer) => framebuffer,
+        // The boot info does not contain a framebuffer configuration. Nothing
+        // for us to do!
+        Optional::None => return false,
+    };
+
+    let info = framebuffer.info();
+    let cfg = framebuffer::Config {
+        height: info.vertical_resolution,
+        width: info.horizontal_resolution,
+        px_bytes: info.bytes_per_pixel,
+        line_len: info.stride,
+        px_kind: match info.pixel_format {
+            boot_info::PixelFormat::RGB => framebuffer::PixelKind::Rgb,
+            boot_info::PixelFormat::BGR => framebuffer::PixelKind::Bgr,
+            boot_info::PixelFormat::U8 => framebuffer::PixelKind::Gray,
+            x => unimplemented!("hahaha wtf, found a weird pixel format: {:?}", x),
+        },
+    };
+    FRAMEBUFFER.init((cfg, spin::Mutex::new(framebuffer)));
+    true
+}
+
+static FRAMEBUFFER: InitOnce<(framebuffer::Config, spin::Mutex<boot_info::FrameBuffer>)> =
+    InitOnce::uninitialized();
+
+impl Deref for FramebufGuard {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.0.buffer()
+    }
+}
+
+impl DerefMut for FramebufGuard {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.buffer_mut()
+    }
+}


### PR DESCRIPTION
This commit changes the x86_64 kernel to use the `volatile` crate's
`Volatile` cell for the VGA buffer and framebuffer, rather than explicitly
 using `ptr::write_volatile` and friends. This ensures all writes to the
these MMIO regions are volatile --- we can no longer accidentally
forget to use volatile reads/writes when accessing them.