### PR TITLE
fix(cordyceps): pin `list::IterMut` items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ name = "cordyceps"
 version = "0.2.0"
 dependencies = [
  "loom",
+ "pin-project",
  "proptest",
  "tracing 0.1.34",
  "tracing-subscriber 0.3.11",

--- a/cordyceps/Cargo.toml
+++ b/cordyceps/Cargo.toml
@@ -27,6 +27,7 @@ no-cache-pad = []
 proptest = "1"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+pin-project = "1"
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.5.5"

--- a/cordyceps/src/list/tests.rs
+++ b/cordyceps/src/list/tests.rs
@@ -463,8 +463,10 @@ mod owned_entry {
 
     /// An entry type whose ownership is assigned to the list directly.
     #[derive(Debug)]
+    #[pin_project::pin_project]
     #[repr(C)]
     struct OwnedEntry {
+        #[pin]
         links: Links<OwnedEntry>,
         val: i32,
     }
@@ -599,9 +601,10 @@ mod owned_entry {
         let a = owned_entry(1);
         let b = owned_entry(2);
         let c = owned_entry(3);
-        fn incr_entry(entry: &mut OwnedEntry) -> i32 {
-            entry.val += 1;
-            entry.val
+        fn incr_entry(entry: Pin<&mut OwnedEntry>) -> i32 {
+            let entry = entry.project();
+            *entry.val += 1;
+            *entry.val
         }
 
         let mut list = List::new();


### PR DESCRIPTION
Currently, there is a potential safety issue when using
`cordyceps::list::IterMut`: the iterator's item type is `&mut T`.
`&mut T`s may be `mem::replace`d or `mem::take`en, moving them out of
the list to a different memory location. This would invalidate any
pointers in the list that point to that node.

Therefore, to ensure that the mutable iterator cannot corrupt the list
(potentially leading to dangling pointers or use-after-frees), this PR
changes `list::IterMut`'s `Item` type from `&'list mut T` to 
`Pin<&'list mut T`. This ensures that the iterator cannot be used to 
corrupt the list.