### PR TITLE
fix(mycotest): fix missing runner feature flag

### DIFF
--- a/mycotest/src/lib.rs
+++ b/mycotest/src/lib.rs
@@ -3,6 +3,7 @@
 //! This is in its own crate mainly so the constants are the same and I can't
 //! have the kernel write the wrong strings (which I did lol).
 
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![no_std]
 
 #[cfg(feature = "alloc")]
@@ -14,6 +15,7 @@ use core::{
     marker::PhantomData,
 };
 pub mod report;
+#[cfg(feature = "runner")]
 pub mod runner;
 
 pub type Outcome = Result<(), Failure>;


### PR DESCRIPTION
Currently, there is an error when compiling with the
`runner` feature disabled, as the module is not feature flagged,
but some of its dependencies are.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>