### PR TITLE
docs(cordyceps): use `ptr::addr_of_mut!` instead of casts

### DIFF
--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -58,10 +58,148 @@ use core::ptr::NonNull;
 /// Failure to uphold these invariants will result in corruption of the
 /// intrusive data structure, including dangling pointers.
 ///
+/// # Implementing `Linked::links`
+///
+/// The [`Linked::links`] method provides access to a `Linked` type's `Links`
+/// field through a [`NonNull`] pointer. This is necessary for a type to
+/// participate in an intrusive structure, as it tells the intrusive structure
+/// how to access the links to other parts of that data structure. However, this
+/// method is somewhat difficult to implement correctly.
+///
+/// Suppose we have an entry type like this:
+/// ```rust
+/// use cordyceps::list;
+///
+/// struct Entry {
+///     links: list::Links<Self>,
+///     data: usize,
+/// }
+/// ```
+///
+/// The naive implementation of [`links`](Linked::links) for this `Entry` type
+/// might look like this:
+///
+/// ```
+/// use cordyceps::Linked;
+/// use core::ptr::NonNull;
+///
+/// # use cordyceps::list;
+/// # struct Entry {
+/// #    links: list::Links<Self>,
+/// # }
+///
+/// unsafe impl Linked<list::Links<Self>> for Entry {
+///     # type Handle = NonNull<Self>;
+///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
+///     // ...
+///
+///     unsafe fn links(target: NonNull<Self>) -> NonNull<list::Links<Self>> {
+///         // Borrow the target's `links` field.
+///         let links = target.as_mut().links;
+///         // Convert that reference into a pointer.
+///         NonNull::from(links)
+///     }
+/// }
+/// ```
+///
+/// However, this implementation **is not sound** under [Stacked Borrows]! It
+/// creates a temporary reference from the original raw pointer, and then
+/// creates a new raw pointer from that temporary reference. Stacked Borrows
+/// will reject this reborrow as unsound.[^1]
+///
+/// There are two ways we can implement [`Linked::links`] without creating a
+/// temporary reference in this manner. The recommended one is to use the
+/// [`core::ptr::addr_of_mut!`] macro, as follows:
+///
+/// ```
+/// use core::ptr::{self, NonNull};
+/// # use cordyceps::{Linked, list};
+/// # struct Entry {
+/// #    links: list::Links<Self>,
+/// # }
+///
+/// unsafe impl Linked<list::Links<Self>> for Entry {
+///     # type Handle = NonNull<Self>;
+///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
+///     // ...
+///
+///     unsafe fn links(target: NonNull<Self>) -> NonNull<list::Links<Self>> {
+///         let target = target.as_ptr();
+///
+///         // Using the `ptr::addr_of_mut!` macro, we can offset a raw pointer to a
+///         // raw pointer to a field *without* creating a temporary reference.
+///         let links = ptr::addr_of_mut!((*target).links);
+///
+///         // `NonNull::new_unchecked` is safe to use here, because the pointer that
+///         // we offset was not null, implying that the pointer produced by offsetting
+///         // it will also not be null.
+///         NonNull::new_unchecked(links)
+///     }
+/// }
+/// ```
+///
+/// It is also possible to ensure that the struct implementing `Linked` is laid
+/// out so that the `Links` field is the first member of the struct, and then
+/// cast the pointer to a `Links`. Since [Rust's native type representation][repr]
+/// does not guarantee the layout of struct members, it is **necessary** to ensure
+/// that any struct that implements the `Linked::links` method in this manner has a
+/// [`#[repr(C)]` attribute][repr-c], ensuring that its fields are laid out in the
+/// order that they are defined.
+///
+/// For example:
+///
+/// ```
+/// use core::ptr::NonNull;
+/// use cordyceps::{Linked, list};
+///
+/// // This `repr(C)` attribute is *mandatory* here, as it ensures that the
+/// // `links` field will *always* be the first field in the struct's in-memory
+/// // representation.
+/// #[repr(C)]
+/// struct Entry {
+///     links: list::Links<Self>,
+///     data: usize,
+/// }
+///
+/// unsafe impl Linked<list::Links<Self>> for Entry {
+///     # type Handle = NonNull<Self>;
+///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
+///     // ...
+///
+///     unsafe fn links(target: NonNull<Self>) -> NonNull<list::Links<Self>> {
+///         // safety: this performs a layout-dependent cast! it is only sound
+///         // if the `Entry` type has a `#[repr(C)]` attribute!
+///         target.cast::<list::Links<Self>>()
+///     }
+/// }
+/// ```
+///
+/// In general, this approach is not recommended, and using
+/// [`core::ptr::addr_of_mut!`] should be preferred in almost all cases. In
+/// particular, the layout-dependent cast is more error-prone, as it requires a
+/// `#[repr(C)]` attribute to avoid soundness issues. Additionally, the
+/// layout-based cast does not permit a single struct to contain `Links` fields
+/// for multiple intrusive data structures, as the `Links` type *must* be the
+/// struct's first field.[^2] Therefore, [`Linked::links`] should generally be
+/// implemented using [`addr_of_mut!`](core::ptr::addr_of_mut).
+///
+/// [^1]: Note that code like this is not *currently* known to result in
+///     miscompiles, but it is rejected by tools like Miri as being unsound.
+///     Like all undefined behavior, there is no guarantee that future Rust
+///     compilers will not miscompile code like this, with disastrous results.
+/// [^2]: And two different fields cannot both be the first field at the same
+///      time...by definition.
+///
 /// [intrusive collection]: crate#intrusive-data-structures
 /// [`Unpin`]: core::marker::Unpin
 /// [doubly-linked list]: crate::list
 /// [MSPC queue]: crate::mpsc_queue
+/// [Stacked Borrows]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md
+/// [repr]: https://doc.rust-lang.org/nomicon/repr-rust.html
+/// [repr-c]: https://doc.rust-lang.org/nomicon/other-reprs.html#reprc
 pub unsafe trait Linked<L> {
     /// The handle owning nodes in the linked list.
     ///
@@ -95,5 +233,8 @@ pub unsafe trait Linked<L> {
     /// - It is valid to construct a [`Self::Handle`] from a`raw pointer
     /// - The pointer points to a valid instance of `Self` (e.g. it does not
     ///   dangle).
+    ///
+    /// See [the trait-level documentation](#implementing-linkedlinks) for
+    /// details on how to correctly implement this method.
     unsafe fn links(ptr: NonNull<Self>) -> NonNull<L>;
 }

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -90,13 +90,13 @@ use core::ptr::NonNull;
 ///
 /// unsafe impl Linked<list::Links<Self>> for Entry {
 ///     # type Handle = NonNull<Self>;
-///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
 ///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
 ///     // ...
 ///
-///     unsafe fn links(target: NonNull<Self>) -> NonNull<list::Links<Self>> {
+///     unsafe fn links(mut target: NonNull<Self>) -> NonNull<list::Links<Self>> {
 ///         // Borrow the target's `links` field.
-///         let links = target.as_mut().links;
+///         let links = &mut target.as_mut().links;
 ///         // Convert that reference into a pointer.
 ///         NonNull::from(links)
 ///     }
@@ -121,7 +121,7 @@ use core::ptr::NonNull;
 ///
 /// unsafe impl Linked<list::Links<Self>> for Entry {
 ///     # type Handle = NonNull<Self>;
-///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
 ///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
 ///     // ...
 ///
@@ -165,12 +165,12 @@ use core::ptr::NonNull;
 ///
 /// unsafe impl Linked<list::Links<Self>> for Entry {
 ///     # type Handle = NonNull<Self>;
-///     # unsafe fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
+///     # fn into_ptr(r: Self::Handle) -> NonNull<Self> { r }
 ///     # unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle { ptr }
 ///     // ...
 ///
 ///     unsafe fn links(target: NonNull<Self>) -> NonNull<list::Links<Self>> {
-///         // safety: this performs a layout-dependent cast! it is only sound
+///         // Safety: this performs a layout-dependent cast! it is only sound
 ///         // if the `Entry` type has a `#[repr(C)]` attribute!
 ///         target.cast::<list::Links<Self>>()
 ///     }

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -44,12 +44,9 @@ pub use self::cursor::{Cursor, CursorMut};
 ///
 /// // This example uses the Rust standard library for convenience, but
 /// // the doubly-linked list itself does not require std.
-/// use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
+/// use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 ///
 /// /// A simple queue entry that stores an `i32`.
-/// // This type must be `repr(C)` in order for the cast in `Linked::links`
-/// // to be sound.
-/// #[repr(C)]
 /// #[derive(Debug, Default)]
 /// struct Entry {
 ///    links: list::Links<Entry>,
@@ -87,9 +84,10 @@ pub use self::cursor::{Cursor, CursorMut};
 ///
 ///     /// Access an element's `Links`.
 ///     unsafe fn links(target: NonNull<Entry>) -> NonNull<list::Links<Entry>> {
-///         // Safety: this cast is safe only because `Entry` `is repr(C)` and
-///         // the links is the first field.
-///         target.cast()
+///         // Using `ptr::addr_of_mut!` permits us to avoid creating a temporary
+///         // reference without using layout-dependent casts.
+///         let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+///         NonNull::new_unchecked(links)
 ///     }
 /// }
 ///
@@ -110,8 +108,7 @@ pub use self::cursor::{Cursor, CursorMut};
 /// #     Linked,
 /// #     list::{self, List},
 /// # };
-/// # use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
-/// # #[repr(C)]
+/// # use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 /// # #[derive(Debug, Default)]
 /// # struct Entry {
 /// #    links: list::Links<Entry>,
@@ -126,7 +123,8 @@ pub use self::cursor::{Cursor, CursorMut};
 /// #         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))
 /// #     }
 /// #     unsafe fn links(target: NonNull<Entry>) -> NonNull<list::Links<Entry>> {
-/// #         target.cast()
+/// #        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+/// #        NonNull::new_unchecked(links)
 /// #     }
 /// # }
 /// # impl Entry {
@@ -164,8 +162,7 @@ pub use self::cursor::{Cursor, CursorMut};
 /// #     Linked,
 /// #     list::{self, List},
 /// # };
-/// # use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
-/// # #[repr(C)]
+/// # use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 /// # #[derive(Debug, Default)]
 /// # struct Entry {
 /// #    links: list::Links<Entry>,
@@ -180,7 +177,8 @@ pub use self::cursor::{Cursor, CursorMut};
 /// #         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))
 /// #     }
 /// #     unsafe fn links(target: NonNull<Entry>) -> NonNull<list::Links<Entry>> {
-/// #         target.cast()
+/// #        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+/// #        NonNull::new_unchecked(links)
 /// #     }
 /// # }
 /// # impl Entry {

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -87,6 +87,10 @@ pub use self::cursor::{Cursor, CursorMut};
 ///         // Using `ptr::addr_of_mut!` permits us to avoid creating a temporary
 ///         // reference without using layout-dependent casts.
 ///         let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+///
+///         // `NonNull::new_unchecked` is safe to use here, because the pointer that
+///         // we offset was not null, implying that the pointer produced by offsetting
+///         // it will also not be null.
 ///         NonNull::new_unchecked(links)
 ///     }
 /// }

--- a/cordyceps/src/list/tests.rs
+++ b/cordyceps/src/list/tests.rs
@@ -1,8 +1,13 @@
 use super::*;
-use std::{boxed::Box, pin::Pin, ptr::NonNull, vec, vec::Vec};
+use std::{
+    boxed::Box,
+    pin::Pin,
+    ptr::{self, NonNull},
+    vec,
+    vec::Vec,
+};
 
 #[derive(Debug)]
-#[repr(C)]
 struct Entry<'a> {
     links: Links<Entry<'a>>,
     val: i32,
@@ -30,9 +35,12 @@ unsafe impl<'a> Linked<Links<Self>> for Entry<'a> {
     }
 
     unsafe fn links(target: NonNull<Entry<'a>>) -> NonNull<Links<Entry<'a>>> {
-        // Safety: this is safe because the `links` are the first field of
-        // `Entry`, and `Entry` is `repr(C)`.
-        target.cast()
+        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+        // Safety: it's fine to use `new_unchecked` here; if the pointer that we
+        // offset to the `links` field is not null (which it shouldn't be, as we
+        // received it as a `NonNull`), the offset pointer should therefore also
+        // not be null.
+        NonNull::new_unchecked(links)
     }
 }
 

--- a/cordyceps/src/mpsc_queue.rs
+++ b/cordyceps/src/mpsc_queue.rs
@@ -41,12 +41,9 @@ use core::{
 ///
 /// // This example uses the Rust standard library for convenience, but
 /// // the MPSC queue itself does not require std.
-/// use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
+/// use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 ///
 /// /// A simple queue entry that stores an `i32`.
-/// // This type must be `repr(C)` in order for the cast in `Linked::links`
-/// // to be sound.
-/// #[repr(C)]
 /// #[derive(Debug, Default)]
 /// struct Entry {
 ///    links: mpsc_queue::Links<Entry>,
@@ -79,14 +76,15 @@ use core::{
 ///         // some random `NonNull<Entry>`, this would not be the case, and
 ///         // this could be constructing an erroneous `Pin` from a referent
 ///         // that may not be pinned!
-///         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))
+///         Pin::new_unchecked(Box::from_raw(target.as_ptr()))
 ///     }
 ///
 ///     /// Access an element's `Links`.
 ///     unsafe fn links(target: NonNull<Entry>) -> NonNull<mpsc_queue::Links<Entry>> {
-///         // Safety: this cast is safe only because `Entry` `is repr(C)` and
-///         // the links is the first field.
-///         target.cast()
+///         // Using `ptr::addr_of_mut!` permits us to avoid creating a temporary
+///         // reference without using layout-dependent casts.
+///         let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+///         NonNull::new_unchecked(links)
 ///     }
 /// }
 ///
@@ -160,7 +158,7 @@ use core::{
 /// #     Linked,
 /// #     mpsc_queue::{self, MpscQueue},
 /// # };
-/// # use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
+/// # use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 /// #
 /// # #[repr(C)]
 /// # #[derive(Debug, Default)]
@@ -181,7 +179,8 @@ use core::{
 /// #     }
 /// #
 /// #     unsafe fn links(target: NonNull<Entry>) -> NonNull<mpsc_queue::Links<Entry>> {
-/// #         target.cast()
+/// #        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+/// #        NonNull::new_unchecked(links)
 /// #     }
 /// # }
 /// #
@@ -233,7 +232,7 @@ use core::{
 /// #     Linked,
 /// #     mpsc_queue::{self, MpscQueue},
 /// # };
-/// # use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
+/// # use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
 /// #
 /// # #[repr(C)]
 /// # #[derive(Debug, Default)]
@@ -254,7 +253,8 @@ use core::{
 /// #     }
 /// #
 /// #     unsafe fn links(target: NonNull<Entry>) -> NonNull<mpsc_queue::Links<Entry>> {
-/// #         target.cast()
+/// #        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+/// #        NonNull::new_unchecked(links)
 /// #     }
 /// # }
 /// #
@@ -481,7 +481,7 @@ impl<T: Linked<Links<T>>> MpscQueue<T> {
     /// #     Linked,
     /// #     mpsc_queue::{self, MpscQueue},
     /// # };
-    /// # use std::{pin::Pin, ptr::NonNull, thread, sync::Arc};
+    /// # use std::{pin::Pin, ptr::{self, NonNull}, thread, sync::Arc};
     /// #
     /// #
     ///
@@ -507,7 +507,8 @@ impl<T: Linked<Links<T>>> MpscQueue<T> {
     /// #     }
     /// #
     /// #     unsafe fn links(target: NonNull<Entry>) -> NonNull<mpsc_queue::Links<Entry>> {
-    /// #         target.cast()
+    /// #        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+    /// #        NonNull::new_unchecked(links)
     /// #     }
     /// # }
     /// #
@@ -1485,8 +1486,8 @@ mod tests {
 mod test_util {
     use super::*;
     use crate::loom::alloc;
-    pub use std::{boxed::Box, pin::Pin, println, vec, vec::Vec};
-    #[repr(C)]
+    pub use std::{boxed::Box, pin::Pin, println, ptr, vec, vec::Vec};
+
     pub(super) struct Entry {
         links: Links<Entry>,
         pub(super) val: i32,
@@ -1521,9 +1522,8 @@ mod test_util {
         }
 
         unsafe fn links(target: NonNull<Entry>) -> NonNull<Links<Entry>> {
-            // Safety: this cast is safe only because `Entry` `is repr(C)` and
-            // the links is the first field.
-            target.cast()
+            let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+            NonNull::new_unchecked(links)
         }
     }
 

--- a/cordyceps/src/mpsc_queue.rs
+++ b/cordyceps/src/mpsc_queue.rs
@@ -76,7 +76,7 @@ use core::{
 ///         // some random `NonNull<Entry>`, this would not be the case, and
 ///         // this could be constructing an erroneous `Pin` from a referent
 ///         // that may not be pinned!
-///         Pin::new_unchecked(Box::from_raw(target.as_ptr()))
+///         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))
 ///     }
 ///
 ///     /// Access an element's `Links`.
@@ -84,6 +84,10 @@ use core::{
 ///         // Using `ptr::addr_of_mut!` permits us to avoid creating a temporary
 ///         // reference without using layout-dependent casts.
 ///         let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+///
+///         // `NonNull::new_unchecked` is safe to use here, because the pointer that
+///         // we offset was not null, implying that the pointer produced by offsetting
+///         // it will also not be null.
 ///         NonNull::new_unchecked(links)
 ///     }
 /// }


### PR DESCRIPTION
Currently, the `cordyceps` tests and docs show the use of a `#[repr(C)]`
struct with the `Links` field as the first member of the struct, and use
a cast from `NonNull<Self>` to `NonNull<Links<Self>>` in order to
implement the `Linked::links` method. This is done to avoid the creation
of a temporary reference by dereferencing the pointer and borrowing the
`Links` field, which Stacked Borrows dislikes.

This approach is not ideal for a couple of reasons:

 * It performs a layout-dependent cast, and therefore *requires* the
   `#[repr(C)]` attribute be present to ensure soundness. This means
   that forgetting to add that attribute may result in miscompiles.
   Also, relying on struct layout makes me feel uncomfortable and we
   should try to avoid it where possible.
 * It means that a given struct may not contain multiple types of
   `Links` for different intrusive data structures. This is because the
   layout-dependent cast requires the `Links` field to be the *first*
   member of the struct, and multiple fields obviously cannot be the
   first. :)

We can also avoid the creation of a temporary reference by using the
`core::ptr::addr_of_mut!` macro to offset a pointer to a subfield of the
pointed type. This avoids the disadvantages of the cast while still
passing Miri.

Therefore, this branch updates the `cordyceps` examples, docs, and
tests, to show the use of `addr_of_mut!` rather than casting. In
addition, I've added a section to the `Linked` trait documentation
explaining why it's necessary to avoid temporary references, and
discussing why `addr_of_mut!` should be used for this purpose.

In the future, we may want to consider adding a macro (or a derive
attribute?) that generates correct `Linked` implementations using
`addr_of_mut!`, to make it easier to use intrusive structures safely...