### PR TITLE
feat(cordyceps): added new push_back and pop_front methods to list

### DIFF
--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -665,6 +665,9 @@ mod tests {
         let f = list.pop_back().unwrap();
         assert_eq!(5, f.val);
 
+        assert!(list.is_empty());
+        assert!(list.pop_back().is_none());
+
         list.assert_valid();
     }
 

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -16,7 +16,7 @@ use core::{
 /// This data structure may be used as a first-in, first-out queue by using the
 /// [`List::push_front`] and [`List::pop_back`] methods. It also supports
 /// random-access removals using the [`List::remove`] method.
-/// 
+///
 /// This data structure can also be used as a stack or doubly-linked list by using
 /// the [`List::pop_front`] and [`List::push_back`] methods.
 ///


### PR DESCRIPTION
This PR adds some nice-to-have methods as detailed in [this issue](https://github.com/hawkw/mycelium/issues/186).

Changes:
* New `push_back` method
* New `pop_front` method
* Tests for each method

Small change but hope it's good :D