### PR TITLE
feat: bring back the Red Screen of uwu

### DIFF
--- a/hal-core/src/framebuffer.rs
+++ b/hal-core/src/framebuffer.rs
@@ -57,7 +57,7 @@ pub trait Draw {
     /// implementation, and are thus encouraged to override this method.
     fn fill(&mut self, color: RgbColor) -> &mut Self {
         for y in 0..self.height() {
-            self.line_horiz(y, self.width(), color);
+            self.fill_row(y, color);
         }
         self
     }

--- a/hal-core/src/interrupt.rs
+++ b/hal-core/src/interrupt.rs
@@ -49,13 +49,9 @@ pub trait Handlers<R: fmt::Debug + fmt::Display> {
     where
         C: ctx::Context<Registers = R> + ctx::CodeFault;
 
-    #[inline(always)]
     fn double_fault<C>(cx: C)
     where
-        C: ctx::Context<Registers = R> + ctx::CodeFault,
-    {
-        Self::code_fault(cx)
-    }
+        C: ctx::Context<Registers = R>;
 
     fn timer_tick();
 

--- a/hal-core/src/interrupt/ctx.rs
+++ b/hal-core/src/interrupt/ctx.rs
@@ -16,7 +16,7 @@ pub trait Context {
 
 pub trait PageFault: Context {
     fn fault_vaddr(&self) -> VAddr;
-
+    fn debug_error_code(&self) -> &dyn fmt::Debug;
     // TODO(eliza): more
 }
 

--- a/hal-core/src/interrupt/ctx.rs
+++ b/hal-core/src/interrupt/ctx.rs
@@ -23,6 +23,7 @@ pub trait PageFault: Context {
 pub trait CodeFault: Context {
     fn is_user_mode(&self) -> bool;
     fn instruction_ptr(&self) -> VAddr;
+    fn fault_kind(&self) -> &'static str;
 }
 
 #[non_exhaustive]

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -30,7 +30,7 @@ pub struct Interrupt<T = ()> {
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
-pub struct PageFaultCode(u64);
+pub struct PageFaultCode(u32);
 
 #[repr(C)]
 pub struct Registers {
@@ -91,6 +91,10 @@ impl<'a, T> hal_core::interrupt::Context for Context<'a, T> {
 impl<'a> ctx::PageFault for Context<'a, PageFaultCode> {
     fn fault_vaddr(&self) -> crate::VAddr {
         unimplemented!("eliza")
+    }
+
+    fn debug_error_code(&self) -> &dyn fmt::Debug {
+        &self.code
     }
 }
 
@@ -228,6 +232,12 @@ impl fmt::Display for Registers {
 
 pub fn fire_test_interrupt() {
     unsafe { asm!("int {0}", const 69) }
+}
+
+impl fmt::Debug for PageFaultCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PageFaultCode({:#b})", self.0)
+    }
 }
 
 #[cfg(test)]

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -21,6 +21,7 @@ pub type ErrorCode = u64;
 #[derive(Debug)]
 pub struct CodeFault {
     kind: &'static str,
+    #[allow(dead_code)] // TODO(eliza): actually use this lol
     error_code: Option<u64>,
 }
 

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -18,6 +18,12 @@ pub struct Context<'a, T = ()> {
 
 pub type ErrorCode = u64;
 
+#[derive(Debug)]
+pub struct CodeFault {
+    kind: &'static str,
+    error_code: Option<u64>,
+}
+
 /// An interrupt service routine.
 pub type Isr<T> = extern "x86-interrupt" fn(&mut Context<T>);
 
@@ -98,13 +104,17 @@ impl<'a> ctx::PageFault for Context<'a, PageFaultCode> {
     }
 }
 
-impl<'a> ctx::CodeFault for Context<'a, ErrorCode> {
+impl<'a> ctx::CodeFault for Context<'a, CodeFault> {
     fn is_user_mode(&self) -> bool {
         false // TODO(eliza)
     }
 
     fn instruction_ptr(&self) -> crate::VAddr {
         self.registers.instruction_ptr
+    }
+
+    fn fault_kind(&self) -> &'static str {
+        self.code.kind
     }
 }
 
@@ -142,6 +152,36 @@ impl hal_core::interrupt::Control for Idt {
     where
         H: Handlers<Registers>,
     {
+        macro_rules! gen_code_faults {
+            ($self:ident, $h:ty, $($vector:path => fn $name:ident($($rest:tt)+),)+) => {
+                $(
+                    gen_code_faults! {@ $name($($rest)+); }
+                    $self.set_isr($vector, $name::<$h> as *const ());
+                )+
+            };
+            (@ $name:ident($kind:literal);) => {
+                extern "x86-interrupt" fn $name<H: Handlers<Registers>>(registers: &mut Registers) {
+                    let code = CodeFault {
+                        error_code: None,
+                        kind: $kind,
+                    };
+                    H::code_fault(Context { registers, code });
+                }
+            };
+            (@ $name:ident($kind:literal, code);) => {
+                extern "x86-interrupt" fn $name<H: Handlers<Registers>>(
+                    registers: &mut Registers,
+                    code: u64,
+                ) {
+                    let code = CodeFault {
+                        error_code: Some(code),
+                        kind: $kind,
+                    };
+                    H::code_fault(Context { registers, code });
+                }
+            };
+        }
+
         let span = tracing::debug_span!("Idt::register_handlers");
         let _enter = span.enter();
 
@@ -193,14 +233,29 @@ impl hal_core::interrupt::Control for Idt {
                 }
             }
             tracing::error!(code = ?&format_args!("{:x}", code), "lmao, a general protection fault is happening");
+            let code = CodeFault {
+                error_code: Some(code),
+                kind: "General Protection Fault (0xD)",
+            };
             H::code_fault(Context { registers, code });
+        }
+
+        gen_code_faults! {
+            self, H,
+            Self::DIVIDE_BY_ZERO => fn div_0_isr("Divide-By-Zero (0x0)"),
+            Self::OVERFLOW => fn overflow_isr("Overflow (0x4)"),
+            Self::BOUND_RANGE_EXCEEDED => fn br_isr("Bound Range Exceeded (0x5)"),
+            Self::INVALID_OPCODE => fn ud_isr("Invalid Opcode (0x6)"),
+            Self::DEVICE_NOT_AVAILABLE => fn no_fpu_isr("Device (FPU) Not Available (0x7)"),
+            Self::ALIGNMENT_CHECK => fn alignment_check_isr("Alignment Check (0x11)", code),
+            Self::SIMD_FLOATING_POINT => fn simd_fp_exn_isr("SIMD Floating-Point Exception (0x13)"),
+            Self::X87_FPU_EXCEPTION => fn x87_exn_isr("x87 Floating-Point Exception (0x10)"),
         }
 
         self.set_isr(0x20, timer_isr::<H> as *const ());
         self.set_isr(0x21, keyboard_isr::<H> as *const ());
         self.set_isr(69, test_isr::<H> as *const ());
         self.set_isr(Self::PAGE_FAULT, page_fault_isr::<H> as *const ());
-
         self.set_isr(Self::GENERAL_PROTECTION_FAULT, gpf_isr::<H> as *const ());
         self.set_isr(Self::DOUBLE_FAULT, double_fault_isr::<H> as *const ());
         Ok(())

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -99,7 +99,7 @@ impl Idt {
 
     pub const PAGE_FAULT: usize = 14;
 
-    pub const X87_FPU_EXCEPTION_PENDING: usize = 16;
+    pub const X87_FPU_EXCEPTION: usize = 16;
 
     pub const ALIGNMENT_CHECK: usize = 17;
 

--- a/hal-x86_64/src/segment.rs
+++ b/hal-x86_64/src/segment.rs
@@ -72,6 +72,10 @@ impl Selector {
         Self::INDEX.pack_into(index, &mut self.0);
         self
     }
+
+    pub fn bits(&self) -> u16 {
+        self.0
+    }
 }
 
 impl fmt::Debug for Selector {

--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -1,4 +1,4 @@
-use core::{fmt, ptr};
+use core::fmt;
 use mycelium_util::{
     io,
     sync::{spin, Lazy},
@@ -75,15 +75,6 @@ impl ColorSpec {
     pub const fn new(fg: Color, bg: Color) -> Self {
         let bg = (bg as u8) << 4;
         Self(bg | (fg as u8))
-    }
-}
-
-impl Character {
-    fn write(&mut self, ch: Character) {
-        unsafe {
-            // safety: we have mutable access to this character.
-            ptr::write_volatile(self as *mut Character, ch)
-        }
     }
 }
 

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,11 +1,9 @@
 use bootloader::boot_info;
 use core::sync::atomic::{AtomicUsize, Ordering};
-#[cfg(test)]
-use core::{ptr, sync::atomic::AtomicPtr};
 use hal_core::{boot::BootInfo, mem, PAddr, VAddr};
 use hal_x86_64::{cpu, interrupt::Registers as X64Registers, serial, vga};
 pub use hal_x86_64::{interrupt, mm, NAME};
-use mycelium_util::{fmt, sync::InitOnce};
+use mycelium_util::sync::InitOnce;
 
 mod framebuf;
 use self::framebuf::FramebufWriter;

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -153,13 +153,16 @@ impl hal_core::interrupt::Handlers<X64Registers> for InterruptHandlers {
         C: hal_core::interrupt::Context<Registers = X64Registers>
             + hal_core::interrupt::ctx::CodeFault,
     {
-        oops(Oops::fault(&cx, "CODE FAULT"));
+        oops(Oops::fault_with_details(
+            &cx,
+            "CODE FAULT",
+            &cx.fault_kind(),
+        ));
     }
 
     fn double_fault<C>(cx: C)
     where
-        C: hal_core::interrupt::Context<Registers = X64Registers>
-            + hal_core::interrupt::ctx::CodeFault,
+        C: hal_core::interrupt::Context<Registers = X64Registers>,
     {
         oops(Oops::fault(&cx, "DOUBLE FAULT"))
     }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -2,7 +2,7 @@ use bootloader::boot_info;
 use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(test)]
 use core::{ptr, sync::atomic::AtomicPtr};
-use hal_core::{boot::BootInfo, mem, Address, PAddr, VAddr};
+use hal_core::{boot::BootInfo, mem, PAddr, VAddr};
 use hal_x86_64::{cpu, interrupt::Registers as X64Registers, serial, vga};
 pub use hal_x86_64::{interrupt, mm, NAME};
 use mycelium_util::{fmt, sync::InitOnce};

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -163,8 +163,8 @@ pub fn oops(oops: Oops<'_>) -> ! {
         // skip printing disassembly if we already faulted; disassembling the
         // fault address may fault a second time.
         if !oops.already_faulted {
-            let fault_addr = registers.instruction_ptr.as_usize();
-            disassembly(fault_addr);
+             let fault_addr = registers.instruction_ptr.as_usize();
+             disassembly(fault_addr);
         }
         */
     }

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -1,0 +1,280 @@
+use super::framebuf;
+use core::{
+    panic::PanicInfo,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use embedded_graphics::{
+    mono_font::{ascii, MonoTextStyleBuilder},
+    pixelcolor::{Rgb888, RgbColor as _},
+    prelude::*,
+    text::{Alignment, Text},
+};
+use hal_core::{
+    framebuffer::{Draw, RgbColor},
+    interrupt, Address,
+};
+use hal_x86_64::{
+    cpu,
+    framebuffer::{self, Framebuffer},
+    interrupt::Registers as X64Registers,
+    serial, vga,
+};
+use mycelium_trace::{
+    embedded_graphics::MakeTextWriter,
+    writer::{self, MakeWriter},
+};
+use mycelium_util::fmt::{self, Write};
+#[derive(Debug)]
+pub struct Oops<'a> {
+    already_panicked: bool,
+    already_faulted: bool,
+    situation: OopsSituation<'a>,
+}
+
+enum OopsSituation<'a> {
+    Fault {
+        kind: &'static str,
+        fault: Fault<'a>,
+    },
+    Panic(&'a PanicInfo<'a>),
+}
+
+type Fault<'a> = &'a dyn interrupt::ctx::Context<Registers = X64Registers>;
+
+#[cold]
+pub fn oops(oops: Oops<'_>) -> ! {
+    let mut vga = vga::writer();
+
+    // /!\ disable all interrupts, unlock everything to prevent deadlock /!\
+    //
+    // Safety: it is okay to do this because we are oopsing and everything
+    // is going to die anyway.
+    unsafe {
+        // disable all interrupts.
+        cpu::intrinsics::cli();
+
+        // If the system has a COM1, unlock it.
+        if let Some(com1) = serial::com1() {
+            com1.force_unlock();
+        }
+
+        // unlock the VGA buffer.
+        vga.force_unlock();
+
+        // unlock the frame buffer
+        framebuf::force_unlock();
+    }
+
+    // emit a DEBUG event first. with the default tracing configuration, these
+    // will go to the serial port and *not* get written to the framebuffer. this
+    // is important, since it lets us still get information about the oops on
+    // the serial port, even if the oops was due to a bug in eliza's framebuffer
+    // code, which (it turns out) is surprisingly janky...
+    tracing::debug!(?oops);
+    // okay, we've dumped the oops to serial, now try to log a nicer event at
+    // the ERROR level.
+    // let registers = if let Some(fault) = fault {
+    //     let registers = fault.registers();
+    //     tracing::error!(%cause, ?registers, "OOPS! a CPU fault occurred");
+    //     Some(registers)
+    // } else {
+    //     tracing::error!(%cause, "OOPS! a panic occurred", );
+    //     None
+    // };
+
+    let mut framebuf = unsafe { super::framebuf::mk_framebuf() };
+    framebuf.fill(RgbColor::RED);
+
+    let mut target = framebuf.as_draw_target();
+    let smol = MonoTextStyleBuilder::new()
+        .font(&ascii::FONT_6X10)
+        .text_color(Rgb888::WHITE)
+        .build();
+    let uwu = MonoTextStyleBuilder::new()
+        .font(&ascii::FONT_9X15_BOLD)
+        .text_color(Rgb888::RED)
+        .background_color(Rgb888::WHITE)
+        .build();
+
+    let _ = Text::with_alignment(
+        oops.situation.header(),
+        Point::new(5, 15),
+        uwu,
+        Alignment::Left,
+    )
+    .draw(&mut target)
+    .unwrap();
+    let _ = Text::with_alignment(
+        "uwu we did a widdle fucky-wucky!",
+        Point::new(5, 30),
+        smol,
+        Alignment::Left,
+    )
+    .draw(&mut target)
+    .unwrap();
+    drop(target);
+    drop(framebuf);
+
+    let mk_writer = MakeTextWriter::new_at(
+        || unsafe { super::framebuf::mk_framebuf() },
+        Point::new(5, 45),
+    );
+    let mut writer = mk_writer.make_writer();
+    match oops.situation {
+        OopsSituation::Fault { kind, fault } => {
+            let registers = fault.registers();
+            writeln!(writer, "a {} occurred!\n", kind).unwrap();
+            writeln!(
+                writer,
+                "%rip    = {:#016x}",
+                registers.instruction_ptr.as_usize()
+            )
+            .unwrap();
+            writeln!(writer, "%rsp    = {:#016x}", registers.stack_ptr.as_usize()).unwrap();
+            writeln!(writer, "%cs     = {:016x}", registers.code_segment).unwrap();
+            writeln!(writer, "%ss     = {:016x}", registers.stack_segment).unwrap();
+            writeln!(writer, "%rflags = {:#016b}", registers.cpu_flags).unwrap();
+        }
+        OopsSituation::Panic(panic) => {
+            writeln!(writer, "mycelium panicked!\n").unwrap();
+        }
+    }
+
+    crate::ALLOC.dump_free_lists();
+
+    if let Some(registers) = oops.situation.registers() {
+        // tracing::error!("%rip    = {:#016x}", registers.instruction_ptr.as_usize());
+        // tracing::error!("%rsp    = {:#016x}", registers.stack_ptr.as_usize());
+        // tracing::error!("%cs     = {:#016x}", registers.code_segment);
+        // tracing::error!("%ss     = {:#016x}", registers.stack_segment);
+        // tracing::error!("%rflags = {:#016b}", registers.cpu_flags);
+
+        // skip printing disassembly if we already faulted; disassembling the
+        // fault address may fault a second time.
+        if !oops.already_faulted {
+            let fault_addr = registers.instruction_ptr.as_usize();
+            disassembly(fault_addr);
+        }
+    }
+
+    #[cfg(test)]
+    oops.fail_test();
+
+    #[cfg(not(test))]
+    unsafe {
+        cpu::halt()
+    }
+}
+
+// === impl Oops ===
+
+static IS_PANICKING: AtomicBool = AtomicBool::new(false);
+static IS_FAULTING: AtomicBool = AtomicBool::new(false);
+
+impl<'a> Oops<'a> {
+    #[inline(always)] // don't push a stack frame in case we overflowed!
+    pub(super) fn fault(fault: Fault<'a>, kind: &'static str) -> Self {
+        let situation = OopsSituation::Fault { kind, fault };
+        let already_panicked = IS_PANICKING.load(Ordering::Acquire);
+        let already_faulted = IS_FAULTING.swap(true, Ordering::AcqRel);
+        Self {
+            already_panicked,
+            already_faulted,
+            situation,
+        }
+    }
+
+    pub fn panic(panic: &'a PanicInfo<'a>) -> Self {
+        let already_panicked = IS_PANICKING.swap(true, Ordering::AcqRel);
+        let already_faulted = IS_FAULTING.load(Ordering::Acquire);
+        Self {
+            already_panicked,
+            already_faulted,
+            situation: OopsSituation::Panic(panic),
+        }
+    }
+
+    #[cfg(test)]
+    fn fail_test(&self) -> ! {
+        use super::{qemu_exit, QemuExitCode};
+        let failure = match self.situation {
+            OopsSituation::Panic(_) => mycotest::Failure::Panic,
+            OopsSituation::Fault { .. } => mycotest::Failure::Fault,
+        };
+
+        if let Some(test) = mycotest::runner::current_test() {
+            if let Some(com1) = serial::com1() {
+                // if writing the test outcome fails, don't double panic...
+                let _ = test.write_outcome(Err(failure), com1.lock());
+            }
+        }
+        qemu_exit(QemuExitCode::Failed)
+    }
+}
+
+impl<'a> From<&'a PanicInfo<'a>> for Oops<'a> {
+    #[inline]
+    fn from(panic: &'a PanicInfo<'a>) -> Self {
+        Self::panic(panic)
+    }
+}
+
+// === impl OopsSituation ===
+
+impl<'a> OopsSituation<'a> {
+    fn header(&self) -> &'static str {
+        match self {
+            Self::Fault { .. } => " OOPSIE-WOOPSIE! ",
+            Self::Panic(_) => " DON'T PANIC! ",
+        }
+    }
+
+    fn registers(&self) -> Option<&X64Registers> {
+        match self {
+            Self::Fault { fault, .. } => Some(fault.registers()),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Debug for OopsSituation<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fault { kind, fault } => f
+                .debug_struct("OopsSituation::Fault")
+                .field("kind", kind)
+                .field("registers", fault.registers())
+                .finish(),
+            Self::Panic(panic) => f.debug_tuple("OopsSituation::Panic").field(&panic).finish(),
+        }
+    }
+}
+
+#[tracing::instrument(target = "oops", level = "error", skip(rip), fields(rip = fmt::hex(rip)))]
+fn disassembly(rip: usize) {
+    use yaxpeax_arch::LengthedInstruction;
+    // let _ = writeln!(mk_writer.make_writer(), "Disassembly:");
+    let mut ptr = rip as u64;
+    let decoder = yaxpeax_x86::long_mode::InstDecoder::default();
+    for _ in 0..10 {
+        // Safety: who cares! At worst this might double-fault by reading past the end of valid
+        // memory. whoopsie.
+
+        // XXX(eliza): this read also page faults sometimes. seems wacky.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, 16) };
+        // tracing::debug!(?bytes);
+        // let _ = write!(mk_writer.make_writer(), "  {:016x}: ", ptr).unwrap();
+        match decoder.decode_slice(bytes) {
+            Ok(inst) => {
+                // let _ = writeln!(mk_writer.make_writer(), "{}", inst);
+                tracing::error!(target: "oops", "{:016x}: {}", ptr, inst);
+                ptr += inst.len();
+            }
+            Err(e) => {
+                // let _ = writeln!(mk_writer.make_writer(), "{}", e);
+                tracing::error!(target: "oops", "{:016x}: {}", ptr, e);
+                break;
+            }
+        }
+    }
+}

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -107,7 +107,7 @@ pub fn oops(oops: Oops<'_>) -> ! {
     .draw(&mut target)
     .unwrap();
     let _ = Text::with_alignment(
-        "uwu we did a widdle fucky-wucky!",
+        "uwu mycelium did a widdle fucky-wucky!",
         Point::new(5, 30),
         smol,
         Alignment::Left,
@@ -128,22 +128,11 @@ pub fn oops(oops: Oops<'_>) -> ! {
             fault,
             details,
         } => {
-            let registers = fault.registers();
             if let Some(deets) = details {
                 writeln!(writer, "a {} occurred: {}\n", kind, deets).unwrap();
             } else {
                 writeln!(writer, "a {} occurred!\n", kind).unwrap();
             }
-            writeln!(
-                writer,
-                "%rip    = {:#016x}",
-                registers.instruction_ptr.as_usize()
-            )
-            .unwrap();
-            writeln!(writer, "%rsp    = {:#016x}", registers.stack_ptr.as_usize()).unwrap();
-            writeln!(writer, "%cs     = {:016x}", registers.code_segment).unwrap();
-            writeln!(writer, "%ss     = {:016x}", registers.stack_segment).unwrap();
-            writeln!(writer, "%rflags = {:#016b}", registers.cpu_flags).unwrap();
         }
         OopsSituation::Panic(panic) => {
             writeln!(writer, "mycelium panicked!\n").unwrap();
@@ -151,21 +140,37 @@ pub fn oops(oops: Oops<'_>) -> ! {
     }
 
     if let Some(registers) = oops.situation.registers() {
+        writeln!(
+            writer,
+            "%rip    = {:#016x}",
+            registers.instruction_ptr.as_usize()
+        )
+        .unwrap();
+        writeln!(writer, "%rsp    = {:#016x}", registers.stack_ptr.as_usize()).unwrap();
+        writeln!(writer, "%cs     = {:016x}", registers.code_segment).unwrap();
+        writeln!(writer, "%ss     = {:016x}", registers.stack_segment).unwrap();
+        writeln!(writer, "%rflags = {:#016b}", registers.cpu_flags).unwrap();
         // tracing::error!("%rip    = {:#016x}", registers.instruction_ptr.as_usize());
         // tracing::error!("%rsp    = {:#016x}", registers.stack_ptr.as_usize());
         // tracing::error!("%cs     = {:#016x}", registers.code_segment);
         // tracing::error!("%ss     = {:#016x}", registers.stack_segment);
         // tracing::error!("%rflags = {:#016b}", registers.cpu_flags);
 
+        // TODO(eliza): disassembly appears to (always?) do a general protection
+        // fault. seems weird.
+        /*
         // skip printing disassembly if we already faulted; disassembling the
         // fault address may fault a second time.
         if !oops.already_faulted {
             let fault_addr = registers.instruction_ptr.as_usize();
             disassembly(fault_addr);
         }
+        */
     }
 
     crate::ALLOC.dump_free_lists();
+
+    writeln!(writer, "\nit will NEVER be safe to turn off your computer!").unwrap();
 
     #[cfg(test)]
     oops.fail_test();

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -177,16 +177,14 @@ pub fn oops(oops: Oops<'_>) -> ! {
             "...while handling a panic! we really screwed up!"
         )
         .unwrap();
-    }
+    } else {
 
     if oops.already_faulted {
-        if oops.already_panicked {
-            writeln!(
-                mk_writer.make_writer(),
-                "...while handling a fault! seems real bad lol!"
-            )
-            .unwrap();
-        }
+        writeln!(
+            mk_writer.make_writer(),
+            "...while handling a fault! seems real bad lol!"
+        )
+        .unwrap();
     }
 
     writeln!(

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -13,16 +13,8 @@ use hal_core::{
     framebuffer::{Draw, RgbColor},
     interrupt, Address,
 };
-use hal_x86_64::{
-    cpu,
-    framebuffer::{self, Framebuffer},
-    interrupt::Registers as X64Registers,
-    serial, vga,
-};
-use mycelium_trace::{
-    embedded_graphics::MakeTextWriter,
-    writer::{self, MakeWriter},
-};
+use hal_x86_64::{cpu, interrupt::Registers as X64Registers, serial, vga};
+use mycelium_trace::{embedded_graphics::MakeTextWriter, writer::MakeWriter};
 use mycelium_util::fmt::{self, Write};
 
 #[derive(Debug)]

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -177,7 +177,7 @@ pub fn oops(oops: Oops<'_>) -> ! {
             "...while handling a panic! we really screwed up!"
         )
         .unwrap();
-    } else {
+    }
 
     if oops.already_faulted {
         writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,17 @@ pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     // XXX(eliza): this sucks
     ALLOC.set_vm_offset(arch::mm::vm_offset());
 
+    unsafe {
+        core::arch::asm!(
+            "
+            mov edx, 0x0
+            mov eax, 0x2
+            mov ecx, 0x0
+            div ecx
+        "
+        );
+    }
+
     let mut regions = 0;
     let mut free_regions = 0;
     let mut free_bytes = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,16 +104,7 @@ pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     // XXX(eliza): this sucks
     ALLOC.set_vm_offset(arch::mm::vm_offset());
 
-    unsafe {
-        core::arch::asm!(
-            "
-            mov edx, 0x0
-            mov eax, 0x2
-            mov ecx, 0x0
-            div ecx
-        "
-        );
-    }
+    panic!("fake panic lol");
 
     let mut regions = 0;
     let mut free_regions = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,30 +205,29 @@ pub fn alloc_error(layout: core::alloc::Layout) -> ! {
 
 #[cfg_attr(target_os = "none", panic_handler)]
 #[cold]
-pub fn panic(panic: &core::panic::PanicInfo) -> ! {
-    use core::fmt;
-    struct PrettyPanic<'a>(&'a core::panic::PanicInfo<'a>);
-    impl<'a> fmt::Display for PrettyPanic<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let message = self.0.message();
-            let location = self.0.location();
-            if let Some(message) = message {
-                writeln!(f, "  mycelium panicked: {}", message)?;
-                if let Some(loc) = location {
-                    writeln!(f, "  at: {}:{}:{}", loc.file(), loc.line(), loc.column(),)?;
-                } else {
-                    writeln!(f, "  at: ???")?;
-                }
-            } else {
-                writeln!(f, "  mycelium panicked: {}", self.0)?;
-            }
-            Ok(())
-        }
-    }
+pub fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
+    // use core::fmt;
+    // struct PrettyPanic<'a>(&'a core::panic::PanicInfo<'a>);
+    // impl<'a> fmt::Display for PrettyPanic<'a> {
+    //     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    //         let message = self.0.message();
+    //         let location = self.0.location();
+    //         if let Some(message) = message {
+    //             writeln!(f, "  mycelium panicked: {}", message)?;
+    //             if let Some(loc) = location {
+    //                 writeln!(f, "  at: {}:{}:{}", loc.file(), loc.line(), loc.column(),)?;
+    //             } else {
+    //                 writeln!(f, "  at: ???")?;
+    //             }
+    //         } else {
+    //             writeln!(f, "  mycelium panicked: {}", self.0)?;
+    //         }
+    //         Ok(())
+    //     }
+    // }
 
-    let pp = PrettyPanic(panic);
-    tracing::info!(%pp);
-    arch::oops(&pp, None)
+    // let pp = PrettyPanic(panic);
+    arch::oops(arch::Oops::from(panic))
 }
 
 #[cfg(all(test, not(target_os = "none")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,6 @@ pub fn kernel_main(bootinfo: &impl BootInfo) -> ! {
     // XXX(eliza): this sucks
     ALLOC.set_vm_offset(arch::mm::vm_offset());
 
-    panic!("fake panic lol");
-
     let mut regions = 0;
     let mut free_regions = 0;
     let mut free_bytes = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", feature(alloc_error_handler))]
-#![cfg_attr(target_os = "none", feature(asm))]
 #![cfg_attr(target_os = "none", feature(panic_info_message))]
 #![allow(clippy::single_component_path_imports)]
 // Force linking to the `mycelium_kernel` lib.

--- a/trace/src/embedded_graphics.rs
+++ b/trace/src/embedded_graphics.rs
@@ -133,6 +133,10 @@ where
 
 impl<D: Draw> MakeTextWriter<D> {
     pub fn new(mk: fn() -> D) -> Self {
+        Self::new_at(mk, Point { x: 10, y: 10 })
+    }
+
+    pub fn new_at(mk: fn() -> D, point: Point) -> Self {
         let (pixel_width, pixel_height) = {
             let buf = (mk)();
             (buf.width() as u32, buf.height() as u32)
@@ -142,7 +146,7 @@ impl<D: Draw> MakeTextWriter<D> {
         let char_height = text_style.font.character_size.height;
         let last_line = (pixel_height - char_height - 10) as i32;
         Self {
-            next_point: AtomicU64::new(pack_point(Point { x: 10, y: 10 })),
+            next_point: AtomicU64::new(pack_point(point)),
             char_height,
             mk,
             line_len,


### PR DESCRIPTION
This branch rewrites the x86_64 oopsing code, making the following
changes:

 - write to the framebuffer instead of the VGA buffer, so everything
   looks nice
 - put oopsing code in its own module and clean it up
 - track whether we've panicked/faulted previously while handling an
   oops
 - disable yaxpeax disassembly for now since it appears to always cause
  a general protection fault (???)
 - add details to faults
 - populate a bunch more code fault ISRs so they don't all double fault

## Cool Screenshots

A fault: 
![image](https://user-images.githubusercontent.com/2796466/162590828-03797179-a17f-4468-9810-b927c2560443.png)
A panic:
![image](https://user-images.githubusercontent.com/2796466/162590842-3b49b33a-2064-45a9-9891-3b4575e03286.png)
Rudimentary double panic handling:
![image](https://user-images.githubusercontent.com/2796466/162590972-9319a3ce-980e-4c38-9210-04c71cc8c12d.png)
