### PR TITLE
chore: run `miri` tests using `cargo-nextest` when available

### DIFF
--- a/bin/miri
+++ b/bin/miri
@@ -3,7 +3,32 @@
 # Runs `miri` tests
 set -euo pipefail
 
-cd "$(dirname "$0")"/..
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+
+
+# shellcheck source=_util.sh
+. "$bindir"/_util.sh
+
+cd "$rootdir"
+
+# assume `cargo nextest` is present
+testcmd=(cargo miri nextest run)
+
+# shellcheck source=_util.sh
+. "$bindir"/_util.sh
+
+if [[ "${MIRI_NO_NEXTEST:-}" ]]; then
+    testcmd=(cargo miri test)
+elif ! cargo --list | grep -q "nextest"; then
+    err "missing cargo-nextest executable"
+    if confirm "      install it?"; then
+        cargo install cargo-nextest
+    else
+        echo "okay, using cargo test"
+        testcmd=(cargo miri test)
+    fi
+fi
 
 # configure flags
 
@@ -34,4 +59,4 @@ export RUSTFLAGS="${add_rustflags[*]} ${RUSTFLAGS:-}"
 export MIRIFLAGS="${add_miriflags[*]} ${MIRIFLAGS:-}"
 
 # actually run miri
-cargo miri test --lib "${@}"
+"${testcmd[@]}" --lib "${@}"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-29"
+channel = "nightly-2022-07-31"
 components = [
     "clippy",
     "rustfmt",


### PR DESCRIPTION
`nextest` now has support for running Miri tests. This branch updates
the `bin/miri` script to use `cargo-nextest` if it is available. It was
also necessary to update the pinned Rust nightly to 2022-07-31 to pick
up nextest support in miri.