### PR TITLE
feat(maitake): add feature flags for both versions of `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
 dependencies = [
  "once_cell",
  "owo-colors 1.3.0",
- "tracing-core 0.1.26",
+ "tracing-core 0.1.28",
  "tracing-error 0.1.2",
 ]
 
@@ -191,7 +191,7 @@ dependencies = [
  "loom",
  "pin-project",
  "proptest",
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing-subscriber 0.3.11",
 ]
 
@@ -456,7 +456,7 @@ dependencies = [
  "locate-cargo-manifest",
  "mycotest",
  "owo-colors 2.1.0",
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing-error 0.2.0",
  "tracing-subscriber 0.3.11",
  "wait-timeout",
@@ -537,7 +537,7 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_json",
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing-subscriber 0.3.11",
 ]
 
@@ -552,7 +552,7 @@ dependencies = [
  "mycelium-bitfield",
  "mycelium-util",
  "pin-project",
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing 0.2.0",
  "tracing-subscriber 0.3.0",
  "tracing-subscriber 0.3.11",
@@ -660,7 +660,7 @@ name = "mycotest"
 version = "0.1.0"
 dependencies = [
  "mycelium-trace",
- "tracing 0.1.34",
+ "tracing 0.1.35",
 ]
 
 [[package]]
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -1076,14 +1076,14 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
  "tracing-attributes 0.1.21",
- "tracing-core 0.1.26",
+ "tracing-core 0.1.28",
 ]
 
 [[package]]
@@ -1121,11 +1121,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -1143,7 +1143,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
 dependencies = [
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing-subscriber 0.2.25",
 ]
 
@@ -1153,7 +1153,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
- "tracing 0.1.34",
+ "tracing 0.1.35",
  "tracing-subscriber 0.3.11",
 ]
 
@@ -1165,7 +1165,7 @@ checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
- "tracing-core 0.1.26",
+ "tracing-core 0.1.28",
 ]
 
 [[package]]
@@ -1186,7 +1186,7 @@ checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "sharded-slab",
  "thread_local",
- "tracing-core 0.1.26",
+ "tracing-core 0.1.28",
 ]
 
 [[package]]
@@ -1215,8 +1215,8 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing 0.1.34",
- "tracing-core 0.1.26",
+ "tracing 0.1.35",
+ "tracing-core 0.1.28",
  "tracing-log 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ opt-level = 3
 [dependencies]
 hal-core = { path = "hal-core", features = ["embedded-graphics-core"] }
 mycelium-alloc = { path = "alloc", features = ["buddy", "bump"] }
-maitake = { path = "maitake" }
+maitake = { path = "maitake", features = ["tracing-02"] }
 mycelium-util = { path = "util" }
 mycelium-trace = { path = "trace", features = ["embedded-graphics"] }
 rlibc = "1.0"

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -39,10 +39,17 @@ mycelium-util = { path = "../util" }
 cordyceps = { path = "../cordyceps" }
 pin-project = "1"
 
-[dependencies.tracing_02]
+[dependencies.tracing-02]
 package = "tracing"
 default_features = false
 git = "https://github.com/tokio-rs/tracing"
+optional = true
+
+[dependencies.tracing-01]
+package = "tracing"
+default_features = false
+version = "0.1.35"
+optional = true
 
 [dev-dependencies]
 futures-util = "0.3"
@@ -50,6 +57,7 @@ futures = "0.3"
 
 [target.'cfg(not(loom))'.dev-dependencies]
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", features = ["ansi", "fmt"] }
+tracing-02 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5.5", features = ["futures", "checkpoint"] }

--- a/maitake/README.md
+++ b/maitake/README.md
@@ -132,10 +132,13 @@ The following features are available (this list is incomplete; you can help by [
 
 [expanding it]: https://github.com/hawkw/mycelium/edit/main/maitake/README.md
 
-| Feature | Default | Explanation |
-| :---    | :---    | :---        |
-| `alloc` | `true`  | Enables [`liballoc`] dependency |
+| Feature        | Default | Explanation |
+| :---           | :---    | :---        |
+| `alloc`        | `true`  | Enables [`liballoc`] dependency |
 | `no-cache-pad` | `false` | Inhibits cache padding for the [`CachePadded`] struct. When this feature is NOT enabled, the size will be determined based on target platform. |
+| `tracing-01`   | `false`  | Enables support for v0.1.x of [`tracing`] (the current release version). Requires `liballoc`.|
+| `tracing-02`   | `false`  | Enables support for the upcoming v0.2 of [`tracing`] (via a Git dependency). |
 
 [`liballoc`]: https://doc.rust-lang.org/alloc/
 [`CachePadded`]: https://mycelium.elizas.website/mycelium_util/sync/struct.cachepadded
+[`tracing`]: https://crates.io/crates/tracing

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -1,7 +1,4 @@
-use crate::{
-    task::{self, Header, Storage, TaskRef},
-    util::tracing,
-};
+use crate::task::{self, Header, Storage, TaskRef};
 use core::{future::Future, pin::Pin};
 
 use cordyceps::mpsc_queue::MpscQueue;
@@ -115,15 +112,14 @@ impl Core {
         };
 
         for task in self.run_queue.consume() {
-            let span = tracing::debug_span!("poll", ?task);
-            let _enter = span.enter();
+            in_debug_span!("poll", ?task);
             let poll = task.poll();
             if poll.is_ready() {
                 tick.completed += 1;
             }
             tick.polled += 1;
 
-            tracing::debug!(parent: span.id(), poll = ?poll, tick.polled, tick.completed);
+            debug!(poll = ?poll, tick.polled, tick.completed);
             if tick.polled == n {
                 return tick;
             }

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -22,7 +22,7 @@ use crate::{
     loom::cell::UnsafeCell,
     scheduler::Schedule,
     task::state::{OrDrop, ScheduleAction, StateCell},
-    util::{non_null, tracing},
+    util::non_null,
 };
 
 use core::{
@@ -172,7 +172,7 @@ struct Vtable {
 
 macro_rules! trace_task {
     ($ptr:expr, $f:ty, $method:literal) => {
-        tracing::trace!(
+        trace!(
             ptr = ?$ptr,
             output = %type_name::<<$f>::Output>(),
             concat!("Task::", $method),
@@ -387,7 +387,7 @@ impl TaskRef {
         STO: Storage<S, F>,
     {
         let ptr = STO::into_raw(task).cast::<Header>();
-        tracing::trace!(
+        trace!(
             ?ptr,
             "Task<..., Output = {}>::new",
             type_name::<F::Output>()


### PR DESCRIPTION
This branch adds support for emitting both `tracing` 0.1 and `tracing`
0.2 diagnostics from Maitake. They are both controlled by feature flags,
which are additive --- both `tracing` versions _can_ be supported
simultaneously. The `tracing` configuration for tests still works as it
did previously.

The `tracing` 0.2 feature flag probably can't stay forever, if we ever
want to do a crates.io release of `maitake` before `tracing` 0.2 is
done...