### PR TITLE
fix CI yaml mistake

### DIFF
--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -8,7 +8,12 @@
 # added to this workflow!
 name: mycelium-async
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
 
 env:
   # disable incremental compilation.

--- a/.github/workflows/async.yml
+++ b/.github/workflows/async.yml
@@ -63,14 +63,14 @@ jobs:
         LOOM_LOG: loom=trace
         RUSTFLAGS: "--cfg loom"
 
-  miri:
-    # needs: is_enabled
-    # if: ${{ needs.is_enabled.outputs.should_skip != 'true' }}
-    # runs-on: ubuntu-latest
-    # name: Miri tests (mycelium-async)
-    # steps:
-    # - name: install rust toolchain
-    #   run: rustup show
-    # - uses: actions/checkout@v2
-    # - name: run miri tests
-    #   run: ./bin/miri -p mycelium-async
+  # miri:
+  #   needs: is_enabled
+  #   if: ${{ needs.is_enabled.outputs.should_skip != 'true' }}
+  #   runs-on: ubuntu-latest
+  #   name: Miri tests (mycelium-async)
+  #   steps:
+  #   - name: install rust toolchain
+  #     run: rustup show
+  #   - uses: actions/checkout@v2
+  #   - name: run miri tests
+  #     run: ./bin/miri -p mycelium-async

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
 
 env:
   # disable incremental compilation.

--- a/.github/workflows/ci_warnings.yml
+++ b/.github/workflows/ci_warnings.yml
@@ -4,7 +4,11 @@
 # future, but aren't hard PR blockers.
 name: CI (warnings)
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
 
 env:
   # disable incremental compilation.

--- a/.github/workflows/cordyceps.yml
+++ b/.github/workflows/cordyceps.yml
@@ -8,7 +8,11 @@
 # added to this workflow!
 name: cordyceps
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
 
 env:
   # disable incremental compilation.

--- a/.github/workflows/loom-util.yml
+++ b/.github/workflows/loom-util.yml
@@ -8,9 +8,11 @@
 # added to this workflow!
 name: Loom (mycelium-util)
 
-
-on: [pull_request, workflow_dispatch]
-
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
 
 env:
   # disable incremental compilation.


### PR DESCRIPTION
this fixes a stupid yaml mistake in the CI config for mycelium-async, and always runs CI on pushes to `main`