### PR TITLE
feat(async): implement task state transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "cordyceps",
  "futures-util",
  "loom",
+ "mycelium-bitfield",
  "mycelium-util",
  "mycotest",
  "pin-project",

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+mycelium-bitfield = { path = "../bitfield" }
 mycelium-util = { path = "../util" }
 mycotest = { path = "../mycotest", default-features = false }
 cordyceps = { path = "../cordyceps" }

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -21,8 +21,10 @@ package = "tracing"
 default_features = false
 git = "https://github.com/tokio-rs/tracing"
 
+[dev-dependencies]
+futures-util = "0.3"
+
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5.5", features = ["futures"] }
 tracing_01 = { package = "tracing", version = "0.1", default_features = false }
 tracing_subscriber_03 = { package = "tracing-subscriber", version = "0.3.11", features = ["fmt"] }
-futures-util = "0.3"

--- a/async/src/scheduler.rs
+++ b/async/src/scheduler.rs
@@ -269,13 +269,13 @@ mod tests {
             }
         });
 
-        dbg!(SCHEDULER.tick());
-
         std::thread::spawn(move || {
             chan.notify();
         });
 
-        dbg!(SCHEDULER.tick());
+        while dbg!(SCHEDULER.tick().completed) < 1 {
+            std::thread::yield_now();
+        }
 
         assert_eq!(COMPLETED.load(Ordering::SeqCst), 1);
     }

--- a/async/src/task.rs
+++ b/async/src/task.rs
@@ -121,7 +121,7 @@ impl<S: Schedule, F: Future> Task<S, F> {
         trace_task!(ptr, F, "wake_by_val");
 
         let this = non_null(ptr as *mut ()).cast::<Self>();
-        match this.as_ref().state().wake_by_val() {
+        match test_dbg!(this.as_ref().state().wake_by_val()) {
             OrDrop::Drop => drop(Box::from_raw(this.as_ptr())),
             OrDrop::Action(ScheduleAction::Enqueue) => {
                 // the task should be enqueued.

--- a/async/src/util.rs
+++ b/async/src/util.rs
@@ -40,7 +40,7 @@ macro_rules! test_trace {
 macro_rules! fmt_bits {
     ($self: expr, $f: expr, $has_states: ident, $($name: ident),+) => {
         $(
-            if $self.contains(Self::$name) {
+            if $self.is(Self::$name) {
                 if $has_states {
                     $f.write_str(" | ")?;
                 }

--- a/async/src/wait.rs
+++ b/async/src/wait.rs
@@ -3,14 +3,14 @@
 //! This module implements two types of structure for waiting: a [`WaitCell`],
 //! which stores a *single* waiting task, and a wait *queue*, which
 //! stores a queue of waiting tasks.
-mod cell;
+pub(crate) mod cell;
 pub use cell::WaitCell;
 
 use core::task::Poll;
 
 /// An error indicating that a [`WaitCell`] or queue was closed while attempting
 /// register a waiter.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Closed(());
 
 pub type WaitResult = Result<(), Closed>;

--- a/async/src/wait/cell.rs
+++ b/async/src/wait/cell.rs
@@ -62,10 +62,10 @@ impl WaitCell {
         // this is based on tokio's AtomicWaker synchronization strategy
         match test_dbg!(self.compare_exchange(State::WAITING, State::PARKING, Acquire)) {
             // someone else is notifying, so don't wait!
-            Err(actual) if test_dbg!(actual.contains(State::CLOSED)) => {
+            Err(actual) if test_dbg!(actual.is(State::CLOSED)) => {
                 return wait::closed();
             }
-            Err(actual) if test_dbg!(actual.contains(State::NOTIFYING)) => {
+            Err(actual) if test_dbg!(actual.is(State::NOTIFYING)) => {
                 waker.wake_by_ref();
                 crate::loom::hint::spin_loop();
                 return wait::notified();
@@ -111,7 +111,7 @@ impl WaitCell {
                     waker.wake();
                 }
 
-                if test_dbg!(state.contains(State::CLOSED)) {
+                if test_dbg!(state.is(State::CLOSED)) {
                     wait::closed()
                 } else {
                     wait::notified()
@@ -197,7 +197,7 @@ impl State {
     const NOTIFYING: Self = Self(0b10);
     const CLOSED: Self = Self(0b100);
 
-    fn contains(self, Self(state): Self) -> bool {
+    fn is(self, Self(state): Self) -> bool {
         self.0 & state == state
     }
 }


### PR DESCRIPTION
this branch adds a proper implementation of task state transitions to
the async crate's task system. right now, the set of state transitions
is fairly small, but this will become more complex if we add
`JoinHandle`s or a similar abstraction for awaiting a task's completion.
also, i added tests exercising `wake_by_val` wakeups, and, it turns out,
we were leaking tasks in this case. so that's fixed now.