### PR TITLE
test: run Miri with `RUSTFLAGS="-Zrandomize-layout"`

### DIFF
--- a/bin/miri
+++ b/bin/miri
@@ -2,10 +2,36 @@
 #
 # Runs `miri` tests
 set -euo pipefail
-set -x
 
 cd "$(dirname "$0")"/..
 
-MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers -Zmiri-strict-provenance ${MIRIFLAGS:-}" \
-    PROPTEST_CASES="${PROPTEST_CASES:-10}" \
-    cargo miri test --lib "${@}"
+# configure flags
+
+# additional miri flags
+add_miriflags=(
+    # enable stacked borrows and strict provenance checks.
+    # Note: this also implies `-Zmiri-tag-raw-pointers`
+    "-Zmiri-strict-provenance"
+
+    # disable miri's host isolation, because running `proptest` tests in miri
+    # requires randomness.
+    "-Zmiri-disable-isolation"
+)
+
+# additional flags passed to rustc
+add_rustflags=(
+    # enable layout randomization to help catch incorrect layout-dependent casts
+    # etc.
+    "-Zrandomize-layout"
+)
+
+# show the user the env vars we're setting for miri
+set -x
+
+# set env vars
+export PROPTEST_CASES="${PROPTEST_CASES:-10}"
+export RUSTFLAGS="${add_rustflags[*]} ${RUSTFLAGS:-}"
+export MIRIFLAGS="${add_miriflags[*]} ${MIRIFLAGS:-}"
+
+# actually run miri
+cargo miri test --lib "${@}"


### PR DESCRIPTION
`cordyceps` and `maitake` currently contain code that perform
layout-dependent casts (in this case, casting a ptr to struct to a ptr
to the struct's first subfield), which would be UB if those structs
were not `#[repr(C)]`.

the `-Zrandomize-layout` flag tells the Rust compiler to randomize the
layout of all `#[repr(Rust)]` structs (see rust-lang/compiler-team#457
for details). if we ever perform a layout-dependent cast on a struct
that is not `#[repr(C)]` (or `#[repr(transparent)]`), layout
randomization would break that cast. enabling this flag while running
the Miri tests will help to catch any bugs introduced by accidentally
performing such a cast on a non-layout-dependent type.

i also made some changes to the `bin/miri` script. this was primarily to
add comments on the individual flags that are added to `$MIRIFLAGS`, so
that we can remember what they're doing when we look back at the script.
the actual behavior should be identical, but the values added to
`$MIRIFLAGS` are now declared in an array so that each flag can have a
comment.

Closes #229

Signed-off-by: Eliza Weisman <eliza@buoyant.io>