### PR TITLE
feat(maitake): add `Schedule::current_task`

### DIFF
--- a/maitake/src/task/builder.rs
+++ b/maitake/src/task/builder.rs
@@ -1,4 +1,4 @@
-use super::{Future, JoinHandle, Schedule, Storage, Task, TaskRef};
+use super::{Future, JoinHandle, Schedule, Storage, TaskRef};
 use core::panic::Location;
 
 /// Builds a new [`Task`] prior to spawning it.
@@ -122,7 +122,8 @@ impl<'a, S: Schedule> Builder<'a, S> {
             F::Output: 'static,
         {
             use alloc::boxed::Box;
-            use super::BoxStorage;
+            use super::{BoxStorage, Task};
+
             let task = Box::new(Task::<S, _, BoxStorage>::new(self.scheduler.clone(), future));
             let (task, join) = TaskRef::build_allocated::<S, _, BoxStorage>(&self.settings, task);
             self.scheduler.schedule(task);

--- a/maitake/src/task/builder.rs
+++ b/maitake/src/task/builder.rs
@@ -2,6 +2,8 @@ use super::{Future, JoinHandle, Schedule, Storage, TaskRef};
 use core::panic::Location;
 
 /// Builds a new [`Task`] prior to spawning it.
+///
+/// [`Task`]: crate::task::Task
 #[derive(Debug, Clone)]
 pub struct Builder<'a, S> {
     scheduler: S,

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -24,6 +24,10 @@ use core::{future::Future, marker::PhantomData, pin::Pin};
 /// [`task::Builder::spawn`]: crate::task::Builder::spawn
 /// [`task::Builder::spawn_allocated`]: crate::task::Builder::spawn_allocated
 #[derive(Debug, PartialEq, Eq)]
+// This clippy lint appears to be triggered incorrectly; this type *does* derive
+// `Eq` based on its `PartialEq<Self>` impl, but it also implements `PartialEq`
+// with types other than `Self` (which cannot impl `Eq`).
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub struct JoinHandle<T> {
     task: Option<TaskRef>,
     _t: PhantomData<fn(T)>,

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -1,8 +1,4 @@
-use crate::{
-    future,
-    scheduler::{Schedule, Scheduler},
-    task::*,
-};
+use crate::{future, scheduler::Schedule, task::*};
 
 #[derive(Copy, Clone, Debug)]
 struct NopSchedule;
@@ -20,13 +16,16 @@ impl Schedule for NopSchedule {
 #[cfg(loom)]
 mod loom {
     use super::*;
-    use crate::loom::{
-        self,
-        alloc::{Track, TrackFuture},
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
+    use crate::{
+        loom::{
+            self,
+            alloc::{Track, TrackFuture},
+            sync::{
+                atomic::{AtomicBool, Ordering},
+                Arc,
+            },
         },
+        scheduler::Scheduler,
     };
 
     #[test]
@@ -135,6 +134,7 @@ mod loom {
 #[cfg(all(not(loom), feature = "alloc"))]
 mod alloc_tests {
     use super::*;
+    use crate::scheduler::Scheduler;
     use alloc::boxed::Box;
     use core::{
         ptr,

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -1,34 +1,39 @@
+use crate::{
+    future,
+    scheduler::{Schedule, Scheduler},
+    task::*,
+};
+
+#[derive(Copy, Clone, Debug)]
+struct NopSchedule;
+
+impl Schedule for NopSchedule {
+    fn schedule(&self, task: TaskRef) {
+        unimplemented!("nop scheduler tried to schedule task {:?}", task);
+    }
+
+    fn current_task(&self) -> Option<TaskRef> {
+        unimplemented!("nop scheduler does not have a current task")
+    }
+}
+
 #[cfg(loom)]
 mod loom {
-    use crate::{
-        future,
-        loom::{
-            self,
-            alloc::{Track, TrackFuture},
-            sync::{
-                atomic::{AtomicBool, Ordering},
-                Arc,
-            },
+    use super::*;
+    use crate::loom::{
+        self,
+        alloc::{Track, TrackFuture},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
         },
-        scheduler::Scheduler,
-        task::*,
     };
-    #[derive(Clone)]
-    struct NopScheduler;
-
-    impl crate::scheduler::Schedule for NopScheduler {
-        fn schedule(&self, task: TaskRef) {
-            unimplemented!(
-                "nop scheduler should not actually schedule tasks (tried to schedule {task:?})"
-            )
-        }
-    }
 
     #[test]
     fn taskref_deallocates() {
         loom::model(|| {
             let track = Track::new(());
-            let task = TaskRef::new(NopScheduler, async move {
+            let task = TaskRef::new(NopSchedule, async move {
                 drop(track);
             });
 
@@ -42,7 +47,7 @@ mod loom {
     fn taskref_clones_deallocate() {
         loom::model(|| {
             let track = Track::new(());
-            let (task, _) = TaskRef::new(NopScheduler, async move {
+            let (task, _) = TaskRef::new(NopSchedule, async move {
                 drop(track);
             });
 
@@ -67,11 +72,11 @@ mod loom {
     fn joinhandle_deallocates() {
         loom::model(|| {
             let track = Track::new(());
-            let (task, join) = TaskRef::new(NopScheduler, async move {
+            let (task, join) = TaskRef::new(NopSchedule, async move {
                 drop(track);
             });
 
-            let mut thread = loom::thread::spawn(move || {
+            let thread = loom::thread::spawn(move || {
                 drop(join);
             });
 
@@ -128,26 +133,13 @@ mod loom {
 }
 
 #[cfg(all(not(loom), feature = "alloc"))]
-mod alloc {
-    use crate::{
-        future,
-        scheduler::{Schedule, Scheduler},
-        task::*,
-    };
+mod alloc_tests {
+    use super::*;
     use alloc::boxed::Box;
     use core::{
         ptr,
         sync::atomic::{AtomicBool, Ordering},
     };
-
-    #[derive(Copy, Clone, Debug)]
-    struct NopSchedule;
-
-    impl Schedule for NopSchedule {
-        fn schedule(&self, task: TaskRef) {
-            unimplemented!("nop scheduler tried to schedule task {:?}", task);
-        }
-    }
 
     /// This test ensures that layout-dependent casts in the `Task` struct's
     /// vtable methods are valid.


### PR DESCRIPTION
This adds an initial implementation of a `Schedule::current_task` method
for cloning the currently-polled task. This implementation is somewhat
inefficient, as it has to perform an additional ref count clone/drop
cycle on every poll. This is unfortunately necessary because the current
task variable is not unset until the `TaskRef::poll` method returns, and
that method can drop the task, so we have to keep the task alive as long
as it's accessible through the scheduler (or else we risk handing out
`TaskRef`s pointed at deallocated tasks).

We can probably improve this by removing the unnecessary ref clone/drop
cycle, if we refactored how polling works a bit. If the scheduler unset
the current task variable _before_ a task is dropped, we wouldn't need
to clone the task before storing it in the current task variable...but,
this implementation works for now.

Closes #277