### PR TITLE
feat(async): add `WaitCell`

### DIFF
--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -57,7 +57,7 @@ jobs:
       run: rustup show
     - uses: actions/checkout@v2
     - name: run loom tests
-      run: ./bin/loom -p cordyceps
+      run: ./bin/loom -p cordyceps -- --test-threads=1 --nocapture
 
   miri:
     needs: is_enabled

--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -58,6 +58,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: run loom tests
       run: ./bin/loom -p cordyceps -- --test-threads=1 --nocapture
+      env:
+        LOOM_LOG: "off"
 
   miri:
     needs: is_enabled

--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -57,11 +57,7 @@ jobs:
       run: rustup show
     - uses: actions/checkout@v2
     - name: run loom tests
-      run: cargo test --profile loom --lib -p cordyceps
-      env:
-        LOOM_MAX_PREEMPTIONS: 2
-        LOOM_LOG: loom=trace
-        RUSTFLAGS: "--cfg loom"
+      run: ./bin/loom -p cordyceps
 
   miri:
     needs: is_enabled

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generator"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +474,7 @@ checksum = "85eb735cf3c8ebac6cc3655c5da2f4a088b6a19133aa482471a21ba0eb5d83ab"
 dependencies = [
  "cfg-if",
  "generator",
+ "pin-utils",
  "scoped-tls",
  "tracing 0.1.34",
  "tracing-subscriber 0.3.11",
@@ -492,6 +530,7 @@ name = "mycelium-async"
 version = "0.1.0"
 dependencies = [
  "cordyceps",
+ "futures-util",
  "loom",
  "mycelium-util",
  "mycotest",
@@ -647,6 +686,12 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -853,6 +898,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -20,6 +20,7 @@ features = ["attributes"]
 git = "https://github.com/tokio-rs/tracing"
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = "0.5.5"
+loom = { version = "0.5.5", features = ["futures"] }
 tracing_01 = { package = "tracing", version = "0.1", default_features = false, features = ["attributes"] }
 tracing_subscriber_03 = { package = "tracing-subscriber", version = "0.3.11", features = ["fmt"] }
+futures-util = "0.3"

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -2,8 +2,9 @@
 extern crate alloc;
 
 #[macro_use]
-mod util;
+pub(crate) mod util;
 pub(crate) mod loom;
 
 pub mod scheduler;
 pub mod task;
+pub mod wait;

--- a/async/src/loom.rs
+++ b/async/src/loom.rs
@@ -3,7 +3,7 @@ pub(crate) use self::inner::*;
 
 #[cfg(loom)]
 mod inner {
-    pub use loom::{alloc, cell, hint, model, sync, thread};
+    pub use loom::{alloc, cell, future, hint, model, sync, thread};
 }
 
 #[cfg(not(loom))]

--- a/async/src/task/task_list.rs
+++ b/async/src/task/task_list.rs
@@ -1,0 +1,10 @@
+use super::Task;
+use mycelium_util::{intrusive::list, sync::spin};
+pub(crate) struct TaskList {
+    inner: spin::Mutex<Inner>,
+}
+
+struct Inner {
+    list: list::List<Task>,
+    closed: bool,
+}

--- a/async/src/util.rs
+++ b/async/src/util.rs
@@ -25,6 +25,33 @@ macro_rules! test_dbg {
     };
 }
 
+#[cfg(not(test))]
+macro_rules! test_trace {
+    ($($args:tt)+) => {};
+}
+
+#[cfg(test)]
+macro_rules! test_trace {
+    ($($args:tt)+) => {
+        crate::util::tracing::debug!($($args)+);
+    };
+}
+
+macro_rules! fmt_bits {
+    ($self: expr, $f: expr, $has_states: ident, $($name: ident),+) => {
+        $(
+            if $self.contains(Self::$name) {
+                if $has_states {
+                    $f.write_str(" | ")?;
+                }
+                $f.write_str(stringify!($name))?;
+                $has_states = true;
+            }
+        )+
+
+    };
+}
+
 /// Helper to construct a `NonNull<T>` from a raw pointer to `T`, with null
 /// checks elided in release mode.
 #[cfg(debug_assertions)]

--- a/async/src/wait.rs
+++ b/async/src/wait.rs
@@ -1,0 +1,30 @@
+//! Waiter cells and queues to allow tasks to wait for notifications.
+//!
+//! This module implements two types of structure for waiting: a [`WaitCell`],
+//! which stores a *single* waiting task, and a wait *queue*, which
+//! stores a queue of waiting tasks.
+mod cell;
+pub use cell::WaitCell;
+
+use core::task::Poll;
+
+/// An error indicating that a [`WaitCell`] or queue was closed while attempting
+/// register a waiter.
+#[derive(Clone, Debug)]
+pub struct Closed(());
+
+pub type WaitResult = Result<(), Closed>;
+
+pub(in crate::wait) const fn closed() -> Poll<WaitResult> {
+    Poll::Ready(Err(Closed::new()))
+}
+
+pub(in crate::wait) const fn notified() -> Poll<WaitResult> {
+    Poll::Ready(Ok(()))
+}
+
+impl Closed {
+    pub(in crate::wait) const fn new() -> Self {
+        Self(())
+    }
+}

--- a/async/src/wait/cell.rs
+++ b/async/src/wait/cell.rs
@@ -1,0 +1,324 @@
+use crate::{
+    loom::{
+        cell::UnsafeCell,
+        sync::atomic::{
+            AtomicUsize,
+            Ordering::{self, *},
+        },
+    },
+    util::tracing,
+    wait::{self, WaitResult},
+};
+use core::{
+    ops,
+    task::{Poll, Waker},
+};
+use mycelium_util::{fmt, sync::CachePadded};
+
+/// An atomically registered [`Waker`].
+///
+/// This is inspired by the [`AtomicWaker` type] used in Tokio's
+/// synchronization primitives, with the following modifications:
+///
+/// - An additional bit of state is added to allow setting a "close" bit.
+/// - A `WaitCell` is always woken by value (for now).
+/// - `WaitCell` does not handle unwinding, because mycelium kernel-mode code
+///   does not support unwinding.
+///
+/// [`AtomicWaker`]: https://github.com/tokio-rs/tokio/blob/09b770c5db31a1f35631600e1d239679354da2dd/tokio/src/sync/task/atomic_waker.rs
+/// [`Waker`]: core::task::Waker
+pub struct WaitCell {
+    lock: CachePadded<AtomicUsize>,
+    waker: UnsafeCell<Option<Waker>>,
+}
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+struct State(usize);
+
+// === impl WaitCell ===
+
+impl WaitCell {
+    #[cfg(not(all(loom, test)))]
+    pub const fn new() -> Self {
+        Self {
+            lock: CachePadded::new(AtomicUsize::new(State::WAITING.0)),
+            waker: UnsafeCell::new(None),
+        }
+    }
+
+    #[cfg(all(loom, test))]
+    pub fn new() -> Self {
+        Self {
+            lock: CachePadded::new(AtomicUsize::new(State::WAITING.0)),
+            waker: UnsafeCell::new(None),
+        }
+    }
+}
+
+impl WaitCell {
+    pub fn wait(&self, waker: &Waker) -> Poll<WaitResult> {
+        tracing::trace!(wait_cell = ?fmt::ptr(self), ?waker, "registering waker");
+
+        // this is based on tokio's AtomicWaker synchronization strategy
+        match test_dbg!(self.compare_exchange(State::WAITING, State::PARKING, Acquire)) {
+            // someone else is notifying, so don't wait!
+            Err(actual) if test_dbg!(actual.contains(State::CLOSED)) => {
+                return wait::closed();
+            }
+            Err(actual) if test_dbg!(actual.contains(State::NOTIFYING)) => {
+                waker.wake_by_ref();
+                crate::loom::hint::spin_loop();
+                return wait::notified();
+            }
+
+            Err(actual) => {
+                debug_assert!(
+                    actual == State::PARKING || actual == State::PARKING | State::NOTIFYING
+                );
+                return Poll::Pending;
+            }
+            Ok(_) => {}
+        }
+
+        test_trace!("-> wait cell locked!");
+        let prev_waker = self.waker.with_mut(|old_waker| unsafe {
+            match &mut *old_waker {
+                Some(old_waker) if waker.will_wake(old_waker) => None,
+                old => old.replace(waker.clone()),
+            }
+        });
+
+        match test_dbg!(self.compare_exchange(State::PARKING, State::WAITING, AcqRel)) {
+            Ok(_) => Poll::Pending,
+            Err(actual) => {
+                test_trace!(state = ?actual, "was notified");
+                let waker = self.waker.with_mut(|waker| unsafe { (*waker).take() });
+                // Reset to the WAITING state by clearing everything *except*
+                // the closed bits (which must remain set).
+                let state = test_dbg!(self.fetch_and(State::CLOSED, AcqRel));
+                // The only valid state transition while we were parking is to
+                // add the CLOSED bit.
+                debug_assert!(
+                    state == actual || state == actual | State::CLOSED,
+                    "state changed unexpectedly while parking!"
+                );
+
+                if let Some(prev_waker) = prev_waker {
+                    prev_waker.wake();
+                }
+
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+
+                if test_dbg!(state.contains(State::CLOSED)) {
+                    wait::closed()
+                } else {
+                    wait::notified()
+                }
+            }
+        }
+    }
+
+    pub fn notify(&self) -> bool {
+        self.notify2(State::WAITING)
+    }
+
+    pub fn close(&self) {
+        self.notify2(State::CLOSED);
+    }
+
+    fn notify2(&self, close: State) -> bool {
+        tracing::trace!(wait_cell = ?fmt::ptr(self), ?close, "notifying");
+        let bits = State::NOTIFYING | close;
+        if test_dbg!(self.fetch_or(bits, AcqRel)) == State::WAITING {
+            // we have the lock!
+            let waker = self.waker.with_mut(|thread| unsafe { (*thread).take() });
+
+            test_dbg!(self.fetch_and(!State::NOTIFYING, AcqRel));
+
+            if let Some(waker) = test_dbg!(waker) {
+                tracing::trace!(wait_cell = ?fmt::ptr(self), ?close, ?waker, "notified");
+                waker.wake();
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl WaitCell {
+    #[inline(always)]
+    fn compare_exchange(
+        &self,
+        State(curr): State,
+        State(new): State,
+        success: Ordering,
+    ) -> Result<State, State> {
+        self.lock
+            .compare_exchange(curr, new, success, Acquire)
+            .map(State)
+            .map_err(State)
+    }
+
+    #[inline(always)]
+    fn fetch_and(&self, State(state): State, order: Ordering) -> State {
+        State(self.lock.fetch_and(state, order))
+    }
+
+    #[inline(always)]
+    fn fetch_or(&self, State(state): State, order: Ordering) -> State {
+        State(self.lock.fetch_or(state, order))
+    }
+
+    #[inline(always)]
+    fn current_state(&self) -> State {
+        State(self.lock.load(Acquire))
+    }
+}
+
+unsafe impl Send for WaitCell {}
+unsafe impl Sync for WaitCell {}
+
+impl fmt::Debug for WaitCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WaitCell")
+            .field("state", &self.current_state())
+            .field("waker", &fmt::display(".."))
+            .finish()
+    }
+}
+
+// === impl State ===
+
+impl State {
+    const WAITING: Self = Self(0b00);
+    const PARKING: Self = Self(0b01);
+    const NOTIFYING: Self = Self(0b10);
+    const CLOSED: Self = Self(0b100);
+
+    fn contains(self, Self(state): Self) -> bool {
+        self.0 & state == state
+    }
+}
+
+impl ops::BitOr for State {
+    type Output = Self;
+
+    fn bitor(self, Self(rhs): Self) -> Self::Output {
+        Self(self.0 | rhs)
+    }
+}
+
+impl ops::Not for State {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut has_states = false;
+
+        fmt_bits!(self, f, has_states, PARKING, NOTIFYING, CLOSED);
+
+        if !has_states {
+            if *self == Self::WAITING {
+                return f.write_str("WAITING");
+            }
+
+            f.debug_tuple("UnknownState")
+                .field(&format_args!("{:#b}", self.0))
+                .finish()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(all(loom, test))]
+mod loom {
+    use super::*;
+    use crate::loom::{
+        future,
+        sync::atomic::{AtomicUsize, Ordering::Relaxed},
+        thread,
+    };
+    use core::task::Poll;
+    use std::sync::Arc;
+
+    struct Chan {
+        num: AtomicUsize,
+        task: WaitCell,
+    }
+
+    const NUM_NOTIFY: usize = 2;
+
+    async fn wait_on(chan: Arc<Chan>) {
+        futures_util::future::poll_fn(move |cx| {
+            let res = test_dbg!(chan.task.wait(cx.waker()));
+
+            if NUM_NOTIFY == chan.num.load(Relaxed) {
+                return Poll::Ready(());
+            }
+
+            if res.is_ready() {
+                return Poll::Ready(());
+            }
+
+            Poll::Pending
+        })
+        .await
+    }
+
+    #[test]
+    fn basic_notification() {
+        crate::loom::model(|| {
+            let chan = Arc::new(Chan {
+                num: AtomicUsize::new(0),
+                task: WaitCell::new(),
+            });
+
+            for _ in 0..NUM_NOTIFY {
+                let chan = chan.clone();
+
+                thread::spawn(move || {
+                    chan.num.fetch_add(1, Relaxed);
+                    chan.task.notify();
+                });
+            }
+
+            future::block_on(wait_on(chan));
+        });
+    }
+
+    #[test]
+    fn close() {
+        crate::loom::model(|| {
+            let chan = Arc::new(Chan {
+                num: AtomicUsize::new(0),
+                task: WaitCell::new(),
+            });
+
+            thread::spawn({
+                let chan = chan.clone();
+                move || {
+                    chan.num.fetch_add(1, Relaxed);
+                    chan.task.notify();
+                }
+            });
+
+            thread::spawn({
+                let chan = chan.clone();
+                move || {
+                    chan.num.fetch_add(1, Relaxed);
+                    chan.task.close();
+                }
+            });
+
+            future::block_on(wait_on(chan));
+        });
+    }
+}

--- a/bin/loom
+++ b/bin/loom
@@ -4,7 +4,6 @@ set -x
 
 RUSTFLAGS="--cfg loom ${RUSTFLAGS}" \
 LOOM_LOG="${LOOM_LOG:-info}" \
-LOOM_MAX_PREEMPTIONS="${LOOM_MAX_PREEMPTIONS:-2}" \
 LOOM_LOCATION=true \
 cargo test \
     --profile loom \

--- a/util/src/fmt.rs
+++ b/util/src/fmt.rs
@@ -1,5 +1,6 @@
 //! Text formatting utilities.
 pub use core::fmt::*;
+pub use tracing::field::{debug, display};
 
 /// A wrapper type that formats the wrapped value using a provided function.
 pub struct FormatWith<T, F = fn(&T, &mut Formatter<'_>) -> Result>


### PR DESCRIPTION
This commit adds a `WaitCell` primitive to `mycelium-async`, which
stores a single waiter and notifies it.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>