### PR TITLE
chore(ci): don't always pass `--workspace` to miri

### DIFF
--- a/bin/miri
+++ b/bin/miri
@@ -8,4 +8,4 @@ cd "$(dirname "$0")"/..
 
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers ${MIRIFLAGS:-}" \
     PROPTEST_CASES="${PROPTEST_CASES:-10}" \
-    cargo miri test --lib --workspace "${@}"
+    cargo miri test --lib "${@}"


### PR DESCRIPTION
This should let us only run miri tests for `cordyceps`, rather than other
random kernel code that we know miri won't like (since it does e.g.
MMIO).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>