### PR TITLE
feat(cordyceps): add some list surgery methods

### DIFF
--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, deny(missing_docs))]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![allow(unused_unsafe)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -874,16 +874,18 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
         // the head of the new list is the split node's `next` node (which is
         // replaced with `None`)
         let head = unsafe { T::links(split_node).as_mut().set_next(None) };
-        if let Some(head) = head {
+        let tail = if let Some(head) = head {
             // since `head` is now the head of its own list, it has no `prev`
             // link any more.
             let _prev = unsafe { T::links(head).as_mut().set_prev(None) };
             debug_assert_eq!(_prev, Some(split_node));
-        }
 
-        // the tail of the new list is this list's old tail, if the split list
-        // is not empty.
-        let tail = self.tail.replace(split_node);
+            // the tail of the new list is this list's old tail, if the split list
+            // is not empty.
+            self.tail.replace(split_node)
+        } else {
+            None
+        };
 
         let split = Self {
             head,

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -812,6 +812,7 @@ impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for List<T> {
         f.debug_struct("List")
             .field("head", &FmtOption::new(&self.head))
             .field("tail", &FmtOption::new(&self.tail))
+            .field("len", &self.len())
             .finish()
     }
 }


### PR DESCRIPTION
This adds `List::append`, `List::split_off`, and `Cursor::split_before`/`split_after`.