### PR TITLE
perf(maitake): don't use `WaitCell` for join wakers

### DIFF
--- a/maitake/src/lib.rs
+++ b/maitake/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(docsrs, loom)))]
 #![cfg_attr(not(test), no_std)]
+#![allow(unused_unsafe)]
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -107,8 +107,11 @@ pub struct Task<S, F: Future, STO> {
     ///
     /// # Safety
     ///
-    /// This field is only initialized when the [`State::HAS_JOIN_WAKER`] bit is
-    /// set. If that bit is unset, this field may be uninitialized.
+    /// This field is only initialized when the [`State::JOIN_WAKER`] state
+    /// field is set to `JoinWakerState::Waiting`. If the join waker state is
+    /// any other value, this field may be uninitialized.
+    ///
+    /// [`State::JOIN_WAKER`]: state::State::JOIN_WAKER
     join_waker: UnsafeCell<CheckedMaybeUninit<Waker>>,
 
     /// The [`Storage`] type associated with this struct

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -108,15 +108,11 @@ pub struct Task<S, F: Future, STO> {
 
     /// The [`Waker`] of the [`JoinHandle`] for this task, if one exists.
     ///
-    // TODO(eliza): using `WaitCell` here is, admittedly, not the most
-    // efficient. A `WaitCell` has its own atomic state word, but we really only
-    // need a couple bits of state to control access to the waker. This *could*
-    // be rolled into the task's `StateCell`, and the join waker could just be
-    // an `UnsafeCell<MaybeUninit<Waker>>`, which would probably be better ---
-    // it would mean we only need to ever touch _one_ atomic, and we wouldn't
-    // need a whole extra word in the task allocation just to store a couple
-    // bits. But, `WaitCell` works fine for now.
-    join_waker: WaitCell,
+    /// # Safety
+    ///
+    /// This field is only initialized when the [`State::HAS_JOIN_WAKER`] bit is
+    /// set. If that bit is unset, this field may be uninitialized.
+    join_waker: UnsafeCell<mem::MaybeUninit<Waker>>,
 
     /// The [`Storage`] type associated with this struct
     ///
@@ -296,7 +292,7 @@ where
             },
             scheduler,
             inner: UnsafeCell::new(Cell::Pending(future)),
-            join_waker: WaitCell::new(),
+            join_waker: UnsafeCell::new(mem::MaybeUninit::uninit()),
             span: crate::trace::Span::none(),
             storage: PhantomData,
         }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -104,6 +104,7 @@ impl JoinError {
         }
     }
 
+    #[allow(dead_code)] // this will be used when i implement task cancellation
     #[inline]
     pub(crate) fn stub() -> Self {
         Self {

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -32,12 +32,20 @@ mycelium_bitfield::bitfield! {
         /// `join_waker` slot; it only indicates that a [`JoinHandle`] for this
         /// task *exists*. The join waker may not currently be registered if
         /// this flag is set.
+        ///
+        /// [`Waker`]: core::task::Waker
+        /// [`JoinHandle`]: super::JoinHandle
         pub(crate) const HAS_JOIN_HANDLE: bool;
 
-        /// The state of the task's [`JoinHandle`] waker.
+        /// The state of the task's [`JoinHandle`] [`Waker`].
+        ///
+        /// [`Waker`]: core::task::Waker
+        /// [`JoinHandle`]: super::JoinHandle
         const JOIN_WAKER: JoinWakerState;
 
         /// If set, this task has output ready to be taken by a [`JoinHandle`].
+        ///
+        /// [`JoinHandle`]: super::JoinHandle
         pub(crate) const HAS_OUTPUT: bool;
 
         /// The number of currently live references to this task.
@@ -414,8 +422,11 @@ impl StateCell {
         })
     }
 
-    /// Returns `true` if this task has an un-dropped [`JoinHandle`] waker that
+    /// Returns `true` if this task has an un-dropped [`JoinHandle`] [`Waker`] that
     /// needs to be dropped.
+    ///
+    /// [`JoinHandle`]: super::JoinHandle
+    /// [`Waker`]: core::task::Waker
     pub(super) fn join_waker_needs_drop(&self) -> bool {
         let state = self.load(Acquire);
         match test_dbg!(state.get(State::JOIN_WAKER)) {

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -3,6 +3,7 @@ use crate::loom::sync::atomic::{
     Ordering::{self, *},
 };
 use core::fmt;
+use mycelium_util::{sync::spin::Backoff, unreachable_unchecked};
 
 mycelium_bitfield::bitfield! {
     /// A snapshot of a task's current state.
@@ -33,13 +34,8 @@ mycelium_bitfield::bitfield! {
         /// this flag is set.
         pub(crate) const HAS_JOIN_HANDLE: bool;
 
-        /// If set, the task's [`JoinHandle`] has registered a [`Waker`] in the
-        /// task's `join_waker` slot.
-        ///
-        /// If this is not set, the `join_waker` slot may be uninitialized.
-        ///
-        /// If this is set, it implies that `HAS_JOIN_HANDLE` is also set.
-        pub(crate) const HAS_JOIN_WAKER: bool;
+        /// The state of the task's [`JoinHandle`] waker.
+        const JOIN_WAKER: JoinWakerState;
 
         /// If set, this task has output ready to be taken by a [`JoinHandle`].
         pub(crate) const HAS_OUTPUT: bool;
@@ -49,7 +45,6 @@ mycelium_bitfield::bitfield! {
         /// When this is 0, the task may be deallocated.
         const REFS = ..;
     }
-
 }
 
 /// An atomic cell that stores a task's current [`State`].
@@ -76,6 +71,20 @@ pub(super) enum PollAction {
     /// The task does not need to be enqueued, and the join waker does not need
     /// to be woken.
     None,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(super) enum JoinAction {
+    /// It's safe to take the task's output!
+    TakeOutput,
+
+    /// Register the *first* join waker; there is no previous join waker and the
+    /// slot is not initialized.
+    Register,
+
+    /// The task is not ready to read the output, but a previous join waker is
+    /// registered.
+    Reregister,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -106,6 +115,19 @@ impl State {
 
 const REF_ONE: usize = State::REFS.first_bit();
 const REF_MAX: usize = State::REFS.raw_mask();
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum JoinWakerState {
+    /// There is no join waker; the slot is uninitialized.
+    Empty = 0b00,
+    /// A join waker is *being* registered.
+    Registering = 0b01,
+    /// A join waker is registered, the slot is initialized.
+    Waiting = 0b10,
+    /// The join waker has been woken.
+    Woken = 0b11,
+}
 
 // === impl StateCell ===
 
@@ -144,7 +166,8 @@ impl StateCell {
     }
 
     pub(super) fn end_poll(&self, completed: bool) -> OrDrop<PollAction> {
-        self.transition(|state| {
+        let mut should_wait_for_join_waker = false;
+        let action = self.transition(|state| {
             // Cannot end a poll if a task is not being polled!
             debug_assert!(state.get(State::POLLING));
             debug_assert!(!state.get(State::COMPLETED));
@@ -158,27 +181,63 @@ impl StateCell {
                 return OrDrop::Action(PollAction::Enqueue);
             }
 
-            let had_join_waiter = if test_dbg!(completed) {
+            let had_join_waker = if test_dbg!(completed) {
                 // set the output flag so that the joinhandle knows it is now
                 // safe to read the task's output.
-                next_state = next_state.with(State::HAS_OUTPUT, true);
-                test_dbg!(state.get(State::HAS_JOIN_HANDLE))
+                next_state.set(State::HAS_OUTPUT, true);
+                match state.get(State::JOIN_WAKER) {
+                    JoinWakerState::Empty => false,
+                    JoinWakerState::Registering => {
+                        should_wait_for_join_waker = true;
+                        true
+                    },
+                    JoinWakerState::Waiting => {
+                        should_wait_for_join_waker = false;
+                        next_state.set(State::JOIN_WAKER, JoinWakerState::Empty);
+                        true
+                    },
+                    JoinWakerState::Woken => {
+                        debug_assert!(false, "join waker should not be woken until task has completed, wtf");
+                        false
+                    }
+                }
             } else {
                 false
             };
 
-            *state = next_state;
 
-            if next_state.ref_count() == 0 {
-                debug_assert!(!had_join_waiter, "a task's ref count went to zero, but the `HAS_JOIN_HANDLE` bit was set! state: {state:?}");
+            let action = if next_state.ref_count() == 0 {
+                debug_assert!(
+                    !had_join_waker,
+                    "a task's ref count went to zero, but the `HAS_JOIN_WAKER` bit was set! state: {state:?}",
+                );
+                debug_assert!(
+                    !state.get(State::HAS_JOIN_HANDLE),
+                    "a task's ref count went to zero, but the `HAS_JOIN_HANDLE` bit was set! state: {state:?}",
+                );
                 OrDrop::Drop
-            } else if had_join_waiter {
+            } else if had_join_waker {
+                debug_assert!(
+                    state.get(State::HAS_JOIN_HANDLE),
+                    "a task cannot have a join waker if it does not have a join handle!",
+                );
 
                 OrDrop::Action(PollAction::WakeJoinWaiter)
             } else {
                 OrDrop::Action(PollAction::None)
-            }
-        })
+            };
+
+            *state = next_state;
+
+            action
+        });
+
+        if should_wait_for_join_waker {
+            debug_assert_eq!(action, OrDrop::Action(PollAction::WakeJoinWaiter));
+            self.wait_for_join_waker();
+        }
+
+        action
     }
 
     /// Transition to the woken state by value, returning `true` if the task
@@ -315,22 +374,43 @@ impl StateCell {
         )
     }
 
-    /// Returns `true` if it's okay to take the task's output.
-    pub(super) fn try_take_output(&self) -> bool {
+    /// Returns whether if it's okay to take the task's output.
+    pub(super) fn try_join(&self) -> JoinAction {
+        fn should_register(state: &mut State) -> JoinAction {
+            let action = match state.get(State::JOIN_WAKER) {
+                JoinWakerState::Empty => JoinAction::Register,
+                x => {
+                    debug_assert_eq!(x, JoinWakerState::Waiting);
+                    JoinAction::Reregister
+                }
+            };
+            state.set(State::JOIN_WAKER, JoinWakerState::Registering);
+
+            action
+        }
+
         self.transition(|state| {
             // If the task has not completed, we can't take its join output.
             if test_dbg!(!state.get(State::COMPLETED)) {
-                *state = state.with(State::HAS_JOIN_HANDLE, true);
-                return false;
+                return should_register(state);
             }
 
             // If the task does not have output, we cannot take it.
             if test_dbg!(!state.get(State::HAS_OUTPUT)) {
-                return false;
+                return should_register(state);
             }
 
             *state = state.with(State::HAS_OUTPUT, false);
-            true
+            JoinAction::TakeOutput
+        })
+    }
+
+    pub(super) fn join_waker_registered(&self) {
+        self.transition(|state| {
+            debug_assert_eq!(state.get(State::JOIN_WAKER), JoinWakerState::Registering);
+            state
+                .set(State::HAS_JOIN_HANDLE, true)
+                .set(State::JOIN_WAKER, JoinWakerState::Waiting);
         })
     }
 
@@ -363,11 +443,55 @@ impl StateCell {
             }
         }
     }
+
+    fn wait_for_join_waker(&self) {
+        test_trace!("StateCell::wait_for_join_waker");
+        let mut state = self.load(Acquire);
+        let mut boff = Backoff::new();
+        loop {
+            state.set(State::JOIN_WAKER, JoinWakerState::Waiting);
+            let next = state.with(State::JOIN_WAKER, JoinWakerState::Woken);
+            match self
+                .0
+                .compare_exchange_weak(state.0, next.0, AcqRel, Acquire)
+            {
+                Ok(_) => return,
+                Err(actual) => state = State(actual),
+            }
+            boff.spin();
+        }
+    }
 }
 
 impl fmt::Debug for StateCell {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.load(Relaxed).fmt(f)
+    }
+}
+
+impl mycelium_bitfield::FromBits<usize> for JoinWakerState {
+    type Error = core::convert::Infallible;
+
+    /// The number of bits required to represent a value of this type.
+    const BITS: u32 = 2;
+
+    #[inline]
+    fn try_from_bits(bits: usize) -> Result<Self, Self::Error> {
+        match bits {
+            b if b == Self::Registering as usize => Ok(Self::Registering),
+            b if b == Self::Waiting as usize => Ok(Self::Waiting),
+            b if b == Self::Empty as usize => Ok(Self::Empty),
+            b if b == Self::Woken as usize => Ok(Self::Woken),
+            _ => unsafe {
+                // this should never happen unless the bitpacking code is broken
+                unreachable_unchecked!("invalid join waker state {bits:#b}")
+            },
+        }
+    }
+
+    #[inline]
+    fn into_bits(self) -> usize {
+        self as u8 as usize
     }
 }
 

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -26,9 +26,24 @@ mycelium_bitfield::bitfield! {
         /// If set, this task has a [`JoinHandle`] awaiting its completion.
         ///
         /// If the `JoinHandle` is dropped, this flag is unset.
+        ///
+        /// This flag does *not* indicate the presence of a [`Waker`] in the
+        /// `join_waker` slot; it only indicates that a [`JoinHandle`] for this
+        /// task *exists*. The join waker may not currently be registered if
+        /// this flag is set.
         pub(crate) const HAS_JOIN_HANDLE: bool;
+
+        /// If set, the task's [`JoinHandle`] has registered a [`Waker`] in the
+        /// task's `join_waker` slot.
+        ///
+        /// If this is not set, the `join_waker` slot may be uninitialized.
+        ///
+        /// If this is set, it implies that `HAS_JOIN_HANDLE` is also set.
+        pub(crate) const HAS_JOIN_WAKER: bool;
+
         /// If set, this task has output ready to be taken by a [`JoinHandle`].
         pub(crate) const HAS_OUTPUT: bool;
+
         /// The number of currently live references to this task.
         ///
         /// When this is 0, the task may be deallocated.

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -168,6 +168,27 @@ mod alloc {
         unsafe { drop(Box::from_raw(task_ptr)) }
     }
 
+    /// This test just prints the size (in bytes) of an empty task struct.
+    #[test]
+    fn empty_task_size() {
+        type Future = futures::future::Ready<()>;
+        type EmptyTask = Task<NopSchedule, Future, BoxStorage>;
+        println!(
+            "{}: {}B",
+            core::any::type_name::<EmptyTask>(),
+            core::mem::size_of::<EmptyTask>(),
+        );
+        println!(
+            "{}: {}B",
+            core::any::type_name::<Future>(),
+            core::mem::size_of::<Future>(),
+        );
+        println!(
+            "task size: {}B",
+            core::mem::size_of::<EmptyTask>() - core::mem::size_of::<Future>()
+        );
+    }
+
     #[test]
     fn join_handle_wakes() {
         crate::util::trace_init();


### PR DESCRIPTION
Currently, `maitake`'s tasks store the `Waker` of any `JoinHandle` that
has polled the task using a `WaitCell`. This is somewhat inefficient, as
`WaitCell`s have their own atomic word of state, but only a couple bits
of state are actually needed to control access to the `Waker`.

Since `Task`s already have their own atomic word of state, we can reduce
the task's heap size significantly by changing from using a `WaitCell`
to just using a couple additional bits of the task's `StateCell` to
track the waiter's state. This gets rid of a word-sized atomic and (when
cache padding is enabled) that atomic's cache-line padding as well. By
storing the waker in a `MaybeUninit` instead of an `Option` (which is
fine here, as we will never set a waker again after consuming it), we
also avoid the `Option`'s enum descriminant...as well as any padding
added by the compiler to align the `WaitCell`.

Adding a test that prints the total size of an empty[^1] `Task`, we see
a significant decrease in the release-mode size of the `Task` struct.

Before:

```shell
:# eliza at noctis in mycelium on eliza/task-sz-test [$]
:; cargo test -p maitake --release --lib -- empty_task_size --show-output
    Finished release [optimized] target(s) in 0.08s
     Running unittests src/lib.rs (target/release/deps/maitake-a93de07a086e60a9)

running 1 test
test task::tests::alloc::empty_task_size ... ok

successes:

---- task::tests::alloc::empty_task_size stdout ----
maitake::task::Task<maitake::task::tests::alloc::NopSchedule, futures_util::future::ready::Ready<()>, maitake::task::storage::BoxStorage>: 384B
futures_util::future::ready::Ready<()>: 1B
task size: 383B
```

After:

```shell
:# eliza at noctis in mycelium on eliza/joinwaker-unsafe-cell [$]
:; cargo test -p maitake --release --lib -- empty_task_size --show-output
    Finished release [optimized] target(s) in 0.08s
     Running unittests src/lib.rs (target/release/deps/maitake-a93de07a086e60a9)

running 1 test
test task::tests::alloc::empty_task_size ... ok

successes:

---- task::tests::alloc::empty_task_size stdout ----
maitake::task::Task<maitake::task::tests::alloc::NopSchedule, futures_util::future::ready::Ready<()>, maitake::task::storage::BoxStorage>: 88B
futures_util::future::ready::Ready<()>: 1B
task size: 87B
```

A reduction of 296 bytes!

Depends on #275.

[^1]: Created by spawning `futures::future::Ready<()>`.