### PR TITLE
feat(cordyceps): add `List::drain_filter`

### DIFF
--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -944,12 +944,12 @@ where
     type Item = T::Handle;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(mut node) = self.curr {
+        while let Some(node) = self.curr {
             unsafe {
                 self.curr = T::links(node).as_ref().next();
                 self.seen += 1;
 
-                if (self.pred)(node.as_mut()) {
+                if (self.pred)(node.as_ref()) {
                     return self.list.remove(node);
                 }
             }


### PR DESCRIPTION
This branch adds a `List::drain_filter` iterator that moves items out of
the list if they match a predicate. This is based on the
[`drain_filter`] iterator on the `std::collections::LinkedList` type,
but modified slightly.

[`drain_filter`]: https://doc.rust-lang.org/stable/std/collections/struct.LinkedList.html#method.drain_filter