### PR TITLE
test(cordyceps): decrease # messages in loom tests

### DIFF
--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -57,10 +57,10 @@ jobs:
       run: rustup show
     - uses: actions/checkout@v2
     - name: run loom tests
-      run: cargo test --profile loom --lib -p cordyceps
+      run: cargo test --profile loom --lib -p cordyceps -- --nocapture --test-threads=1
       env:
         LOOM_MAX_PREEMPTIONS: 2
-        LOOM_LOG: loom=trace
+        LOOM_LOG: loom=info
         RUSTFLAGS: "--cfg loom"
 
   miri:

--- a/cordyceps/src/mpsc_queue.rs
+++ b/cordyceps/src/mpsc_queue.rs
@@ -776,7 +776,7 @@ mod loom {
     #[test]
     fn basically_works_loom() {
         const THREADS: i32 = 2;
-        const MSGS: i32 = THREADS * 2;
+        const MSGS: i32 = THREADS;
         const TOTAL_MSGS: i32 = THREADS * MSGS;
         basically_works_test(THREADS, MSGS, TOTAL_MSGS);
     }
@@ -786,7 +786,7 @@ mod loom {
         // Test that dropping the queue drops any messages that haven't been
         // consumed by the consumer.
         const THREADS: i32 = 2;
-        const MSGS: i32 = THREADS * 2;
+        const MSGS: i32 = THREADS;
         // Only consume half as many messages as are sent, to ensure dropping
         // the queue does not leak.
         const TOTAL_MSGS: i32 = (THREADS * MSGS) / 2;


### PR DESCRIPTION
These take *way* too long to run on CI. This branch makes them way
shorter.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>