### PR TITLE
feat(maitake): add `WaitQueue`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,9 @@ jobs:
       run: rustup show
     - uses: actions/checkout@v2
     - name: run tests
-      run: cargo test -p maitake --no-default-features
+      # don't run doctests with `no-default-features`, as some of them
+      # require liballoc.
+      run: cargo test -p maitake --no-default-features --tests --lib 
 
   # run loom tests
   maitake_loom:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "pin-project",
  "tracing 0.1.34",
  "tracing 0.2.0",
+ "tracing-subscriber 0.3.0",
  "tracing-subscriber 0.3.11",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
 name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,8 @@ dependencies = [
  "generator",
  "pin-utils",
  "scoped-tls",
+ "serde",
+ "serde_json",
  "tracing 0.1.34",
  "tracing-subscriber 0.3.11",
 ]
@@ -894,10 +902,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "serde"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/bin/loom
+++ b/bin/loom
@@ -3,7 +3,7 @@
 set -x
 
 RUSTFLAGS="--cfg loom ${RUSTFLAGS}" \
-LOOM_LOG="${LOOM_LOG:-info}" \
+LOOM_LOG="${LOOM_LOG:-debug}" \
 LOOM_LOCATION=true \
 cargo test \
     --profile loom \

--- a/bitfield/src/bitfield.rs
+++ b/bitfield/src/bitfield.rs
@@ -234,11 +234,11 @@ macro_rules! bitfield {
         #[automatically_derived]
         impl core::fmt::Debug for $Name {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                if f.alternate() {
-                    f.debug_tuple(stringify!($Name)).field(&format_args!("{}", self)).finish()
-                } else {
-                    f.debug_tuple(stringify!($Name)).field(&format_args!("{:#b}", self.0)).finish()
-                }
+                let mut dbg = f.debug_struct(stringify!($Name));
+                $(
+                    dbg.field(stringify!($Field), &self.get(Self::$Field));
+                )+
+                dbg.finish()
 
             }
         }

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -49,7 +49,7 @@ git = "https://github.com/tokio-rs/tracing"
 futures-util = "0.3"
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.5.5", features = ["futures"] }
+loom = { version = "0.5.5", features = ["futures", "checkpoint"] }
 tracing_01 = { package = "tracing", version = "0.1", default_features = false }
 tracing_subscriber_03 = { package = "tracing-subscriber", version = "0.3.11", features = ["fmt"] }
 

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -48,6 +48,10 @@ git = "https://github.com/tokio-rs/tracing"
 [dev-dependencies]
 futures-util = "0.3"
 
+
+[target.'cfg(not(loom))'.dev-dependencies]
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", features = ["ansi", "fmt"] }
+
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5.5", features = ["futures", "checkpoint"] }
 tracing_01 = { package = "tracing", version = "0.1", default_features = false }

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -48,7 +48,6 @@ git = "https://github.com/tokio-rs/tracing"
 [dev-dependencies]
 futures-util = "0.3"
 
-
 [target.'cfg(not(loom))'.dev-dependencies]
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", features = ["ansi", "fmt"] }
 

--- a/maitake/src/lib.rs
+++ b/maitake/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, doc = include_str!("../README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
-#![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
+#![cfg_attr(docsrs, doc(cfg_hide(docsrs, loom)))]
 #![cfg_attr(not(test), no_std)]
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/maitake/src/loom.rs
+++ b/maitake/src/loom.rs
@@ -4,7 +4,7 @@ pub(crate) use self::inner::*;
 #[cfg(loom)]
 mod inner {
     #![allow(dead_code)]
-    
+
     #[cfg(feature = "alloc")]
     pub(crate) use loom::alloc;
     pub(crate) use loom::{cell, future, hint, model, thread};

--- a/maitake/src/scheduler/tests.rs
+++ b/maitake/src/scheduler/tests.rs
@@ -49,6 +49,8 @@ mod alloc {
         static SCHEDULER: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
         static IT_WORKED: AtomicBool = AtomicBool::new(false);
 
+        crate::util::trace_init();
+
         SCHEDULER.spawn(async {
             Yield::once().await;
             IT_WORKED.store(true, Ordering::Release);
@@ -69,6 +71,7 @@ mod alloc {
 
         const TASKS: usize = 10;
 
+        crate::util::trace_init();
         for _ in 0..TASKS {
             SCHEDULER.spawn(async {
                 Yield::once().await;
@@ -89,6 +92,7 @@ mod alloc {
         static SCHEDULER: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+        crate::util::trace_init();
         let chan = Chan::new(1);
 
         SCHEDULER.spawn({
@@ -114,6 +118,7 @@ mod alloc {
         static SCHEDULER: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+        crate::util::trace_init();
         let chan = Chan::new(1);
 
         SCHEDULER.spawn({
@@ -141,6 +146,8 @@ mod alloc {
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
         const TASKS: usize = 10;
+
+        crate::util::trace_init();
 
         for i in 0..TASKS {
             SCHEDULER.spawn(async {
@@ -196,6 +203,8 @@ mod custom_storage {
         static SCHEDULER: StaticScheduler = unsafe { StaticScheduler::new_with_static_stub(&STUB) };
         static IT_WORKED: AtomicBool = AtomicBool::new(false);
 
+        crate::util::trace_init();
+
         MyBoxTask::spawn(&SCHEDULER, async {
             Yield::once().await;
             IT_WORKED.store(true, Ordering::Release);
@@ -216,6 +225,8 @@ mod custom_storage {
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
         const TASKS: usize = 10;
+
+        crate::util::trace_init();
 
         for _ in 0..TASKS {
             MyBoxTask::spawn(&SCHEDULER, async {
@@ -238,6 +249,7 @@ mod custom_storage {
         static SCHEDULER: StaticScheduler = unsafe { StaticScheduler::new_with_static_stub(&STUB) };
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+        crate::util::trace_init();
         let chan = Chan::new(1);
 
         MyBoxTask::spawn(&SCHEDULER, {
@@ -264,6 +276,7 @@ mod custom_storage {
         static SCHEDULER: StaticScheduler = unsafe { StaticScheduler::new_with_static_stub(&STUB) };
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+        crate::util::trace_init();
         let chan = Chan::new(1);
 
         MyBoxTask::spawn(&SCHEDULER, {
@@ -291,6 +304,7 @@ mod custom_storage {
         static SCHEDULER: StaticScheduler = unsafe { StaticScheduler::new_with_static_stub(&STUB) };
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
+        crate::util::trace_init();
         const TASKS: usize = 10;
 
         for i in 0..TASKS {

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -18,7 +18,12 @@ macro_rules! test_dbg {
     ($e:expr) => {
         match $e {
             e => {
-                crate::util::tracing::debug!("{} = {:?}", stringify!($e), &e);
+                crate::util::tracing::debug!(
+                    location = %core::panic::Location::caller(),
+                    "{} = {:?}",
+                    stringify!($e),
+                    &e
+                );
                 e
             }
         }
@@ -33,7 +38,10 @@ macro_rules! test_trace {
 #[cfg(test)]
 macro_rules! test_trace {
     ($($args:tt)+) => {
-        crate::util::tracing::debug!($($args)+);
+        crate::util::tracing::debug!(
+            location = %core::panic::Location::caller(),
+            $($args)+
+        );
     };
 }
 

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -95,3 +95,12 @@ pub(crate) unsafe fn non_null<T>(ptr: *mut T) -> NonNull<T> {
 unsafe fn non_null<T>(ptr: *mut T) -> NonNull<T> {
     NonNull::new_unchecked(ptr)
 }
+
+#[cfg(all(test, not(loom)))]
+pub(crate) fn trace_init() {
+    use tracing_subscriber::filter::LevelFilter;
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::TRACE)
+        .with_test_writer()
+        .try_init();
+}

--- a/maitake/src/wait.rs
+++ b/maitake/src/wait.rs
@@ -4,7 +4,8 @@
 //! which stores a *single* waiting task, and a wait *queue*, which
 //! stores a queue of waiting tasks.
 pub(crate) mod cell;
-pub use cell::WaitCell;
+mod queue;
+pub use self::{cell::WaitCell, queue::WaitQueue};
 
 use core::task::Poll;
 

--- a/maitake/src/wait.rs
+++ b/maitake/src/wait.rs
@@ -11,7 +11,7 @@ use core::task::Poll;
 
 /// An error indicating that a [`WaitCell`] or queue was closed while attempting
 /// register a waiter.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Closed(());
 
 pub type WaitResult = Result<(), Closed>;

--- a/maitake/src/wait.rs
+++ b/maitake/src/wait.rs
@@ -1,16 +1,19 @@
 //! Waiter cells and queues to allow tasks to wait for notifications.
 //!
 //! This module implements two types of structure for waiting: a [`WaitCell`],
-//! which stores a *single* waiting task, and a wait *queue*, which
+//! which stores a *single* waiting task, and a [`WaitQueue`], which
 //! stores a queue of waiting tasks.
 pub(crate) mod cell;
-mod queue;
-pub use self::{cell::WaitCell, queue::WaitQueue};
+pub mod queue;
+
+pub use self::cell::WaitCell;
+#[doc(inline)]
+pub use self::queue::WaitQueue;
 
 use core::task::Poll;
 
-/// An error indicating that a [`WaitCell`] or queue was closed while attempting
-/// register a waiter.
+/// An error indicating that a [`WaitCell`] or [`WaitQueue`] was closed while
+/// attempting register a waiter.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Closed(());
 

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -326,6 +326,7 @@ impl WaitQueue {
         state = self.load();
 
         if let Some(waker) = self.wake_locked(&mut *queue, state) {
+            drop(queue);
             waker.wake();
         }
     }
@@ -463,7 +464,7 @@ impl WaitQueue {
         if test_dbg!(state) != State::Waiting {
             // if there are no longer any queued tasks, try to store the
             // wakeup in the queue and bail.
-            if let Err(actual) = self.compare_exchange(curr, curr.with_state(State::Waiting)) {
+            if let Err(actual) = self.compare_exchange(curr, curr.with_state(State::Woken)) {
                 debug_assert!(actual.get(QueueState::STATE) != State::Waiting);
                 self.store(actual.with_state(State::Woken));
             }

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -1,10 +1,13 @@
 use crate::{
     loom::{
         cell::UnsafeCell,
-        sync::atomic::{
+        sync::{
+            spin::Mutex,
+            atomic::{
             AtomicUsize,
             Ordering::*,
         },
+    }
     },
     util,
     wait::{self, WaitResult},
@@ -22,7 +25,7 @@ use core::{
     mem,
 };
 use mycelium_bitfield::{FromBits, bitfield};
-use mycelium_util::sync::{spin::Mutex, CachePadded};
+use mycelium_util::sync::CachePadded;
 #[cfg(test)]
 use mycelium_util::fmt;
 use pin_project::{pin_project, pinned_drop};

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -1,0 +1,157 @@
+use crate::{
+    loom::{
+        cell::UnsafeCell,
+        sync::atomic::{
+            AtomicUsize,
+            Ordering::{self, *},
+        },
+    },
+    util,
+};
+use cordyceps::{
+    list::{self, List},
+    Linked,
+};
+use core::{marker::PhantomPinned, ptr::NonNull, task::Waker};
+use mycelium_util::sync::{spin::Mutex, CachePadded};
+
+/// A queue of [`Waker`]s implemented using an [intrusive singly-linked list][ilist].
+///
+/// The *[intrusive]* aspect of this list is important, as it means that it does
+/// not allocate memory. Instead, nodes in the linked list are stored in the
+/// futures of tasks trying to wait for capacity. This means that it is not
+/// necessary to allocate any heap memory for each task waiting to be notified.
+///
+/// However, the intrusive linked list introduces one new danger: because
+/// futures can be *cancelled*, and the linked list nodes live within the
+/// futures trying to wait for channel capacity, we *must* ensure that the node
+/// is unlinked from the list before dropping a cancelled future. Failure to do
+/// so would result in the list containing dangling pointers. Therefore, we must
+/// use a *doubly-linked* list, so that nodes can edit both the previous and
+/// next node when they have to remove themselves. This is kind of a bummer, as
+/// it means we can't use something nice like this [intrusive queue by Dmitry
+/// Vyukov][2], and there are not really practical designs for lock-free
+/// doubly-linked lists that don't rely on some kind of deferred reclamation
+/// scheme such as hazard pointers or QSBR.
+///
+/// Instead, we just stick a [`Mutex`] around the linked list, which must be
+/// acquired to pop nodes from it, or for nodes to remove themselves when
+/// futures are cancelled. This is a bit sad, but the critical sections for this
+/// mutex are short enough that we still get pretty good performance despite it.
+///
+/// [`Waker`]: core::task::Waker
+/// [ilist]: cordyceps::List
+/// [intrusive]: https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/fbl_containers_guide/introduction
+/// [2]: https://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
+#[derive(Debug)]
+pub struct WaitQueue {
+    /// The wait queue's state variable.
+    ///
+    /// The queue is always in one of the following states:
+    ///
+    /// - [`EMPTY`]: No waiters are queued, and there is no pending notification.
+    ///   Waiting while the queue is in this state will enqueue the waiter;
+    ///   notifying while in this state will store a pending notification in the
+    ///   queue, transitioning to the `WAKING` state.
+    ///
+    /// - [`WAITING`]: There are one or more waiters in the queue. Waiting while
+    ///   the queue is in this state will not transition the state. Waking while
+    ///   in this state will wake the first waiter in the queue; if this empties
+    ///   the queue, then the queue will transition to the `EMPTY` state.
+    ///
+    /// - [`WAKING`]: The queue has a stored notification. Waiting while the queue
+    ///   is in this state will consume the pending notification *without*
+    ///   enqueueing the waiter and transition the queue to the `EMPTY` state.
+    ///   Waking while in this state will leave the queue in this state.
+    ///
+    /// - [`CLOSED`]: The queue is closed. Waiting while in this state will return
+    ///   [`WaitResult::Closed`] without transitioning the queue's state.
+    state: CachePadded<AtomicUsize>,
+
+    /// The linked list of waiters.
+    ///
+    /// # Safety
+    ///
+    /// This is protected by a mutex; the mutex *must* be acquired when
+    /// manipulating the linked list, OR when manipulating waiter nodes that may
+    /// be linked into the list. If a node is known to not be linked, it is safe
+    /// to modify that node (such as by setting or unsetting its
+    /// `Waker`/`Thread`) without holding the lock; otherwise, it may be
+    /// modified through the list, so the lock must be held when modifying the
+    /// node.
+    ///
+    /// A spinlock is used on `no_std` platforms; [`std::sync::Mutex`] or
+    /// `parking_lot::Mutex` are used when the standard library is available
+    /// (depending on feature flags).
+    list: Mutex<List<Waiter>>,
+}
+
+/// A waiter node which may be linked into a wait queue.
+#[derive(Debug)]
+#[repr(C)]
+struct Waiter {
+    /// The intrusive linked list node.
+    ///
+    /// This *must* be the first field in the struct in order for the `Linked`
+    /// implementation to be sound.
+    node: UnsafeCell<Node>,
+
+    /// The waiter's state variable.
+    ///
+    /// A waiter is always in one of the following states:
+    ///
+    /// - [`EMPTY`]: The waiter is not linked in the queue, and does not have a
+    ///   `Thread`/`Waker`.
+    ///
+    /// - [`WAITING`]: The waiter is linked in the queue and has a
+    ///   `Thread`/`Waker`.
+    ///
+    /// - [`WAKING`]: The waiter has been notified by the wait queue. If it is in
+    ///   this state, it is *not* linked into the queue, and does not have a
+    ///   `Thread`/`Waker`.
+    ///
+    /// - [`WAKING`]: The waiter has been notified because the wait queue closed.
+    ///   If it is in this state, it is *not* linked into the queue, and does
+    ///   not have a `Thread`/`Waker`.
+    ///
+    /// This may be inspected without holding the lock; it can be used to
+    /// determine whether the lock must be acquired.
+    state: CachePadded<AtomicUsize>,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+struct Node {
+    /// Intrusive linked list pointers.
+    ///
+    /// # Safety
+    ///
+    /// This *must* be the first field in the struct in order for the `Linked`
+    /// impl to be sound.
+    links: list::Links<Waiter>,
+
+    /// The node's waker
+    waker: Option<Waker>,
+
+    // This type is !Unpin due to the heuristic from:
+    // <https://github.com/rust-lang/rust/pull/82834>
+    _pin: PhantomPinned,
+}
+
+unsafe impl Linked<list::Links<Waiter>> for Waiter {
+    type Handle = NonNull<Waiter>;
+
+    fn into_ptr(r: Self::Handle) -> NonNull<Self> {
+        r
+    }
+
+    unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+        ptr
+    }
+
+    unsafe fn links(ptr: NonNull<Self>) -> NonNull<list::Links<Waiter>> {
+        (*ptr.as_ptr())
+            .node
+            .with_mut(|node| util::non_null(node).cast::<list::Links<Waiter>>())
+    }
+}

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -275,6 +275,11 @@ impl WaitQueue {
             let waker = Waiter::wake(node, &mut queue, Wakeup::All);
             waker.wake()
         }
+
+        // now that the queue has been drained, transition to the empty state,
+        // and increment the wake_all count.
+        let next_state = QueueState::new().with_state(State::Empty).with(QueueState::WAKE_ALLS, state.get(QueueState::WAKE_ALLS) + 1);
+        self.compare_exchange(state, next_state).expect("state should not have transitioned while locked");
     }
 
 

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -175,9 +175,6 @@ struct Node {
     /// The node's waker
     waker: Wakeup,
 
-    // /// Optional user data.
-    // data: Option<T>,
-
     // This type is !Unpin due to the heuristic from:
     // <https://github.com/rust-lang/rust/pull/82834>
     _pin: PhantomPinned,
@@ -495,7 +492,7 @@ impl Waiter {
     ///
     /// # Safety
     ///
-    /// This is only safe to call while the list is locked. The dummy `_list`
+    /// This is only safe to call while the list is locked. The `list`
     /// parameter ensures this method is only called while holding the lock, so
     /// this can be safe.
     ///

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -6,14 +6,25 @@ use crate::{
             Ordering::{self, *},
         },
     },
-    util,
+    util::{self, tracing},
+    wait::{self, WaitResult},
 };
 use cordyceps::{
     list::{self, List},
     Linked,
 };
-use core::{marker::PhantomPinned, ptr::NonNull, task::Waker};
-use mycelium_util::sync::{spin::Mutex, CachePadded};
+use core::{
+    future::Future,
+    marker::PhantomPinned,
+    pin::Pin,
+    ptr::NonNull,
+    task::{Context, Poll, Waker},
+};
+use mycelium_util::{
+    fmt,
+    sync::{spin::Mutex, CachePadded},
+};
+use pin_project::{pin_project, pinned_drop};
 
 /// A queue of [`Waker`]s implemented using an [intrusive singly-linked list][ilist].
 ///
@@ -86,6 +97,31 @@ pub struct WaitQueue {
     list: Mutex<List<Waiter>>,
 }
 
+/// Future returned from [`WaitQueue::wait()`].
+///
+/// This future is fused, so once it has completed, any future calls to poll
+/// will immediately return `Poll::Ready`.
+#[derive(Debug)]
+#[pin_project(PinnedDrop)]
+pub struct Wait<'a> {
+    /// The `WaitQueue` being received on.
+    q: &'a WaitQueue,
+
+    /// The future's state.
+    state: State,
+
+    /// Entry in the wait queue.
+    #[pin]
+    waiter: Waiter,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum State {
+    Start,
+    Waiting,
+    Done(WaitResult),
+}
+
 /// A waiter node which may be linked into a wait queue.
 #[derive(Debug)]
 #[repr(C)]
@@ -138,6 +174,137 @@ struct Node {
     _pin: PhantomPinned,
 }
 
+const EMPTY: usize = 0;
+const WAITING: usize = 1;
+const WAKING: usize = 2;
+const CLOSED: usize = 3;
+
+// === impl WaitQueue ===
+
+impl WaitQueue {
+    #[inline(always)]
+    fn start_wait(&self, node: Pin<&mut Waiter>, cx: &mut Context<'_>) -> Poll<WaitResult> {
+        // Optimistically, acquire a stored notification before trying to lock
+        // the wait list.
+        match test_dbg!(self.state.compare_exchange(WAKING, EMPTY, SeqCst, SeqCst)) {
+            Ok(_) => return wait::notified(),
+            Err(CLOSED) => return wait::closed(),
+            Err(_) => {}
+        };
+
+        // Slow path: the queue is not closed, and we failed to consume a stored
+        // notification. We need to acquire the lock and enqueue the waiter.
+        self.start_wait_slow(node, cx)
+    }
+
+    /// Slow path of `start_wait`: acquires the linked list lock, and adds the
+    /// waiter to the queue.
+    #[cold]
+    #[inline(never)]
+    fn start_wait_slow(&self, node: Pin<&mut Waiter>, cx: &mut Context<'_>) -> Poll<WaitResult> {
+        // There are no queued notifications to consume, and the queue is
+        // still open. Therefore, it's time to actually push the waiter to
+        // the queue...finally lol :)
+
+        // Grab the lock...
+        let mut list = self.list.lock();
+        // Reload the queue's state, as it may have changed while we were
+        // waiting to lock the linked list.
+        let mut state = self.state.load(Acquire);
+
+        loop {
+            match test_dbg!(state) {
+                // The queue is empty: transition the state to WAITING, as we
+                // are adding a waiter.
+                EMPTY => {
+                    match test_dbg!(self
+                        .state
+                        .compare_exchange_weak(EMPTY, WAITING, SeqCst, SeqCst))
+                    {
+                        Ok(_) => break,
+                        Err(actual) => {
+                            debug_assert!(actual == EMPTY || actual == WAKING || actual == CLOSED);
+                            state = actual;
+                        }
+                    }
+                }
+
+                // The queue was woken while we were waiting to acquire the
+                // lock. Attempt to consume the wakeup.
+                WAKING => {
+                    match test_dbg!(self
+                        .state
+                        .compare_exchange_weak(WAKING, EMPTY, SeqCst, SeqCst))
+                    {
+                        // Consumed the wakeup!
+                        Ok(_) => return wait::notified(),
+                        Err(actual) => {
+                            debug_assert!(actual == WAKING || actual == EMPTY || actual == CLOSED);
+                            state = actual;
+                        }
+                    }
+                }
+
+                // The queue closed while we were waiting to acquire the lock;
+                // we're done here!
+                CLOSED => return wait::closed(),
+
+                // The queue is already in the WAITING state, so we don't need
+                // to mess with it.
+                _state => {
+                    debug_assert_eq!(_state, WAITING,
+                        "start_wait_slow: unexpected state value {:?} (expected WAITING). this is a bug!",
+                        _state,
+                    );
+                    break;
+                }
+            }
+        }
+
+        // Time to wait! Store the waiter in the node, advance the node's state
+        // to Waiting, and add it to the queue.
+
+        node.with_node(&mut *list, |node| {
+            let _prev = node.waker.replace(cx.waker().clone());
+            debug_assert!(
+                _prev.is_none(),
+                "start_wait_slow: called with a node that already had a waiter!"
+            );
+        });
+
+        let _prev_state = test_dbg!(node.state.swap(WAITING, Release));
+        debug_assert!(
+            _prev_state == EMPTY || _prev_state == WAKING,
+            "start_wait_slow: called with a node that was not empty ({}) or woken ({})! actual={}",
+            EMPTY,
+            WAKING,
+            _prev_state,
+        );
+        list.push_front(ptr(node));
+
+        Poll::Pending
+    }
+}
+
+// === impl Waiter ===
+
+impl Waiter {
+    /// # Safety
+    ///
+    /// This is only safe to call while the list is locked. The dummy `_list`
+    /// parameter ensures this method is only called while holding the lock, so
+    /// this can be safe.
+    #[inline(always)]
+    #[cfg_attr(loom, track_caller)]
+    fn with_node<T>(&self, _list: &mut List<Self>, f: impl FnOnce(&mut Node) -> T) -> T {
+        self.node.with_mut(|node| unsafe {
+            // Safety: the dummy `_list` argument ensures that the caller has
+            // the right to mutate the list (e.g. the list is locked).
+            f(&mut *node)
+        })
+    }
+}
+
 unsafe impl Linked<list::Links<Waiter>> for Waiter {
     type Handle = NonNull<Waiter>;
 
@@ -154,4 +321,56 @@ unsafe impl Linked<list::Links<Waiter>> for Waiter {
             .node
             .with_mut(|node| util::non_null(node).cast::<list::Links<Waiter>>())
     }
+}
+
+// === impl Wait ===
+
+impl Future for Wait<'_> {
+    type Output = Result<(), wait::Closed>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
+        let ptr = ptr(this.waiter);
+
+        tracing::trace!(self = fmt::ptr(ptr), state = ?this.state, "Wait::poll");
+
+        loop {
+            let this = self.as_mut().project();
+
+            match *this.state {
+                State::Start => match this.q.start_wait(this.waiter, cx) {
+                    Poll::Ready(x) => {
+                        *this.state = State::Done(x);
+                        return Poll::Ready(x);
+                    }
+                    Poll::Pending => {
+                        *this.state = State::Waiting;
+                        return Poll::Pending;
+                    }
+                },
+                State::Waiting => todo!(),
+                State::Done(res) => return Poll::Ready(res),
+            }
+        }
+    }
+}
+
+#[pinned_drop]
+impl PinnedDrop for Wait<'_> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        let state = this.state;
+        let ptr = ptr(this.waiter);
+
+        tracing::trace!(self = fmt::ptr(ptr), ?state, "Wait::drop");
+        if *state == State::Waiting {
+            unsafe {
+                this.q.list.lock().remove(ptr);
+            }
+        }
+    }
+}
+
+fn ptr(pin: Pin<&mut Waiter>) -> NonNull<Waiter> {
+    pin.as_ref().get_ref().into()
 }

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -288,25 +288,29 @@ enum State {
     /// Waiting while the queue is in this state will enqueue the waiter;
     /// notifying while in this state will store a pending notification in the
     /// queue, transitioning to [`State::Woken`].
-    Empty = 0,
+    Empty = 0b00,
 
     /// There are one or more waiters in the queue. Waiting while
     /// the queue is in this state will not transition the state. Waking while
     /// in this state will wake the first waiter in the queue; if this empties
     /// the queue, then the queue will transition to [`State::Empty`].
-    Waiting = 1,
+    Waiting = 0b01,
 
     /// The queue has a stored notification. Waiting while the queue
     /// is in this state will consume the pending notification *without*
     /// enqueueing the waiter and transition the queue to [`State::Empty`].
     /// Waking while in this state will leave the queue in this state.
-    Woken = 2,
+    Woken = 0b10,
 
     /// The queue is closed. Waiting while in this state will return
     /// [`Closed`] without transitioning the queue's state.
     ///
+    /// *Note*: This *must* correspond to all state bits being set, as it's set
+    /// via a [`fetch_or`].
+    ///
     /// [`Closed`]: crate::wait::Closed
-    Closed = 3,
+    /// [`fetch_or`]: core::sync::atomic::AtomicUsize::fetch_or
+    Closed = 0b11,
 }
 
 impl QueueState {

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -3,7 +3,7 @@ use crate::{
         cell::UnsafeCell,
         sync::atomic::{
             AtomicUsize,
-            Ordering::{self, *},
+            Ordering::*,
         },
     },
     util,
@@ -22,10 +22,9 @@ use core::{
     mem,
 };
 use mycelium_bitfield::{FromBits, bitfield};
-use mycelium_util::{
-    fmt,
-    sync::{spin::Mutex, CachePadded},
-};
+use mycelium_util::sync::{spin::Mutex, CachePadded};
+#[cfg(test)]
+use mycelium_util::fmt;
 use pin_project::{pin_project, pinned_drop};
 
 #[cfg(test)]

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -24,7 +24,30 @@ mod loom {
     }
 
     #[test]
-    fn wake_many() {
+    fn wake_all_sequential() {
+        loom::model(|| {
+            let q = Arc::new(WaitQueue::new());
+            let wait1 = q.wait();
+            let wait2 = q.wait();
+
+            let thread = thread::spawn({
+                let q = q.clone();
+                move || {
+                    q.wake_all();
+                }
+            });
+
+            future::block_on(async {
+                wait1.await.unwrap();
+                wait2.await.unwrap();
+            });
+
+            thread.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn wake_one_many() {
         loom::model(|| {
             let q = Arc::new(WaitQueue::new());
 

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -256,7 +256,7 @@ mod loom {
 
     #[test]
     fn drop_wait_future() {
-        use futures::future::poll_fn;
+        use futures_util::future::poll_fn;
         use std::future::Future;
         use std::task::Poll;
 
@@ -280,7 +280,7 @@ mod loom {
             let thread2 = thread::spawn({
                 let q = q.clone();
                 move || {
-                    block_on(async {
+                    future::block_on(async {
                         q.wait().await.unwrap();
                         // Trigger second notification
                         q.wake();

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+#[cfg(loom)]
+mod loom {
+    use super::*;
+    use crate::loom::{self, sync::Arc, future, thread};
+
+    #[test]
+    fn wake_one() {
+        loom::model(|| {
+            let q = Arc::new(WaitQueue::new());
+            let thread = thread::spawn({
+                let q = q.clone();
+                move || {
+                    future::block_on(async {
+                        q.wait().await.expect("queue must not be closed");
+                    });
+                }
+            });
+
+            q.wake();
+            thread.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn wake_many() {
+        loom::model(|| {
+            let q = Arc::new(WaitQueue::new());
+
+            fn thread(q: &Arc<WaitQueue>) -> thread::JoinHandle<()> {
+                let q = q.clone();
+                thread::spawn(move || {
+                    future::block_on(async {
+                        q.wait().await.expect("queue must not be closed");
+                        q.wake();
+                    })
+                })
+            }
+
+            q.wake();
+
+            let thread1 = thread(&q);
+            let thread2 = thread(&q);
+
+            thread1.join().unwrap();
+            thread2.join().unwrap();
+
+            future::block_on(async {
+                q.wait().await.expect("queue must not be closed");
+            });
+        });
+    }
+}

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -41,7 +41,7 @@ mod alloc {
     }
 
     #[test]
-    fn close_on_drop() {
+    fn close() {
         crate::util::trace_init();
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
@@ -64,7 +64,7 @@ mod alloc {
         assert_eq!(COMPLETED.load(Ordering::SeqCst), 0);
         assert!(!tick.has_remaining);
 
-        drop(q);
+        q.close();
 
         let tick = scheduler.tick();
 
@@ -176,7 +176,7 @@ mod loom {
     }
 
     #[test]
-    fn wake_on_drop() {
+    fn wake_close() {
         use alloc::sync::Arc;
 
         loom::model(|| {
@@ -189,7 +189,7 @@ mod loom {
             let thread2 =
                 thread::spawn(move || future::block_on(wait2).expect_err("wait2 must be canceled"));
 
-            drop(q);
+            q.close();
 
             thread1.join().unwrap();
             thread2.join().unwrap();

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -47,6 +47,44 @@ mod loom {
     }
 
     #[test]
+    fn wake_all_concurrent() {
+        use alloc::sync::Arc;
+        
+        loom::model(|| {
+            let q = Arc::new(WaitQueue::new());
+            let wait1 = q.wait_owned();
+            let wait2 = q.wait_owned();
+
+            let thread1 = thread::spawn(move || { future::block_on(wait1).expect("wait1 must not fail") });
+            let thread2 = thread::spawn(move || { future::block_on(wait2).expect("wait2 must not fail") });
+
+            q.wake_all();
+
+            thread1.join().unwrap();
+            thread2.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn wake_on_drop() {
+        use alloc::sync::Arc;
+
+        loom::model(|| {
+            let q = Arc::new(WaitQueue::new());
+            let wait1 = q.wait_owned();
+            let wait2 = q.wait_owned();
+
+            let thread1 = thread::spawn(move || { future::block_on(wait1).expect_err("wait1 must be canceled") });
+            let thread2 = thread::spawn(move || { future::block_on(wait2).expect_err("wait2 must be canceled") });
+
+            drop(q);
+
+            thread1.join().unwrap();
+            thread2.join().unwrap();
+        });
+    }
+
+    #[test]
     fn wake_one_many() {
         loom::model(|| {
             let q = Arc::new(WaitQueue::new());

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[cfg(loom)]
 mod loom {
     use super::*;
-    use crate::loom::{self, sync::Arc, future, thread};
+    use crate::loom::{self, future, sync::Arc, thread};
 
     #[test]
     fn wake_one() {
@@ -49,14 +49,16 @@ mod loom {
     #[test]
     fn wake_all_concurrent() {
         use alloc::sync::Arc;
-        
+
         loom::model(|| {
             let q = Arc::new(WaitQueue::new());
             let wait1 = q.wait_owned();
             let wait2 = q.wait_owned();
 
-            let thread1 = thread::spawn(move || { future::block_on(wait1).expect("wait1 must not fail") });
-            let thread2 = thread::spawn(move || { future::block_on(wait2).expect("wait2 must not fail") });
+            let thread1 =
+                thread::spawn(move || future::block_on(wait1).expect("wait1 must not fail"));
+            let thread2 =
+                thread::spawn(move || future::block_on(wait2).expect("wait2 must not fail"));
 
             q.wake_all();
 
@@ -74,8 +76,10 @@ mod loom {
             let wait1 = q.wait_owned();
             let wait2 = q.wait_owned();
 
-            let thread1 = thread::spawn(move || { future::block_on(wait1).expect_err("wait1 must be canceled") });
-            let thread2 = thread::spawn(move || { future::block_on(wait2).expect_err("wait2 must be canceled") });
+            let thread1 =
+                thread::spawn(move || future::block_on(wait1).expect_err("wait1 must be canceled"));
+            let thread2 =
+                thread::spawn(move || future::block_on(wait2).expect_err("wait2 must be canceled"));
 
             drop(q);
 

--- a/maitake/src/wait/queue/tests.rs
+++ b/maitake/src/wait/queue/tests.rs
@@ -9,6 +9,7 @@ mod alloc {
 
     #[test]
     fn wake_all() {
+        crate::util::trace_init();
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
         let scheduler = Scheduler::new();
@@ -41,6 +42,7 @@ mod alloc {
 
     #[test]
     fn close_on_drop() {
+        crate::util::trace_init();
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
         let scheduler = Scheduler::new();
@@ -73,6 +75,7 @@ mod alloc {
 
     #[test]
     fn wake_one() {
+        crate::util::trace_init();
         static COMPLETED: AtomicUsize = AtomicUsize::new(0);
 
         let scheduler = Scheduler::new();


### PR DESCRIPTION
this branch adds a `WaitQueue` type in `maitake::wait`. this allows
multiple tasks to wait for an event, and be woken either one at a time
(in FIFO fashion), or all at once.

there are additional APIs we could add here, but this is a good starting
place. there probably should be docs examples but i'm lazy.