### PR TITLE
feat(x86_64): display segment selector indices in faults

### DIFF
--- a/hal-core/src/interrupt/ctx.rs
+++ b/hal-core/src/interrupt/ctx.rs
@@ -20,10 +20,28 @@ pub trait PageFault: Context {
     // TODO(eliza): more
 }
 
+/// Trait representing a fault caused by the currently executing code.
 pub trait CodeFault: Context {
+    /// Returns `true` if the code fault occurred while executing in user
+    /// mode code.
     fn is_user_mode(&self) -> bool;
+
+    /// Returns the virtual address of the instruction pointer where the
+    /// fault occurred.
     fn instruction_ptr(&self) -> VAddr;
+
+    /// Returns a static string describing the kind of code fault.
     fn fault_kind(&self) -> &'static str;
+
+    /// Returns a dynamically formatted message if additional information about
+    /// the fault is available. Otherwise, this returns `None`.
+    ///
+    /// # Default Implementation
+    ///
+    /// Returns `None`.
+    fn details(&self) -> Option<&dyn fmt::Display> {
+        None
+    }
 }
 
 #[non_exhaustive]

--- a/hal-x86_64/src/segment.rs
+++ b/hal-x86_64/src/segment.rs
@@ -37,6 +37,20 @@ impl Selector {
         cpu::Ring::from_u8(Self::RING.unpack(self.0) as u8)
     }
 
+    /// Returns which descriptor table (GDT or LDT) this selector references.
+    ///
+    /// # Note
+    ///
+    /// This will never return [`DescriptorTable::Idt`][idt], as a segment
+    /// selector only references segmentation table descriptors.
+    pub const fn table(&self) -> cpu::DescriptorTable {
+        if self.is_gdt() {
+            cpu::DescriptorTable::Gdt
+        } else {
+            cpu::DescriptorTable::Idt
+        }
+    }
+
     /// Returns true if this is an LDT segment selector.
     pub const fn is_ldt(&self) -> bool {
         Self::LDT_BIT.contained_in_any(self.0)

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -151,11 +151,11 @@ impl hal_core::interrupt::Handlers<X64Registers> for InterruptHandlers {
         C: hal_core::interrupt::Context<Registers = X64Registers>
             + hal_core::interrupt::ctx::CodeFault,
     {
-        oops(Oops::fault_with_details(
-            &cx,
-            "CODE FAULT",
-            &cx.fault_kind(),
-        ));
+        let fault = match cx.details() {
+            Some(deets) => Oops::fault_with_details(&cx, cx.fault_kind(), deets),
+            None => Oops::fault(&cx, cx.fault_kind()),
+        };
+        oops(fault)
     }
 
     fn double_fault<C>(cx: C)


### PR DESCRIPTION
The invalid TSS (0xA), segment not present (0xB), stack-segment
fault (0xC), and general protection fault (0xD) CPU exceptions push an
error code describing the segment selector that caused the fault. This
branch updates interrupt handling code to parse and display these error
codes nicely, and populates the invalid TSS, segment not present, and
stack-segment fault interrupt vectors with new ISRs.

In addition, the HAL "code fault" type now has a new optional `details`
method for passing an arbitrary `Display` payload to display in the oops
screen.