### PR TITLE
feat(maitake): minor joinhandle/taskid API improvements

### DIFF
--- a/maitake/src/task/id.rs
+++ b/maitake/src/task/id.rs
@@ -109,3 +109,19 @@ impl fmt::Display for TaskId {
         fmt::Display::fmt(&self.0, f)
     }
 }
+
+// ==== PartialEq impls for refs ====
+
+impl PartialEq<&'_ TaskId> for TaskId {
+    #[inline]
+    fn eq(&self, other: &&Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl PartialEq<TaskId> for &'_ TaskId {
+    #[inline]
+    fn eq(&self, other: &TaskId) -> bool {
+        self.0 == other.0
+    }
+}

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -139,6 +139,8 @@ impl<T> Drop for JoinHandle<T> {
     }
 }
 
+// ==== PartialEq impls for JoinHandle/TaskRef ====
+
 impl<T> PartialEq<TaskRef> for JoinHandle<T> {
     fn eq(&self, other: &TaskRef) -> bool {
         self.task.as_ref().unwrap() == other
@@ -160,6 +162,36 @@ impl<T> PartialEq<JoinHandle<T>> for TaskRef {
 impl<T> PartialEq<&'_ JoinHandle<T>> for TaskRef {
     fn eq(&self, other: &&JoinHandle<T>) -> bool {
         self == other.task.as_ref().unwrap()
+    }
+}
+
+// ==== PartialEq impls for JoinHandle/TaskId ====
+
+impl<T> PartialEq<TaskId> for JoinHandle<T> {
+    #[inline]
+    fn eq(&self, other: &TaskId) -> bool {
+        self.id == other
+    }
+}
+
+impl<T> PartialEq<&'_ TaskId> for JoinHandle<T> {
+    #[inline]
+    fn eq(&self, other: &&TaskId) -> bool {
+        self.id == *other
+    }
+}
+
+impl<T> PartialEq<JoinHandle<T>> for TaskId {
+    #[inline]
+    fn eq(&self, other: &JoinHandle<T>) -> bool {
+        self == other.id
+    }
+}
+
+impl<T> PartialEq<&'_ JoinHandle<T>> for TaskId {
+    #[inline]
+    fn eq(&self, other: &&JoinHandle<T>) -> bool {
+        self == other.id
     }
 }
 

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -39,6 +39,7 @@ pub struct JoinHandle<T> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct JoinError {
     kind: JoinErrorKind,
+    id: TaskId,
 }
 
 #[allow(dead_code)] // this will be used when i implement task cancellation
@@ -177,22 +178,29 @@ impl<T> fmt::Debug for JoinHandle<T> {
 impl JoinError {
     #[allow(dead_code)] // this will be used when i implement task cancellation
     #[inline]
-    pub(crate) fn canceled() -> Self {
+    pub(crate) fn canceled(id: TaskId) -> Self {
         Self {
             kind: JoinErrorKind::Canceled,
+            id,
         }
     }
 
-    #[allow(dead_code)] // this will be used when i implement task cancellation
+    #[allow(dead_code)]
     #[inline]
     pub(crate) fn stub() -> Self {
         Self {
             kind: JoinErrorKind::StubNever,
+            id: TaskId::stub(),
         }
     }
 
     /// Returns `true` if a task failed to join because it was canceled.
     pub fn is_canceled(&self) -> bool {
         matches!(self.kind, JoinErrorKind::Canceled)
+    }
+
+    /// Returns the [`TaskId`] of the task that failed to join.
+    pub fn id(&self) -> TaskId {
+        self.id
     }
 }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -1,5 +1,6 @@
 use super::{Context, Poll, TaskId, TaskRef};
 use core::{future::Future, marker::PhantomData, pin::Pin};
+use mycelium_util::fmt;
 
 /// An owned permission to join a [task] (await its termination).
 ///
@@ -23,7 +24,7 @@ use core::{future::Future, marker::PhantomData, pin::Pin};
 /// [`Scheduler::spawn_allocated`]: crate::scheduler::Scheduler::spawn_allocated
 /// [`task::Builder::spawn`]: crate::task::Builder::spawn
 /// [`task::Builder::spawn_allocated`]: crate::task::Builder::spawn_allocated
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 // This clippy lint appears to be triggered incorrectly; this type *does* derive
 // `Eq` based on its `PartialEq<Self>` impl, but it also implements `PartialEq`
 // with types other than `Self` (which cannot impl `Eq`).
@@ -158,6 +159,16 @@ impl<T> PartialEq<JoinHandle<T>> for TaskRef {
 impl<T> PartialEq<&'_ JoinHandle<T>> for TaskRef {
     fn eq(&self, other: &&JoinHandle<T>) -> bool {
         self == other.task.as_ref().unwrap()
+    }
+}
+
+impl<T> fmt::Debug for JoinHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JoinHandle")
+            .field("output", &core::any::type_name::<T>())
+            .field("task", &fmt::opt(&self.task).or_else("<completed>"))
+            .field("id", &self.id)
+            .finish()
     }
 }
 

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -30,6 +30,7 @@ use core::{future::Future, marker::PhantomData, pin::Pin};
 #[allow(clippy::derive_partial_eq_without_eq)]
 pub struct JoinHandle<T> {
     task: Option<TaskRef>,
+    id: TaskId,
     _t: PhantomData<fn(T)>,
 }
 
@@ -58,8 +59,10 @@ impl<T> JoinHandle<T> {
     /// The pointed type must actually output a `T`-typed value.
     pub(super) unsafe fn from_task_ref(task: TaskRef) -> Self {
         task.state().create_join_handle();
+        let id = task.id();
         Self {
             task: Some(task),
+            id,
             _t: PhantomData,
         }
     }
@@ -87,10 +90,7 @@ impl<T> JoinHandle<T> {
     #[inline]
     #[track_caller]
     pub fn id(&self) -> TaskId {
-        self.task
-            .as_ref()
-            .expect("`TaskRef` only taken while polling a `JoinHandle`; this is a bug")
-            .id()
+        self.id
     }
 }
 

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -204,3 +204,12 @@ impl JoinError {
         self.id
     }
 }
+
+impl fmt::Display for JoinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            JoinErrorKind::Canceled => write!(f, "task {} was canceled", self.id),
+            JoinErrorKind::StubNever => f.write_str("the stub task can never join"),
+        }
+    }
+}


### PR DESCRIPTION
A bunch of minor `JoinHandle`/`TaskID` API improvements:

* feat(maitake): add `PartialEq<TaskId>` impls for `JoinHandle`
  
  `JoinHandle`s can currently be compared for equality with `TaskRef`s.
  This commit allows comparing them with `TaskId`s as well.
  
* feat(maitake): implement `fmt::Display` for `JoinError`
  
  This commit adds a nice `fmt::Display` implementation for `JoinError`.
  
* feat(maitake): add `TaskId`s to `JoinError`
  
  This commit adds a `TaskId` field to the `JoinError` type, and a
  `JoinError::id` method returning the ID of the task that failed to join.
  This allows user code to determine which task errored.
  
* fix(maitake): `JoinHandle` `Debug` shouldn't require `T: Debug`
  
  Currently, the `fmt::Debug` impl for `JoinHandle`s is derived. The
  derived impl will require `T: fmt::Debug` for the future's `Output`
  type, even though it's stored in a `PhantomData` and the `JoinHandle`
  doesn't actually own a value of that type. `JoinHandle`s probably
  shouldn't require the future's `Output` to be `Debug` in order to format
  a `JoinHandle`.
  
  This commit changes the `Debug` impl to a manual implementation. It also
  improves the debug formatting a bit over the derived version, such as by
  including the output type's _name_.
  
* fix(maitake): allow getting a `JoinHandle`'s ID after completion
  
  Currently calling the `id` method on `JoinHandle` to get the task's ID
  will panic if the `JoinHandle` has already consumed the task's output,
  which seems a bit problematic --- you might want to know the ID of the
  task even after it has completed. Therefore, this commit changes the
  `JoinHandle` type to store the task's ID when it's created, so that it
  can be accessed even after the `JoinHandle`'s future has completed.
  
  This does make the `JoinHandle` struct two words instead of one, but I
  don't think that's hugely problematic.