### PR TITLE
Remove unused mycotest dep

### DIFF
--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -36,7 +36,6 @@ no-cache-pad = ["mycelium-util/no-cache-pad", "cordyceps/no-cache-pad"]
 [dependencies]
 mycelium-bitfield = { path = "../bitfield" }
 mycelium-util = { path = "../util" }
-mycotest = { path = "../mycotest", default-features = false }
 cordyceps = { path = "../cordyceps" }
 pin-project = "1"
 


### PR DESCRIPTION
This removes an unused `mycotest` dependency in maitake.

This was causing `#![no_std]` builds to fail as `mycotest` pulls in `once_cell`, which isn't marked as `no_std` (at least in the used feature configuration).

We should probably add tests in CI to all of the `no_std` crates to make sure that a `cargo build --no-default-features --target thumbv7em-none-eabihf` runs successfully to avoid regressions.