### PR TITLE
fix(x86_64): update `bootloader` to 0.10.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bootloader"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d9b14b92a825ecc3b24e4c163a578af473fbba5f190bfaf48092b29b604504"
+checksum = "24e13520aa8580a2850fc9f5390dc6753f1062fb66f90e5a61bd5c72b55df731"
 
 [[package]]
 name = "bootloader-locator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rlibc = "1.0"
 # NOTE FOR FUTURE ELIZAS WHO ARE MESSING WITH THIS: the bootloader crate's build
 # script is not that good, and breaks if you put this in `cfg(...).dependencies`
 # instead of normal [dependencies]. don't move this.
-bootloader = { version = "0.10.12" }
+bootloader = { version = "0.10.13" }
 embedded-graphics = "0.7"
 mycotest = { path = "mycotest" }
 


### PR DESCRIPTION
This updates the `bootloader` crate to version 0.10.13, which fixes issues when booting on systems that report memory regions at high physical addresses in their memory map (see rust-osdev/bootloader#259).

This should make it possible to run Mycelium in QEMU v7.1.0 and later, without very poor boot performance, as well as on real hardware which reports high addresses (many AMD systems).

In addition, there are some new bootloader features we might want to play around with.

Fixes #321.