### PR TITLE
feat(maitake): implement cancel culture for tasks

### DIFF
--- a/maitake/src/loom.rs
+++ b/maitake/src/loom.rs
@@ -14,6 +14,8 @@ mod inner {
             task::{Context, Poll},
         };
         pub(crate) use loom::alloc::*;
+
+        #[derive(Debug)]
         #[pin_project::pin_project]
         pub(crate) struct TrackFuture<F> {
             #[pin]
@@ -52,6 +54,13 @@ mod inner {
         #[track_caller]
         pub(crate) fn track_future<F: Future>(inner: F) -> TrackFuture<F> {
             TrackFuture::new(inner)
+        }
+
+        // PartialEq impl so that `assert_eq!(..., Ok(...))` works
+        impl<F: PartialEq> PartialEq for TrackFuture<F> {
+            fn eq(&self, other: &Self) -> bool {
+                self.inner == other.inner
+            }
         }
     }
 

--- a/maitake/src/loom.rs
+++ b/maitake/src/loom.rs
@@ -112,7 +112,32 @@ mod inner {
     pub(crate) use core::sync::atomic;
 
     #[cfg(test)]
-    pub use std::thread;
+    pub(crate) mod thread {
+        pub(crate) use std::thread::{yield_now, JoinHandle};
+        pub(crate) fn spawn<F, T>(f: F) -> JoinHandle<T>
+        where
+            F: FnOnce() -> T + Send + 'static,
+            T: Send + 'static,
+        {
+            let track = super::alloc::track::Registry::current();
+            std::thread::spawn(move || {
+                let _tracking = match track {
+                    Some(track) => Some(track.set_default()),
+                    None => None,
+                };
+                f()
+            })
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn model(f: impl FnOnce()) {
+        crate::util::test::trace_init();
+        let registry = alloc::track::Registry::default();
+        let _tracking = registry.set_default();
+        f();
+        registry.check();
+    }
 
     pub(crate) mod hint {
         #[inline(always)]
@@ -202,17 +227,192 @@ mod inner {
         }
     }
     pub(crate) mod alloc {
+        use core::{
+            future::Future,
+            pin::Pin,
+            task::{Context, Poll},
+        };
+
+        #[cfg(test)]
+        use std::sync::Arc;
+        #[cfg(test)]
+        pub(in crate::loom) mod track {
+            use std::{
+                cell::RefCell,
+                collections::HashMap,
+                sync::{Arc, Mutex, Weak},
+            };
+
+            #[derive(Clone, Debug, Default)]
+            pub(crate) struct Registry(Arc<Mutex<RegistryInner>>);
+
+            #[derive(Debug, Default)]
+            struct RegistryInner {
+                tracks: HashMap<usize, TrackData>,
+                next_id: usize,
+            }
+
+            #[derive(Debug)]
+            struct TrackData {
+                type_name: &'static str,
+                loc: &'static core::panic::Location<'static>,
+                weak: Weak<()>,
+            }
+
+            thread_local! {
+                static REGISTRY: RefCell<Option<Registry>> = RefCell::new(None);
+            }
+
+            impl Registry {
+                pub(in crate::loom) fn current() -> Option<Registry> {
+                    REGISTRY.with(|current| current.borrow().clone())
+                }
+
+                pub(in crate::loom) fn set_default(&self) -> impl Drop {
+                    struct Unset(Option<Registry>);
+                    impl Drop for Unset {
+                        fn drop(&mut self) {
+                            let _ =
+                                REGISTRY.try_with(|current| *current.borrow_mut() = self.0.take());
+                        }
+                    }
+
+                    REGISTRY.with(|current| {
+                        let mut current = current.borrow_mut();
+                        let unset = Unset(current.clone());
+                        *current = Some(self.clone());
+                        unset
+                    })
+                }
+
+                #[track_caller]
+                pub(super) fn start_tracking<T>() -> Option<Arc<()>> {
+                    match Self::current() {
+                        Some(registry) => Some(registry.insert::<T>()),
+                        _ => None,
+                    }
+                }
+
+                #[track_caller]
+                pub(super) fn insert<T>(&self) -> Arc<()> {
+                    let mut inner = self.0.lock().unwrap();
+                    let id = inner.next_id;
+                    inner.next_id += 1;
+                    let loc = core::panic::Location::caller();
+                    let type_name = std::any::type_name::<T>();
+                    let arc = Arc::new(());
+                    let weak = Arc::downgrade(&arc);
+                    inner.tracks.insert(
+                        id,
+                        TrackData {
+                            type_name,
+                            loc,
+                            weak,
+                        },
+                    );
+                    arc
+                }
+
+                pub(in crate::loom) fn check(&self) {
+                    let leaked = self
+                        .0
+                        .lock()
+                        .unwrap()
+                        .tracks
+                        .iter()
+                        .filter_map(
+                            |(
+                                id,
+                                TrackData {
+                                    type_name,
+                                    weak,
+                                    loc,
+                                },
+                            )| {
+                                weak.upgrade()?;
+                                Some(format!(" - {type_name} allocated at {loc} (id {id})"))
+                            },
+                        )
+                        .collect::<Vec<_>>();
+                    if !leaked.is_empty() {
+                        let leaked = leaked.join("\n  ");
+                        panic!("the following allocations were leaked:\n  {leaked}");
+                    }
+                }
+            }
+        }
+
+        #[cfg(test)]
+        #[derive(Debug)]
+        #[pin_project::pin_project]
+        pub(crate) struct TrackFuture<F> {
+            #[pin]
+            inner: F,
+            track: Option<Arc<()>>,
+        }
+
+        #[cfg(test)]
+        impl<F: Future> Future for TrackFuture<F> {
+            type Output = TrackFuture<F::Output>;
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                let this = self.project();
+                this.inner.poll(cx).map(|inner| TrackFuture {
+                    inner,
+                    track: this.track.clone(),
+                })
+            }
+        }
+
+        #[cfg(test)]
+        impl<F> TrackFuture<F> {
+            /// Wrap a `Future` in a `TrackFuture` that participates in Loom's
+            /// leak checking.
+            #[track_caller]
+            pub(crate) fn new(inner: F) -> Self {
+                let track = track::Registry::start_tracking::<F>();
+                Self { inner, track }
+            }
+
+            /// Stop tracking this future, and return the inner value.
+            pub(crate) fn into_inner(self) -> F {
+                self.inner
+            }
+        }
+
+        #[cfg(test)]
+        #[track_caller]
+        pub(crate) fn track_future<F: Future>(inner: F) -> TrackFuture<F> {
+            TrackFuture::new(inner)
+        }
+
+        // PartialEq impl so that `assert_eq!(..., Ok(...))` works
+        #[cfg(test)]
+        impl<F: PartialEq> PartialEq for TrackFuture<F> {
+            fn eq(&self, other: &Self) -> bool {
+                self.inner == other.inner
+            }
+        }
+
         /// Track allocations, detecting leaks
         #[derive(Debug, Default)]
         pub struct Track<T> {
             value: T,
+
+            #[cfg(test)]
+            track: Option<Arc<()>>,
         }
 
         impl<T> Track<T> {
             /// Track a value for leaks
             #[inline(always)]
+            #[track_caller]
             pub fn new(value: T) -> Track<T> {
-                Track { value }
+                Track {
+                    value,
+
+                    #[cfg(test)]
+                    track: track::Registry::start_tracking::<T>(),
+                }
             }
 
             /// Get a reference to the value
@@ -233,6 +433,11 @@ mod inner {
                 self.value
             }
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) mod future {
+        pub(crate) use tokio_test::block_on;
     }
 
     #[cfg(test)]

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -608,11 +608,11 @@ where
     }
 
     unsafe fn poll_join(
-        task: NonNull<Header>,
+        ptr: NonNull<Header>,
         outptr: NonNull<()>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), JoinError>> {
-        let task = task.cast::<Self>().as_ref();
+        let task = ptr.cast::<Self>().as_ref();
         trace!(
             task.addr = ?task,
             task.output = %type_name::<<F>::Output>(),

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -716,6 +716,7 @@ where
     F: Future,
 {
     fn drop(&mut self) {
+        test_debug!(task.tid = self.header().id.as_u64(), "Task::drop");
         // if there's a join waker, ensure that its destructor runs when the
         // task is dropped.
         // NOTE: this *should* never happen; we don't ever expect to deallocate

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -632,6 +632,7 @@ where
             "Task::poll_join"
         );
         match test_dbg!(task.state().try_join()) {
+            JoinAction::Canceled => return Poll::Ready(Err(JoinError::canceled(task.id()))),
             JoinAction::TakeOutput => {
                 task.inner.with_mut(|cell| {
                     match mem::replace(&mut *cell, Cell::Joined) {
@@ -886,6 +887,7 @@ impl TaskRef {
         // if the task was successfully canceled, wake it so that it can clean
         // up after itself.
         if canceled {
+            test_debug!("woke canceled task");
             let wake_by_ref = self.header().vtable.wake_by_ref;
             unsafe { wake_by_ref(self.0.as_ptr().cast::<()>()) }
         }

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -890,6 +890,13 @@ impl TaskRef {
 
     /// Forcibly cancel the task.
     ///
+    /// Canceling a task sets a flag indicating that it has been canceled and
+    /// should terminate. The next time a canceled task is polled by the
+    /// scheduler, it will terminate instead of polling the inner [`Future`]. If
+    /// the task has a [`JoinHandle`], that [`JoinHandle`] will complete with a
+    /// [`JoinError`]. The task then will be deallocated once all
+    /// [`JoinHandle`]s and [`TaskRef`]s referencing it have been dropped.
+    ///
     /// This method returns `true` if the task was canceled successfully, and
     /// `false` if the task could not be canceled (i.e., it has already completed,
     /// has already been canceled, cancel culture has gone TOO FAR, et cetera).

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -228,7 +228,6 @@ impl<T> fmt::Debug for JoinHandle<T> {
 
 impl JoinError<()> {
     #[inline]
-    #[must_use]
     pub(super) fn canceled(completed: bool, id: TaskId) -> Poll<Result<(), Self>> {
         Poll::Ready(Err(Self {
             kind: JoinErrorKind::Canceled { completed },
@@ -247,6 +246,7 @@ impl JoinError<()> {
         }
     }
 
+    #[must_use]
     pub(super) fn with_output<T>(self, output: Option<T>) -> JoinError<T> {
         JoinError {
             kind: self.kind,

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -84,6 +84,18 @@ impl<T> JoinHandle<T> {
             .expect("`TaskRef` only taken while polling a `JoinHandle`; this is a bug")
     }
 
+    /// Forcibly cancel the task.
+    ///
+    /// Canceling a task sets a flag indicating that it has been canceled and
+    /// should terminate. The next time a canceled task is polled by the
+    /// scheduler, it will terminate instead of polling the inner [`Future`]. If
+    /// the task has a [`JoinHandle`], that [`JoinHandle`] will complete with a
+    /// [`JoinError`]. The task then will be deallocated once all
+    /// [`JoinHandle`]s and [`TaskRef`]s referencing it have been dropped.
+    ///
+    /// This method returns `true` if the task was canceled successfully, and
+    /// `false` if the task could not be canceled (i.e., it has already completed,
+    /// has already been canceled, cancel culture has gone TOO FAR, et cetera).
     pub fn cancel(&self) -> bool {
         self.task.as_ref().map(TaskRef::cancel).unwrap_or(false)
     }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -36,18 +36,21 @@ pub struct JoinHandle<T> {
 }
 
 /// Errors returned by awaiting a [`JoinHandle`].
-#[derive(Debug, PartialEq, Eq)]
-pub struct JoinError {
+#[derive(PartialEq, Eq)]
+pub struct JoinError<T> {
     kind: JoinErrorKind,
     id: TaskId,
+    output: Option<T>,
 }
 
-#[allow(dead_code)] // this will be used when i implement task cancellation
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 enum JoinErrorKind {
     /// The task was canceled.
-    Canceled,
+    Canceled {
+        /// `true` if the task was canceled after it completed successfully.
+        completed: bool,
+    },
 
     /// A stub was awaited
     StubNever,
@@ -101,7 +104,7 @@ impl<T> JoinHandle<T> {
 }
 
 impl<T> Future for JoinHandle<T> {
-    type Output = Result<T, JoinError>;
+    type Output = Result<T, JoinError<T>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -211,14 +214,15 @@ impl<T> fmt::Debug for JoinHandle<T> {
 
 // === impl JoinError ===
 
-impl JoinError {
-    #[allow(dead_code)] // this will be used when i implement task cancellation
+impl JoinError<()> {
     #[inline]
-    pub(crate) fn canceled(id: TaskId) -> Self {
-        Self {
-            kind: JoinErrorKind::Canceled,
+    #[must_use]
+    pub(super) fn canceled(completed: bool, id: TaskId) -> Poll<Result<(), Self>> {
+        Poll::Ready(Err(Self {
+            kind: JoinErrorKind::Canceled { completed },
             id,
-        }
+            output: None,
+        }))
     }
 
     #[allow(dead_code)]
@@ -227,25 +231,68 @@ impl JoinError {
         Self {
             kind: JoinErrorKind::StubNever,
             id: TaskId::stub(),
+            output: None,
         }
     }
 
+    pub(super) fn with_output<T>(self, output: Option<T>) -> JoinError<T> {
+        JoinError {
+            kind: self.kind,
+            id: self.id,
+            output,
+        }
+    }
+}
+
+impl<T> JoinError<T> {
     /// Returns `true` if a task failed to join because it was canceled.
     pub fn is_canceled(&self) -> bool {
-        matches!(self.kind, JoinErrorKind::Canceled)
+        matches!(self.kind, JoinErrorKind::Canceled { .. })
+    }
+
+    /// Returns `true` if the task completed successfully before it was canceled.
+    pub fn is_completed(&self) -> bool {
+        match self.kind {
+            JoinErrorKind::Canceled { completed } => completed,
+            _ => false,
+        }
     }
 
     /// Returns the [`TaskId`] of the task that failed to join.
     pub fn id(&self) -> TaskId {
         self.id
     }
+
+    /// Returns the task's output, if the task completed successfully before it
+    /// was canceled.
+    ///
+    /// Otherwise, returns `None`.
+    pub fn output(self) -> Option<T> {
+        self.output
+    }
 }
 
-impl fmt::Display for JoinError {
+impl<T> fmt::Display for JoinError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            JoinErrorKind::Canceled => write!(f, "task {} was canceled", self.id),
+            JoinErrorKind::Canceled { completed } => {
+                let completed = if completed {
+                    " (after completing successfully)"
+                } else {
+                    ""
+                };
+                write!(f, "task {} was canceled{completed}", self.id)
+            }
             JoinErrorKind::StubNever => f.write_str("the stub task can never join"),
         }
+    }
+}
+
+impl<T> fmt::Debug for JoinError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JoinError")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .finish()
     }
 }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -81,6 +81,10 @@ impl<T> JoinHandle<T> {
             .expect("`TaskRef` only taken while polling a `JoinHandle`; this is a bug")
     }
 
+    pub fn cancel(&self) -> bool {
+        self.task.as_ref().map(TaskRef::cancel).unwrap_or(false)
+    }
+
     /// Returns a [`TaskId`] that uniquely identifies this [task].
     ///
     /// The returned ID does *not* increment the task's reference count, and may

--- a/maitake/src/task/state.rs
+++ b/maitake/src/task/state.rs
@@ -107,7 +107,12 @@ pub(super) enum StartPollAction {
     Poll,
 
     /// The task was canceled, and its [`JoinHandle`] waker may need to be woken.
-    Canceled { wake_join_waker: bool },
+    ///
+    /// [`JoinHandle`]: super::JoinHandle
+    Canceled {
+        /// If `true`, the task's join waker must be woken.
+        wake_join_waker: bool,
+    },
 
     /// The task is not in a valid state to start a poll. Do nothing.
     CantPoll,

--- a/maitake/src/task/tests.rs
+++ b/maitake/src/task/tests.rs
@@ -13,8 +13,9 @@ impl Schedule for NopSchedule {
     }
 }
 
-#[cfg(loom)]
+#[cfg(any(loom, feature = "alloc"))]
 mod loom {
+    #![allow(clippy::drop_non_drop)]
     use super::*;
     use crate::{
         loom::{
@@ -39,6 +40,15 @@ mod loom {
             // if the task is not deallocated by dropping the `TaskRef`, the
             // `Track` will be leaked.
             drop(task);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn do_leaks_work() {
+        loom::model(|| {
+            let track = Track::new(());
+            std::mem::forget(track);
         });
     }
 

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -132,6 +132,8 @@ pub(crate) mod test {
         } else {
             builder.parse_lossy(env)
         };
+        // enable traces from alloc leak checking.
+        let filter = filter.add_directive("maitake::loom=trace".parse().unwrap());
         let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_test_writer()

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -120,7 +120,7 @@ pub(crate) fn expect_display<T, E: core::fmt::Display>(result: Result<T, E>, msg
 #[cfg(all(test, not(loom)))]
 pub(crate) mod test {
     pub(crate) fn trace_init() {
-        trace_init_with_default("maitake=trace");
+        trace_init_with_default("maitake=debug,cordyceps=debug");
     }
 
     pub(crate) fn trace_init_with_default(default: &str) {


### PR DESCRIPTION
This branch implements cancellation for spawned tasks. A task can be
cancelled through its `JoinHandle` (`JoinHandle::cancel`), or through a
`TaskRef` to it (`TaskRef::cancel`). When a task is cancelled, a bit is
set on its state field indicating that it has been canceled, and the
task is woken.

A leaf future inside a task can cancel that task by calling
`Scheduler::current_task()` to get a `Taskref` to itself, and then
canceling that `TaskRef`.

When the scheduler polls a task with the canceled bit set, it doesn't
poll the future, but instead notifies the task's `JoinHandle` and drops
its own reference to that task. Once the `JoinHandle` and all `TaskRef`s
that own reference counts for that task are dropped, the task can be
deallocated.

A task may be canceled in a state where the `Future` has completed but
the `JoinHandle` hasn't consumed the `Output` from the `Future` yet. In
that case, the `JoinHandle` still returns an error, but the error
indicates that the task was canceled after completion, and allows
recovering the future's `Output`. anyway.

Closes #264 