### PR TITLE
chore(hal): upgrade `volatile` to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,8 +1826,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "volatile"
-version = "0.4.4"
-source = "git+https://github.com/hawkw/volatile?branch=eliza/update-features#9894588aa7158e5d2267cd8aa37e42a2e341811c"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ca98349dda8a60ae74e04fd90c7fb4d6a4fbe01e6d3be095478aa0b76f6c0c"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,6 @@ sysroot_path = "target/x86_64/sysroot"
 # use `tracing` 0.2 from git
 tracing = { git = "https://github.com/tokio-rs/tracing" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing" }
-# temporary patch to use my branch of `volatile` until PR
-# https://github.com/rust-osdev/volatile/pull/25 merges upstream. this is
-# necessary to build with unstable features on recent nightlies.
-volatile = { git = "https://github.com/hawkw/volatile", branch = "eliza/update-features" }
 # patch `once_cell` to use https://github.com/matklad/once_cell/pull/185 so that
 # Miri doesn't reject `tracing`'s use of `once_cell`.
 #

--- a/hal-x86_64/Cargo.toml
+++ b/hal-x86_64/Cargo.toml
@@ -14,4 +14,4 @@ mycelium-util = { path = "../util" }
 mycelium-trace = { path = "../trace" }
 mycotest = { path = "../mycotest"}
 tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes"] }
-volatile = { version = "0.4.4", features = ["unstable"] }
+volatile = { version = "0.4.5", features = ["unstable"] }


### PR DESCRIPTION
Version 0.4.5 of `volatile` includes the patches we needed from Git, so
the cargo patch to use a git dep can be removed.