### PR TITLE
feat(maitake): add`Clone`/`Drop` for `TaskRef`

### DIFF
--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -270,9 +270,7 @@ where
 
     #[inline(always)]
     unsafe fn schedule(this: TaskRef) {
-        this.0.cast::<Self>().as_ref()
-            .scheduler
-            .schedule(this);
+        this.0.cast::<Self>().as_ref().scheduler.schedule(this);
     }
 
     #[inline]

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -453,13 +453,20 @@ impl Header {
         Self {
             run_queue: mpsc_queue::Links::new_stub(),
             state: StateCell::new(),
-            vtable: &Vtable { poll: nop, deallocate: nop_deallocate },
+            vtable: &Vtable {
+                poll: nop,
+                deallocate: nop_deallocate,
+            },
         }
     }
 
     unsafe fn drop_slow(this: NonNull<Self>) {
         #[cfg(debug_assertions)]
-        let refs = this.as_ref().state.load(core::sync::atomic::Ordering::Acquire).ref_count();
+        let refs = this
+            .as_ref()
+            .state
+            .load(core::sync::atomic::Ordering::Acquire)
+            .ref_count();
         debug_assert_eq!(refs, 0, "tried to deallocate a task with references!");
 
         let deallocate = this.as_ref().vtable.deallocate;

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -426,7 +426,7 @@ impl Drop for TaskRef {
         }
 
         unsafe {
-            Header::drop_slow(self.0);
+            Header::deallocate(self.0);
         }
     }
 }
@@ -460,7 +460,7 @@ impl Header {
         }
     }
 
-    unsafe fn drop_slow(this: NonNull<Self>) {
+    unsafe fn deallocate(this: NonNull<Self>) {
         #[cfg(debug_assertions)]
         let refs = this
             .as_ref()

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -15,6 +15,9 @@ pub use core::task::{Context, Poll, Waker};
 mod state;
 mod storage;
 
+#[cfg(test)]
+mod tests;
+
 use crate::{
     loom::cell::UnsafeCell,
     scheduler::Schedule,

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -123,8 +123,7 @@ impl StateCell {
                 *state = test_dbg!(next_state);
                 return OrDrop::Action(ScheduleAction::Enqueue);
             }
-
-            let next_state = test_dbg!(next_state.drop_ref());
+            
             *state = next_state;
 
             if next_state.ref_count() == 0 {

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -123,7 +123,7 @@ impl StateCell {
                 *state = test_dbg!(next_state);
                 return OrDrop::Action(ScheduleAction::Enqueue);
             }
-            
+
             *state = next_state;
 
             if next_state.ref_count() == 0 {

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -1,0 +1,52 @@
+#[cfg(loom)]
+mod loom {
+    use crate::task::*;
+    use crate::loom::{self, alloc::Track};
+
+    #[derive(Clone)]
+    struct NopScheduler;
+
+    impl crate::scheduler::Schedule for NopScheduler {
+        fn schedule(&self, task: TaskRef) {
+            unimplemented!("nop scheduler should not actually schedule tasks (tried to schedule {task:?})")
+        }
+    }
+
+    #[test]
+    fn taskref_deallocates() {
+        loom::model(|| {
+            let track = Track::new(());
+            let task = TaskRef::new(NopScheduler, async move {
+                drop(track);
+            });
+
+            // if the task is not deallocated by dropping the `TaskRef`, the
+            // `Track` will be leaked.
+            drop(task);
+        });
+    }
+
+    #[test]
+    fn taskref_clones_deallocate() {
+        loom::model(|| {
+            let track = Track::new(());
+            let task = TaskRef::new(NopScheduler, async move {
+                drop(track);
+            });
+
+            let mut threads = (0..2).map(|_| {
+                let task = task.clone();
+                loom::thread::spawn(move || {
+                    drop(task);
+                })
+            }).collect::<Vec<_>>();
+
+            drop(task);
+
+            for thread in threads.drain(..) {
+                thread.join().unwrap();
+            }
+
+        });
+    }
+}

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -1,14 +1,16 @@
 #[cfg(loom)]
 mod loom {
-    use crate::task::*;
     use crate::loom::{self, alloc::Track};
+    use crate::task::*;
 
     #[derive(Clone)]
     struct NopScheduler;
 
     impl crate::scheduler::Schedule for NopScheduler {
         fn schedule(&self, task: TaskRef) {
-            unimplemented!("nop scheduler should not actually schedule tasks (tried to schedule {task:?})")
+            unimplemented!(
+                "nop scheduler should not actually schedule tasks (tried to schedule {task:?})"
+            )
         }
     }
 
@@ -34,19 +36,20 @@ mod loom {
                 drop(track);
             });
 
-            let mut threads = (0..2).map(|_| {
-                let task = task.clone();
-                loom::thread::spawn(move || {
-                    drop(task);
+            let mut threads = (0..2)
+                .map(|_| {
+                    let task = task.clone();
+                    loom::thread::spawn(move || {
+                        drop(task);
+                    })
                 })
-            }).collect::<Vec<_>>();
+                .collect::<Vec<_>>();
 
             drop(task);
 
             for thread in threads.drain(..) {
                 thread.join().unwrap();
             }
-
         });
     }
 }


### PR DESCRIPTION
these increment/decrement the task's reference count and can drop the
task if the dropped `TaskRef` is the last ref.

Will be needed for #184

Depends on #188

Signed-off-by: Eliza Weisman <eliza@buoyant.io>