### PR TITLE
fix(bitfield): fix `raw_mask` shifting twice

### DIFF
--- a/bitfield/src/pack.rs
+++ b/bitfield/src/pack.rs
@@ -330,7 +330,7 @@ macro_rules! make_packers {
                 /// Returns a raw, shifted mask for unpacking this packing spec.
                 #[inline]
                 pub const fn raw_mask(&self) -> $Bits {
-                    self.mask << self.shift
+                    self.mask
                 }
 
                 /// Pack the [`self.bits()`] least-significant bits from `value` into `base`.


### PR DESCRIPTION
There's currently a bug in the `raw_mask` method on
`mycelium-bitfield`'s packing spec types. `raw_mask` returns `self.mask`
shifted over by `self.shift`, with the intention of returning the actual
mask used by the packing spec. But...the `self.mask` field is already
shifted to the correct bit position, so shifting it in the `raw_mask`
method results in the mask being shifted over twice as many bits as it's
supposed to be.

This caused some *very* weird behavior in the `maitake` task state
management code, where attempting to toggle a bit using its `raw_mask`
would accidentally clobber low bits of the ref count, resulting in a
ref-count underflow in some cases.