### PR TITLE
chore(ci): fix missing `steps` key for cordyceps

### DIFF
--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -58,6 +58,7 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     name: Miri tests (codyceps)
+    steps:
     - name: install rust toolchain
       run: rustup show
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes CI.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>