### PR TITLE
chore: always use `nextest`'s `immediate-final` failure output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,16 +1,17 @@
 [profile.default]
 # if a test takes more than 2 mins to run, assume it's hung and fail it
 slow-timeout = { period = "1m", terminate-after = 2 }
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability). A lot of our tests, especially in
+# `maitake` will print a bunch of logs on failure, so it's helpful to have the
+# complete list of failing tests printed *after* all the logs.
+failure-output = "immediate-final"
 
 [profile.loom]
 # loom tests might take a long time; don't have `nextest` print "slow" messages.
 slow-timeout = { period = "10m" }
-failure-output = "immediate"
 
 [profile.ci]
-# Print out output for failing tests as soon as they fail, and also at the end
-# of the run (for easy scrollability).
-failure-output = "immediate-final"
 # Do not cancel the test run on the first failure.
 fail-fast = false
 retries = 2
@@ -18,8 +19,5 @@ retries = 2
 [profile.loom-ci]
 # loom tests might take a long time; don't have `nextest` print "slow" messages.
 slow-timeout = { period = "10m" }
-# Print out output for failing tests as soon as they fail, and also at the end
-# of the run (for easy scrollability).
-failure-output = "immediate-final"
 # Do not cancel the test run on the first failure.
 fail-fast = false


### PR DESCRIPTION
The `immediate-final` nextest config prints out output for failing tests
as soon as they fail, and also at the end of the run (for easy
scrollability). A lot of our tests, especially in `maitake`, will print
a bunch of logs on failure, so it's helpful to have the complete list of
failing tests printed *after* all the logs.

We used to only do this on CI. This branch changes the nextest config to
do it all the time.