### PR TITLE
style: fix Rust 1.61 clippy lints

### DIFF
--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -14,13 +14,13 @@ mycotest = { path = "../mycotest", default-features = false }
 cordyceps = { path = "../cordyceps" }
 pin-project = "1"
 
-[dependencies.tracing]
+[dependencies.tracing_02]
+package = "tracing"
 default_features = false
-features = ["attributes"]
 git = "https://github.com/tokio-rs/tracing"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5.5", features = ["futures"] }
-tracing_01 = { package = "tracing", version = "0.1", default_features = false, features = ["attributes"] }
+tracing_01 = { package = "tracing", version = "0.1", default_features = false }
 tracing_subscriber_03 = { package = "tracing-subscriber", version = "0.3.11", features = ["fmt"] }
 futures-util = "0.3"

--- a/async/src/util.rs
+++ b/async/src/util.rs
@@ -1,7 +1,7 @@
 use core::ptr::NonNull;
 
 #[cfg(not(all(test, loom)))]
-pub(crate) use tracing;
+pub(crate) use tracing_02 as tracing;
 
 #[cfg(all(test, loom))]
 pub(crate) use tracing_01 as tracing;

--- a/mycotest/src/report.rs
+++ b/mycotest/src/report.rs
@@ -95,7 +95,7 @@ impl<'a> TestName<'a> {
     }
 
     fn parse(line: &'a str) -> Option<Self> {
-        let mut line = line.trim().split_whitespace();
+        let mut line = line.split_whitespace();
         let module = line.next()?;
         let name = line.next()?;
         Some(Self::new(module, name))

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -96,7 +96,6 @@ pub fn oops(oops: Oops<'_>) -> ! {
     )
     .draw(&mut target)
     .unwrap();
-    drop(target);
     drop(framebuf);
 
     let mk_writer = MakeTextWriter::new_at(

--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -315,7 +315,7 @@ fn disassembly<'a>(rip: usize, mk_writer: &'a impl MakeWriter<'a>) {
         // memory. whoopsie.
         let bytes = unsafe { core::slice::from_raw_parts(ptr as *const u8, 16) };
         let indent = if i == 0 { "> " } else { "  " };
-        let _ = write!(mk_writer.make_writer(), "{}{:016x}: ", indent, ptr).unwrap();
+        let _ = write!(mk_writer.make_writer(), "{}{:016x}: ", indent, ptr);
         match decoder.decode_slice(bytes) {
             Ok(inst) => {
                 let _ = writeln!(mk_writer.make_writer(), "{}", inst);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,11 @@ extern crate alloc;
 extern crate rlibc;
 
 pub mod arch;
+pub mod wasm;
 
 use core::fmt::Write;
 use hal_core::{boot::BootInfo, mem};
 use mycelium_alloc::buddy;
-
-mod wasm;
 
 #[cfg(test)]
 mod tests;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -34,7 +34,7 @@ pub struct Host {
 impl Host {
     // Create a new host for the given instance.
     // NOTE: The instance may not have been started yet.
-    fn new(instance: &wasmi::ModuleRef) -> Result<Self, wasmi::Error> {
+    pub fn new(instance: &wasmi::ModuleRef) -> Result<Self, wasmi::Error> {
         let memory = match instance.export_by_name("memory") {
             Some(wasmi::ExternVal::Memory(memory)) => memory,
             _ => {


### PR DESCRIPTION
Rust 1.61 added new clippy lints. This fixes them:

* f1a2e86 fix dead code warnings in wasm module
* 26d897e fix nop let
* f4a34bc remove meaningless drop
* cd4ed95 remove meaningless `trim()` before `split_whitespace()`
* 7a01ed7 fix clippy re-export lint