### PR TITLE
chore: fix nextest failure output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,7 +5,8 @@ slow-timeout = { period = "1m", terminate-after = 2 }
 # of the run (for easy scrollability). A lot of our tests, especially in
 # `maitake` will print a bunch of logs on failure, so it's helpful to have the
 # complete list of failing tests printed *after* all the logs.
-failure-output = "immediate-final"
+failure-output = "immediate"
+final-status-level = "fail"
 
 [profile.loom]
 # loom tests might take a long time; don't have `nextest` print "slow" messages.
@@ -15,9 +16,11 @@ slow-timeout = { period = "10m" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
 retries = 2
+final-status-level = "skip"
 
 [profile.loom-ci]
 # loom tests might take a long time; don't have `nextest` print "slow" messages.
 slow-timeout = { period = "10m" }
 # Do not cancel the test run on the first failure.
 fail-fast = false
+final-status-level = "skip"


### PR DESCRIPTION
It turns out the `failure-output = "immediate-final"` option in
`nextest.toml` didn't do what I thought it did. It actually tells
Nextest to print all the _output_ from failing tasks at the end of the
run, while I thought that it just told Nextest to print the list of
_which tasks failed_ at the end of the run. It turns out that this is
controlled by a different setting, `final-status-level`.

This commit changes `.config/nextest.toml` to do what I _thought_ I was
configuring it to do all along.