### PR TITLE
feat(maitake): add a task builder for naming tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#e0642d949891546a3bb7e47080365ee7274f05cd"
+source = "git+https://github.com/tokio-rs/tracing#2aa0cb010d8a7fa0de610413b5acd4557a00dd34"
 dependencies = [
  "cfg-if",
  "log",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#e0642d949891546a3bb7e47080365ee7274f05cd"
+source = "git+https://github.com/tokio-rs/tracing#2aa0cb010d8a7fa0de610413b5acd4557a00dd34"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1673,9 +1673,9 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#e0642d949891546a3bb7e47080365ee7274f05cd"
+source = "git+https://github.com/tokio-rs/tracing#2aa0cb010d8a7fa0de610413b5acd4557a00dd34"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1722,10 +1722,10 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing#e0642d949891546a3bb7e47080365ee7274f05cd"
+source = "git+https://github.com/tokio-rs/tracing#2aa0cb010d8a7fa0de610413b5acd4557a00dd34"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core 0.2.0",
 ]
 
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.0"
-source = "git+https://github.com/tokio-rs/tracing#e0642d949891546a3bb7e47080365ee7274f05cd"
+source = "git+https://github.com/tokio-rs/tracing#2aa0cb010d8a7fa0de610413b5acd4557a00dd34"
 dependencies = [
  "ansi_term",
  "sharded-slab",

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -23,6 +23,15 @@ pub struct Tick {
 
 pub trait Schedule: Sized + Clone {
     fn schedule(&self, task: TaskRef);
+
+    /// Returns a new [task `Builder`] for configuring tasks prior to spawning
+    /// them on this scheduler.
+    ///
+    /// [task `Builder`]: task::Builder
+    #[must_use]
+    fn build_task<'a>(&self) -> task::Builder<'a, Self> {
+        task::Builder::new(self.clone())
+    }
 }
 
 /// A stub [`Task`],
@@ -85,6 +94,15 @@ impl StaticScheduler {
     {
         let tr = TaskRef::new_allocated::<&'static Self, F, STO>(task);
         self.schedule(tr);
+    }
+
+    /// Returns a new [task `Builder`] for configuring tasks prior to spawning
+    /// them on this scheduler.
+    ///
+    /// [task `Builder`]: task::Builder
+    #[must_use]
+    pub fn build_task<'a>(&'static self) -> task::Builder<'a, &'static Self> {
+        task::Builder::new(self)
     }
 
     pub fn tick(&'static self) -> Tick {
@@ -179,6 +197,50 @@ feature! {
 
         pub fn new() -> Self {
             Self::default()
+        }
+
+        /// Returns a new [task `Builder`][`Builder`] for configuring tasks prior to spawning
+        /// them on this scheduler.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use maitake::scheduler::Scheduler;
+        ///
+        /// let scheduler = Scheduler::new();
+        /// scheduler.build_task().named("hello world").spawn(async {
+        ///     // ...
+        /// });
+        ///
+        /// scheduler.tick();
+        /// ```
+        ///
+        /// Multiple tasks can be spawned using the same [`Builder`]:
+        ///
+        /// ```
+        /// use maitake::scheduler::Scheduler;
+        ///
+        /// let scheduler = Scheduler::new();
+        /// let builder = scheduler
+        ///     .build_task()
+        ///     .kind("my_cool_task");
+        ///
+        /// builder.spawn(async {
+        ///     // ...
+        /// });
+        ///
+        /// builder.spawn(async {
+        ///     // ...
+        /// });
+        ///
+        /// scheduler.tick();
+        /// ```
+        ///
+        /// [`Builder`]: task::Builder
+        #[must_use]
+        #[inline]
+        pub fn build_task<'a>(&self) -> task::Builder<'a, Self> {
+            task::Builder::new(self.clone())
         }
 
         #[inline]

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -208,7 +208,7 @@ feature! {
         /// use maitake::scheduler::Scheduler;
         ///
         /// let scheduler = Scheduler::new();
-        /// scheduler.build_task().named("hello world").spawn(async {
+        /// scheduler.build_task().name("hello world").spawn(async {
         ///     // ...
         /// });
         ///

--- a/maitake/src/task/builder.rs
+++ b/maitake/src/task/builder.rs
@@ -1,0 +1,135 @@
+use super::{Future, Schedule, Storage, Task, TaskRef};
+use core::panic::Location;
+
+/// Builds a new [`Task`] prior to spawning it.
+#[derive(Debug, Clone)]
+pub struct Builder<'a, S> {
+    scheduler: S,
+    settings: Settings<'a>,
+}
+
+/// Configures settings for new tasks.
+#[derive(Debug, Clone)]
+// These fields are currently only read when tracing is enabled.
+#[cfg_attr(
+    not(any(feature = "tracing-01", feature = "tracing-02", test)),
+    allow(dead_code)
+)]
+pub(crate) struct Settings<'a> {
+    pub(super) name: Option<&'a str>,
+    pub(super) kind: &'static str,
+    pub(super) location: Option<Location<'a>>,
+}
+
+impl<'a, S: Schedule> Builder<'a, S> {
+    pub(crate) const fn new(scheduler: S) -> Self {
+        Self {
+            scheduler,
+            settings: Settings::new(),
+        }
+    }
+
+    /// Adds a name to the tasks produced by this builder.
+    ///
+    /// This will set the `task.name` `tracing` field of spans generated for
+    /// this task, if the "tracing-01" or "tracing-02" feature flags are
+    /// enabled.
+    ///
+    /// By default, tasks are unnamed.
+    pub fn name(self, name: &'a str) -> Self {
+        Self {
+            settings: Settings {
+                name: Some(name),
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Adds a static string which describes the type of the configured task.
+    ///
+    /// Generally, this is set by the runtime, rather than by user code &mdash;
+    /// `kind`s should describe general categories of task, such as "local" or
+    /// "blocking", rather than identifying specific tasks in an application. The
+    /// [`name`] field should be used instead for naming specific tasks within
+    /// an application.
+    ///
+    /// This will set the `task.kind` `tracing` field of spans generated for
+    /// this task, if the "tracing-01" or "tracing-02" feature flags are
+    /// enabled.
+    ///
+    /// By default, tasks will have the kind "task".
+    pub fn kind(self, kind: &'static str) -> Self {
+        Self {
+            settings: Settings {
+                kind,
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Overrides the task's source code location.
+    ///
+    /// By default, tasks will be recorded as having the location from which
+    /// they are spawned. This may be overriden by the runtime if needed.
+    pub fn location(self, location: Location<'a>) -> Self {
+        Self {
+            settings: Settings {
+                location: Some(location),
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Spawns a new task in a custom allocation, with this builder's configured settings.
+    ///
+    /// Note that the `StoredTask` *must* be bound to the same scheduler
+    /// instance as this task's scheduler!
+    #[inline]
+    #[track_caller]
+    pub fn spawn_allocated<STO, F>(&self, task: STO::StoredTask)
+    where
+        F: Future + 'static,
+        STO: Storage<S, F>,
+    {
+        let task = TaskRef::build_allocated::<S, F, STO>(&self.settings, task);
+        self.scheduler.schedule(task);
+    }
+
+    feature! {
+        #![feature = "alloc"]
+
+        /// Spawns a new task with this builder's configured settings.
+        #[inline]
+        #[track_caller]
+        pub fn spawn(&self, future: impl Future + 'static) {
+            use alloc::boxed::Box;
+            use super::BoxStorage;
+            let task = Box::new(Task::<S, _, BoxStorage>::new(self.scheduler.clone(), future));
+            let task = TaskRef::build_allocated::<S, _, BoxStorage>(&self.settings, task);
+            self.scheduler.schedule(task);
+        }
+    }
+}
+
+// === impl Settings ===
+
+impl<'a> Settings<'a> {
+    /// Returns a new, empty task builder with no settings configured.
+    #[must_use]
+    pub(crate) const fn new() -> Self {
+        Self {
+            name: None,
+            location: None,
+            kind: "task",
+        }
+    }
+}
+
+impl Default for Settings<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/maitake/tests/task_builder.rs
+++ b/maitake/tests/task_builder.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "alloc")]
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use maitake::scheduler::Scheduler;
+
+#[test]
+fn basically_works() {
+    let scheduler = Scheduler::new();
+    static IT_WORKED: AtomicBool = AtomicBool::new(false);
+    scheduler.build_task().name("hello world").spawn(async {
+        println!("hello world");
+        IT_WORKED.store(true, Ordering::Relaxed);
+    });
+
+    scheduler.tick();
+    assert!(IT_WORKED.load(Ordering::Acquire));
+}


### PR DESCRIPTION
This branch adds a `task::Builder` API to `maitake` for configuring task
settings prior to spawning. Currently, the only settings that can be
configured are metadata fields used to populate the `tracing` span
generated for that task, such as a name (used for the `tokio-console`
`task.name` field).

This is similar to the (unstable) `task::Builder` API in `tokio`.