### PR TITLE
refac(hal-x86_64): use mycelium-bitfield for segment descrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,6 @@ dependencies = [
 name = "hal-x86_64"
 version = "0.1.0"
 dependencies = [
- "bitflags",
  "hal-core",
  "mycelium-trace",
  "mycelium-util",

--- a/bitfield/src/pack.rs
+++ b/bitfield/src/pack.rs
@@ -607,7 +607,7 @@ macro_rules! make_packers {
                 ///
                 /// The two ranges must be the same size. This can be asserted
                 /// by the `assert_valid` method on the returned pair type.
-                pub const fn pair_with(&self, dst: Self) -> $Pair<T> {
+                pub const fn pair_with<F2>(&self, dst: $Pack<T, F2>) -> $Pair<T> {
                     // TODO(eliza): validate that `dst.shift + self.bits() < N_BITS` in
                     // const fn somehow lol
                     let (dst_shl, dst_shr) = if dst.shift > self.shift {

--- a/bitfield/src/pack.rs
+++ b/bitfield/src/pack.rs
@@ -830,20 +830,20 @@ macro_rules! make_packers {
                 /// # Panics
                 ///
                 /// If `value` contains bits outside the range specified by `packer`.
-                pub fn pack<T: FromBits<$Bits>>(self, value: T, packer: &$Pack<T>) -> Self {
+                pub fn pack<T: FromBits<$Bits>, F>(self, value: T, packer: &$Pack<T, F>) -> Self {
                     Self(packer.pack(value, self.0))
                 }
 
                 /// Set _all_ bits in the range specified by `packer` to 1 in `self`.
                 #[inline]
-                pub const fn set_all(self, packer: &$Pack) -> Self {
+                pub const fn set_all<T, F>(self, packer: &$Pack<T, F>) -> Self {
                     Self(packer.set_all(self.0))
                 }
 
                 /// Set _all_ bits in the range specified by `packer` to 0 in
                 /// `self`.
                 #[inline]
-                pub const fn unset_all(self, packer: &$Pack) -> Self {
+                pub const fn unset_all<T, F>(self, packer: &$Pack<T, F>) -> Self {
                     Self(packer.unset_all(self.0))
                 }
 
@@ -851,7 +851,7 @@ macro_rules! make_packers {
                 /// Returns `true` if **any** bits specified by `packer` are set
                 /// in `self`.
                 #[inline]
-                pub const fn contains_any(self, packer: &$Pack) -> bool {
+                pub const fn contains_any<T, F>(self, packer: &$Pack<T, F>) -> bool {
                     packer.contained_in_any(self.0)
                 }
 
@@ -859,7 +859,7 @@ macro_rules! make_packers {
                 /// Returns `true` if **any** bits specified by `packer` are set
                 /// in `self`.
                 #[inline]
-                pub const fn contains_all(self, packer: &$Pack) -> bool {
+                pub const fn contains_all<T, F>(self, packer: &$Pack<T, F>) -> bool {
                     packer.contained_in_all(self.0)
                 }
 

--- a/hal-x86_64/Cargo.toml
+++ b/hal-x86_64/Cargo.toml
@@ -12,7 +12,6 @@ log = ["tracing/log"]
 hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
 mycelium-trace = { path = "../trace" }
-bitflags = "1.2"
 mycotest = { path = "../mycotest"}
 tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false, features = ["attributes"] }
 volatile = { version = "0.4.5", features = ["unstable"] }

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -151,6 +151,19 @@ impl Ring {
     }
 }
 
+impl bits::FromBits<u64> for Ring {
+    const BITS: u32 = 2;
+    type Error = core::convert::Infallible;
+
+    fn try_from_bits(u: u64) -> Result<Self, Self::Error> {
+        Ok(Self::from_u8(u as u8))
+    }
+
+    fn into_bits(self) -> u64 {
+        self as u8 as u64
+    }
+}
+
 impl bits::FromBits<u16> for Ring {
     const BITS: u32 = 2;
     type Error = core::convert::Infallible;


### PR DESCRIPTION
This commit changes the `segment::Descriptor` implementation to use
`mycelium-bitfield` rather than `bitflags` + our packing specs. This
lets us remove the `bitflags` dep entirely.