### PR TITLE
chore(maitake): Fix misc release mode errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,18 @@ jobs:
       run: rustup show
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - uses: actions/checkout@v2
-    - name: run cargo check
+    - name: run cargo check (debug)
       run: |
         cargo check \
+          --workspace \
+          --all-features \
+          --quiet \
+          --message-format=json |
+          cargo-action-fmt
+    - name: run cargo check (release)
+      run: |
+        cargo check \
+          --release \
           --workspace \
           --all-features \
           --quiet \

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -692,7 +692,7 @@ unsafe fn _maitake_header_nop_poll_join(
     #[cfg(debug_assertions)]
     unreachable!("stub task ({_ptr:?}) should never be polled!");
     #[cfg(not(debug_assertions))]
-    false
+    Poll::Ready(Err(JoinError::stub()))
 }
 
 impl Header {

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -41,6 +41,9 @@ pub struct JoinError {
 enum JoinErrorKind {
     /// The task was canceled.
     Canceled,
+
+    /// A stub was awaited
+    StubNever,
 }
 
 impl<T> JoinHandle<T> {
@@ -98,6 +101,13 @@ impl JoinError {
     pub(crate) fn canceled() -> Self {
         Self {
             kind: JoinErrorKind::Canceled,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn stub() -> Self {
+        Self {
+            kind: JoinErrorKind::StubNever,
         }
     }
 

--- a/util/src/sync/once.rs
+++ b/util/src/sync/once.rs
@@ -178,7 +178,6 @@ impl<T> InitOnce<T> {
     /// your code.
     #[cfg_attr(not(debug_assertions), inline(always))]
     #[cfg_attr(debug_assertions, track_caller)]
-    #[inline]
     #[must_use]
     pub unsafe fn get_unchecked(&self) -> &T {
         debug_assert_eq!(


### PR DESCRIPTION
A couple more issues showed up in release mode only.

Edit:

Added a basic `cargo check --release`, which I verified would have caught this regression.

Closes #273 