### PR TITLE
feat(maitake): add an async `Mutex`

### DIFF
--- a/maitake/src/lib.rs
+++ b/maitake/src/lib.rs
@@ -10,5 +10,6 @@ pub(crate) mod util;
 pub(crate) mod loom;
 
 pub mod scheduler;
+pub mod sync;
 pub mod task;
 pub mod wait;

--- a/maitake/src/loom.rs
+++ b/maitake/src/loom.rs
@@ -68,13 +68,15 @@ mod inner {
 
     pub(crate) mod cell {
         #[derive(Debug)]
-        pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
+        pub(crate) struct UnsafeCell<T: ?Sized>(core::cell::UnsafeCell<T>);
 
         impl<T> UnsafeCell<T> {
             pub const fn new(data: T) -> UnsafeCell<T> {
                 UnsafeCell(core::cell::UnsafeCell::new(data))
             }
+        }
 
+        impl<T: ?Sized> UnsafeCell<T> {
             #[inline(always)]
             pub fn with<F, R>(&self, f: F) -> R
             where

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -4,8 +4,11 @@
 //!
 //! - [`Mutex`]: a fairly queued, asynchronous mutual exclusion lock.
 pub mod mutex;
+#[cfg(feature = "alloc")]
 #[doc(inline)]
-pub use self::mutex::{Mutex, MutexGuard, OwnedMutexGuard};
+pub use self::mutex::OwnedMutexGuard;
+#[doc(inline)]
+pub use self::mutex::{Mutex, MutexGuard};
 
 #[cfg(test)]
 mod tests;

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -1,0 +1,5 @@
+mod mutex;
+pub use self::mutex::{Mutex, MutexGuard};
+
+#[cfg(test)]
+mod tests;

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -1,5 +1,6 @@
-mod mutex;
-pub use self::mutex::{Mutex, MutexGuard};
+pub mod mutex;
+#[doc(inline)]
+pub use self::mutex::{Mutex, MutexGuard, OwnedMutexGuard};
 
 #[cfg(test)]
 mod tests;

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -1,3 +1,8 @@
+//! Synchronization primitives
+//!
+//! This module contains the following asynchronous synchronization primitives:
+//!
+//! - [`Mutex`]: a fairly queued, asynchronous mutual exclusion lock.
 pub mod mutex;
 #[doc(inline)]
 pub use self::mutex::{Mutex, MutexGuard, OwnedMutexGuard};

--- a/maitake/src/sync/mutex.rs
+++ b/maitake/src/sync/mutex.rs
@@ -1,0 +1,111 @@
+use crate::{
+    loom::cell::{MutPtr, UnsafeCell},
+    wait::queue::{self, WaitQueue},
+};
+use core::{
+    future::Future,
+    ops,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use pin_project::pin_project;
+
+pub struct Mutex<T> {
+    wait: WaitQueue,
+    data: UnsafeCell<T>,
+}
+
+pub struct MutexGuard<'a, T> {
+    /// /!\ WARNING: semi-load-bearing drop order /!\
+    ///
+    /// This struct's field ordering is important.
+    data: MutPtr<T>,
+    _wake: WakeOnDrop<'a, T>,
+}
+
+#[pin_project]
+pub struct Lock<'a, T> {
+    #[pin]
+    wait: queue::Wait<'a>,
+    mutex: &'a Mutex<T>,
+}
+
+/// This is used in order to ensure that the wakeup is performed only *after*
+/// the data ptr is dropped, in order to keep `loom` happy.
+struct WakeOnDrop<'a, T>(&'a Mutex<T>);
+
+// === impl Mutex ===
+
+impl<T> Mutex<T> {
+    loom_const_fn! {
+        #[must_use]
+        pub fn new(data: T) -> Self {
+            Self {
+                // The queue must start with a single stored wakeup, so that the
+                // first task that tries to acquire the lock will succeed
+                // immediately.
+                wait: WaitQueue::new_woken(),
+                data: UnsafeCell::new(data),
+            }
+        }
+    }
+
+    pub fn lock(&self) -> Lock<'_, T> {
+        Lock {
+            wait: self.wait.wait(),
+            mutex: self,
+        }
+    }
+}
+
+// === impl Lock ===
+
+impl<'a, T> Future for Lock<'a, T> {
+    type Output = MutexGuard<'a, T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.wait.poll(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(_)) => unsafe {
+                mycelium_util::unreachable_unchecked!("`Mutex` never calls `WaitQueue::close`")
+            },
+            Poll::Pending => return Poll::Pending,
+        }
+
+        let data = this.mutex.data.get_mut();
+        Poll::Ready(MutexGuard {
+            _wake: WakeOnDrop(this.mutex),
+            data,
+        })
+    }
+}
+
+// === impl MutexGuard ===
+
+impl<'a, T> ops::Deref for MutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            // safety: we are holding the lock
+            &*self.data.deref()
+        }
+    }
+}
+
+impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            // safety: we are holding the lock
+            self.data.deref()
+        }
+    }
+}
+
+impl<'a, T> Drop for WakeOnDrop<'a, T> {
+    fn drop(&mut self) {
+        self.0.wait.wake()
+    }
+}

--- a/maitake/src/sync/mutex.rs
+++ b/maitake/src/sync/mutex.rs
@@ -203,7 +203,7 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// let n = mutex.try_lock()?;
     /// assert_eq!(*n, 1);
-    /// # Ok(())
+    /// # Some(())
     /// # }
     /// ```
     pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
@@ -361,16 +361,22 @@ feature! {
         /// # Examples
         ///
         /// ```
+        /// # // since we are targeting no-std, it makes more sense to use `alloc`
+        /// # // in these examples, rather than `std`...but i don't want to make
+        /// # // the tests actually `#![no_std]`...
+        /// # use std as alloc;
         /// use maitake::sync::Mutex;
-        /// use core::sync::Arc;
+        /// use alloc::sync::Arc;
         ///
+        /// # fn main() {
         /// async fn example() {
-        ///     let mutex = Mutex::new(1);
+        ///     let mutex = Arc::new(Mutex::new(1));
         ///
         ///     let mut guard = mutex.clone().lock_owned().await;
         ///     *guard = 2;
         ///     # drop(mutex);
         /// }
+        /// # }
         /// ```
         pub async fn lock_owned(self: Arc<Self>) -> OwnedMutexGuard<T> {
             self.wait.wait().await.unwrap();
@@ -403,17 +409,19 @@ feature! {
         /// # Examples
         ///
         /// ```
+        /// # // since we are targeting no-std, it makes more sense to use `alloc`
+        /// # // in these examples, rather than `std`...but i don't want to make
+        /// # // the tests actually `#![no_std]`...
+        /// # use std as alloc;
         /// use maitake::sync::Mutex;
-        /// use core::sync::Arc;
-        /// # async fn dox() -> Option<()> {
+        /// use alloc::sync::Arc;
         ///
-        /// let mutex = Mutex::new(1);
+        /// # fn main() {
+        /// let mutex = Arc::new(Mutex::new(1));
         ///
-        /// let n = mutex.clone().try_lock()?;
-        /// assert_eq!(*n, 1);
-        ///
-        /// # drop(mutex);
-        /// # Ok(())
+        /// if let Ok(guard) = mutex.clone().try_lock_owned() {
+        ///     assert_eq!(*guard, 1);
+        /// }
         /// # }
         /// ```
         pub fn try_lock_owned(self: Arc<Self>) -> Result<OwnedMutexGuard<T>, Arc<Self>> {

--- a/maitake/src/sync/mutex.rs
+++ b/maitake/src/sync/mutex.rs
@@ -60,8 +60,8 @@ use pin_project::pin_project;
 ///     `liballoc`][storage].
 ///
 /// [^3]: In fact, this mutex _cannot_ implement poisoning, as poisoning
-///     requires support for unwinding, and `maitake` assumes that panics are
-///     invariably fatal.
+///     requires support for unwinding, and [`maitake` assumes that panics are
+///     invariably fatal][no-unwinding].
 ///
 /// [mutex]: https://en.wikipedia.org/wiki/Mutual_exclusion
 /// [RAII guards]: MutexGuard
@@ -75,7 +75,9 @@ use pin_project::pin_project;
 /// [`futures_util::lock::Mutex`]: https://docs.rs/futures-util/latest/futures_util/lock/struct.Mutex.html
 /// [intrusive linked list]: crate::wait::WaitQueue#implementation-notes
 /// [poisoning]: https://doc.rust-lang.org/stable/std/sync/struct.Mutex.html#poisoning
+// for some reason, intra-doc links don't work in footnotes?
 /// [storage]: ../task/trait.Storage.html
+/// [no-unwinding]: ../index.html#maitake-does-not-support-unwinding
 
 pub struct Mutex<T: ?Sized> {
     wait: WaitQueue,

--- a/maitake/src/sync/tests.rs
+++ b/maitake/src/sync/tests.rs
@@ -1,0 +1,2 @@
+#[cfg(loom)]
+mod loom_mutex;

--- a/maitake/src/sync/tests/loom_mutex.rs
+++ b/maitake/src/sync/tests/loom_mutex.rs
@@ -1,0 +1,56 @@
+use crate::loom::{self, sync::Arc, thread, future};
+use crate::sync::Mutex;
+
+#[test]
+fn basic_single_threaded() {
+    loom::model(|| {
+        let lock = Mutex::new(1);
+
+        future::block_on(async {
+            let mut lock = lock.lock().await;
+            assert_eq!(*lock, 1);
+            *lock = 2;
+        });
+
+        future::block_on(async {
+            let mut lock = lock.lock().await;
+            assert_eq!(*lock, 2);
+            *lock = 3;
+        });
+
+        future::block_on(async {
+            let mut lock = lock.lock().await;
+            assert_eq!(*lock, 3);
+            *lock = 4;
+        });
+    });
+}
+
+
+#[test]
+fn basic_multi_threaded() {
+    fn incr(lock: &Arc<Mutex<i32>>) -> thread::JoinHandle<()> {
+        let lock = lock.clone();
+        thread::spawn(move || {
+            future::block_on(async move {
+                let mut lock = lock.lock().await;
+                *lock += 1;
+            })
+        })
+    }
+
+
+    loom::model(|| {
+        let lock = Arc::new(Mutex::new(0));
+        let t1 = incr(&lock);
+        let t2 = incr(&lock);
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        future::block_on(async move {
+            let lock = lock.lock().await;
+            assert_eq!(*lock, 2)
+        })
+    });
+}

--- a/maitake/src/sync/tests/loom_mutex.rs
+++ b/maitake/src/sync/tests/loom_mutex.rs
@@ -1,4 +1,4 @@
-use crate::loom::{self, sync::Arc, thread, future};
+use crate::loom::{self, future, sync::Arc, thread};
 use crate::sync::Mutex;
 
 #[test]
@@ -26,7 +26,6 @@ fn basic_single_threaded() {
     });
 }
 
-
 #[test]
 fn basic_multi_threaded() {
     fn incr(lock: &Arc<Mutex<i32>>) -> thread::JoinHandle<()> {
@@ -38,7 +37,6 @@ fn basic_multi_threaded() {
             })
         })
     }
-
 
     loom::model(|| {
         let lock = Arc::new(Mutex::new(0));

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -73,6 +73,21 @@ macro_rules! feature {
     }
 }
 
+macro_rules! loom_const_fn {
+    (
+        $(#[$meta:meta])*
+        $vis:vis fn $name:ident($($arg:ident: $T:ty),*) -> $Ret:ty $body:block
+    ) => {
+        $(#[$meta])*
+        #[cfg(not(loom))]
+        $vis const fn $name($($arg: $T),*) -> $Ret $body
+
+        $(#[$meta])*
+        #[cfg(loom)]
+        $vis fn $name($($arg: $T),*) -> $Ret $body
+    }
+}
+
 /// Helper to construct a `NonNull<T>` from a raw pointer to `T`, with null
 /// checks elided in release mode.
 #[cfg(debug_assertions)]

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -40,10 +40,10 @@ mod tests;
 /// used to wake a set of tasks when a timer completes or when a resource
 /// becomes available. It can be equally useful for implementing higher-level
 /// synchronization primitives: for example, a `WaitQueue` plus an
-/// [`UnsafeCell`] is essentially an entire implementation of a fair
-/// asynchronous mutex. Finally, a `WaitQueue` can be a useful synchronization
-/// primitive on its own: sometimes, you just need to have a bunch of tasks wait
-/// for something and then wake them all up.
+/// [`UnsafeCell`] is essentially [an entire implementation of a fair
+/// asynchronous mutex][mutex]. Finally, a `WaitQueue` can be a useful
+/// synchronization primitive on its own: sometimes, you just need to have a
+/// bunch of tasks wait for something and then wake them all up.
 ///
 /// # Examples
 ///
@@ -165,6 +165,7 @@ mod tests;
 /// [`UnsafeCell`]: core::cell::UnsafeCell
 /// [ilist]: cordyceps::List
 /// [intrusive]: https://fuchsia.dev/fuchsia-src/development/languages/c-cpp/fbl_containers_guide/introduction
+/// [mutex]: crate::sync::Mutex
 /// [2]: https://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
 #[derive(Debug)]
 pub struct WaitQueue {

--- a/maitake/src/wait/queue.rs
+++ b/maitake/src/wait/queue.rs
@@ -337,23 +337,32 @@ enum Wakeup {
 // === impl WaitQueue ===
 
 impl WaitQueue {
-    /// Returns a new `WaitQueue`.
-    #[must_use]
-    #[cfg(not(loom))]
-    pub const fn new() -> Self {
-        Self {
-            state: CachePadded::new(AtomicUsize::new(State::Empty.into_usize())),
-            queue: Mutex::new(List::new()),
+    loom_const_fn! {
+        /// Returns a new `WaitQueue`.
+        #[must_use]
+        pub fn new() -> Self {
+            Self::new_with_state(State::Empty)
         }
     }
 
-    /// Returns a new `WaitQueue`.
-    #[must_use]
-    #[cfg(loom)]
-    pub fn new() -> Self {
-        Self {
-            state: CachePadded::new(AtomicUsize::new(State::Empty.into_usize())),
-            queue: Mutex::new(List::new()),
+    loom_const_fn! {
+        /// Returns a new `WaitQueue` with a single stored wakeup.
+        ///
+        /// The first call to [`wait`] on this queue will immediately succeed.
+        // TODO(eliza): should this be a public API?
+        #[must_use]
+        pub(crate) fn new_woken() -> Self {
+            Self::new_with_state(State::Woken)
+        }
+    }
+
+    loom_const_fn! {
+        #[must_use]
+        fn new_with_state(state: State) -> Self {
+            Self {
+                state: CachePadded::new(AtomicUsize::new(state.into_usize())),
+                queue: Mutex::new(List::new()),
+            }
         }
     }
 

--- a/maitake/tests/mutex.rs
+++ b/maitake/tests/mutex.rs
@@ -10,11 +10,10 @@ fn try_lock() {
 
     let lock2 = mutex.try_lock();
     assert!(lock2.is_none());
-
     drop(lock1);
 
     let lock3 = mutex.try_lock();
-    assert!(lock3.is_none());
+    assert!(lock3.is_some());
 }
 
 #[test]

--- a/maitake/tests/mutex.rs
+++ b/maitake/tests/mutex.rs
@@ -1,0 +1,46 @@
+use maitake::{scheduler::Scheduler, sync::Mutex};
+use std::{future::Future, sync::Arc};
+
+#[test]
+fn try_lock() {
+    let mutex = Mutex::new(());
+
+    let lock1 = mutex.try_lock();
+    assert!(lock1.is_some());
+
+    let lock2 = mutex.try_lock();
+    assert!(lock2.is_none());
+
+    drop(lock1);
+
+    let lock3 = mutex.try_lock();
+    assert!(lock3.is_none());
+}
+
+#[test]
+fn basically_works() {
+    const TASKS: usize = 10;
+
+    let scheduler = Scheduler::new();
+    let lock = Arc::new(Mutex::new(0));
+
+    fn incr(lock: &Arc<Mutex<usize>>) -> impl Future + Send + 'static {
+        let lock = lock.clone();
+        async move {
+            let mut guard = lock.lock().await;
+            *guard += 1;
+        }
+    }
+
+    for _ in 0..TASKS {
+        scheduler.spawn(incr(&lock));
+    }
+
+    let mut completed = 0;
+    while completed < TASKS {
+        let tick = scheduler.tick();
+        completed += tick.completed;
+    }
+
+    assert_eq!(*lock.try_lock().unwrap(), TASKS);
+}

--- a/maitake/tests/mutex.rs
+++ b/maitake/tests/mutex.rs
@@ -44,3 +44,31 @@ fn basically_works() {
 
     assert_eq!(*lock.try_lock().unwrap(), TASKS);
 }
+
+#[test]
+fn lock_owned() {
+    const TASKS: usize = 10;
+
+    let scheduler = Scheduler::new();
+    let lock = Arc::new(Mutex::new(0));
+
+    fn incr(lock: &Arc<Mutex<usize>>) -> impl Future + Send + 'static {
+        let lock = lock.clone().lock_owned();
+        async move {
+            let mut guard = lock.await;
+            *guard += 1;
+        }
+    }
+
+    for _ in 0..TASKS {
+        scheduler.spawn(incr(&lock));
+    }
+
+    let mut completed = 0;
+    while completed < TASKS {
+        let tick = scheduler.tick();
+        completed += tick.completed;
+    }
+
+    assert_eq!(*lock.try_lock().unwrap(), TASKS);
+}


### PR DESCRIPTION
This branch adds an async `Mutex` type to `maitake`, implemented using
`WaitQueue`. The implementation should be pretty straightforward,
although it required adding some additional methods to `WaitQueue`.
Currently, all the new `WaitQueue` functions are `pub(crate)`, but I'm
open to making them public APIs as well; I just wanted to save that for
a separate PR.

The `Mutex` type lives in a new `maitake::sync` module for
synchronization primitives --- I was on the fence about whether it still
makes sense to have a separate `maitake::wait` module if we are going to
have `maitake::sync`, but I didn't want to put the mutex in `wait`, as
it does more than *just* notify waiting tasks. Perhaps the `wait` types
should be moved into `sync`, but I'd prefer to do that in a separate PR.