### PR TITLE
docs(maitake): document the `scheduler` module

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ check-fmt crate='':
 check-docs crate='': (build-docs crate '--cfg docsrs -Dwarnings') (test-docs crate)
 
 # open RustDoc documentation for `crate` (or for the whole workspace).
-docs crate='': (build-docs)
+docs crate='' $RUSTDOCFLAGS='--cfg docsrs': (build-docs crate RUSTDOCFLAGS)
     {{ _cargo }} doc \
         {{ if crate == '' { '--workspace' } else { '--package' } }} {{ crate }} \
         --no-deps --all-features \

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -778,7 +778,7 @@ feature! {
             task::Builder::new(self.clone())
         }
 
-        /// Spawn a task.
+        /// Spawn a [task].
         ///
         /// This method returns a [`JoinHandle`] that can be used to await the
         /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
@@ -792,6 +792,7 @@ feature! {
         /// # Examples
         ///
         /// Spawning a task and awaiting its output:
+        ///
         /// ```
         /// use maitake::scheduler::Scheduler;
         ///
@@ -820,7 +821,7 @@ feature! {
         ///
         /// ```
         /// use maitake::scheduler::Scheduler;
-        /// # async fn docs() {
+        ///
         /// let scheduler = Scheduler::new();
         ///
         /// // dropping the `JoinHandle` allows the task to run in the background
@@ -833,6 +834,7 @@ feature! {
         /// while scheduler.tick().has_remaining {}
         /// ```
         ///
+        /// [task]: crate::task
         /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
@@ -945,7 +947,7 @@ feature! {
             Self::default()
         }
 
-        /// Spawn a task.
+        /// Spawn a [task].
         ///
         /// This method returns a [`JoinHandle`] that can be used to await the
         /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
@@ -959,6 +961,7 @@ feature! {
         /// # Examples
         ///
         /// Spawning a task and awaiting its output:
+        ///
         /// ```
         /// use maitake::scheduler::{self, StaticScheduler};
         /// static SCHEDULER: StaticScheduler = scheduler::new_static!();
@@ -979,6 +982,7 @@ feature! {
         ///
         /// // run the scheduler, driving the spawned tasks to completion.
         /// while SCHEDULER.tick().has_remaining {}
+        /// ```
         ///
         /// Spawning a task to run in the background, without awaiting its
         /// output:
@@ -987,7 +991,6 @@ feature! {
         /// use maitake::scheduler::{self, StaticScheduler};
         /// static SCHEDULER: StaticScheduler = scheduler::new_static!();
         ///
-        /// # async fn docs() {
         /// // dropping the `JoinHandle` allows the task to run in the background
         /// // without awaiting its output.
         /// SCHEDULER.spawn(async move {
@@ -998,6 +1001,7 @@ feature! {
         /// while SCHEDULER.tick().has_remaining {}
         /// ```
         ///
+        /// [task]: crate::task
         /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -577,7 +577,7 @@ impl StaticScheduler {
     /// A [`Tick`] struct with data describing what occurred during the
     /// scheduler tick.
     ///
-    /// [run-loops]: crate::scheduler::#executing-tasks
+    /// [run-loops]: crate::scheduler#executing-tasks
     pub fn tick(&'static self) -> Tick {
         self.0.tick_n(Self::DEFAULT_TICK_SIZE)
     }
@@ -913,7 +913,7 @@ feature! {
     /// A [`Tick`] struct with data describing what occurred during the
     /// scheduler tick.
     ///
-    /// [run-loops]: crate::scheduler::#executing-tasks
+    /// [run-loops]: crate::scheduler#executing-tasks
         pub fn tick(&self) -> Tick {
             self.0.tick_n(Self::DEFAULT_TICK_SIZE)
         }

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs, missing_debug_implementations)]
 use crate::{
     loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering::*},
     task::{self, Header, JoinHandle, Storage, TaskRef},

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -15,7 +15,7 @@
 //! spawned on that scheduler:
 //!
 //! - [`Scheduler`]: a reference-counted single-core scheduler (requires the
-//!       "alloc" feature). A [`Scheduler`] is internally implemented using an
+//!       "alloc" [feature]). A [`Scheduler`] is internally implemented using an
 //!       [`Arc`], and each task spawned on a [`Scheduler`] holds an `Arc` clone
 //!       of the scheduler core.
 //! - [`StaticScheduler`]: a single-core scheduler stored in a `static`
@@ -26,9 +26,140 @@
 //!       [`StaticScheduler`] *must* be stored in a `'static`, which can limit
 //!       its usage in some cases.
 //!
-//! [woken]: crate::task::Waker::wake
+//! The [`Schedule`] trait in this module is used by the [`Task`] type to
+//! abstract over both types of scheduler that tasks may be spawned on.
+//!
+//! ## Spawning Tasks
+//!
+//! Once a scheduler has been constructed, tasks may be spawned on it using the
+//! [`Scheduler::spawn`] or [`StaticScheduler::spawn`] methods. These methods
+//! allocate a [new `Box` to store the spawned task](task::BoxStorage), and
+//! therefore require the ["alloc" feature][feature].
+//!
+//! Alternatively, if [custom task storage](task::Storage) is in use, the
+//! scheduler types also provide [`Scheduler::spawn_allocated`] and
+//! [`StaticScheduler::spawn_allocated`] methods, which allow spawning a task
+//! that has already been stored in a type implementing the [`task::Storage`]
+//! trait. This can be used *without* the "alloc" feature flag, and is primarily
+//! intended for use in systems where tasks are statically allocated, or where
+//! an alternative allocator API (rather than `liballoc`) is in use.
+//!
+//! Finally, to configure the properties of a task prior to spawning it, both
+//! scheduler types provide [`Scheduler::build_task`] and
+//! [`StaticScheduler::build_task`] methods. These methods return a
+//! [`task::Builder`] struct, which can be used to set properties of a task and
+//! then spawn it on that scheduler.
+//!
+//! ## Executing Tasks
+//!
+//! In order to actually execute the tasks spawned on a scheduler, the scheduler
+//! must be _driven_ by dequeueing tasks from its run queue and polling them.
+//!
+//! Because [`maitake` is a low-level async runtime "construction kit"][kit]
+//! rather than a complete runtime implementation, the interface for driving a
+//! scheduler is tick-based. A _tick_ refers to an iteration of a
+//! scheduler's run loop, in which a set of tasks are dequeued from the
+//! scheduler's run queue and polled. Calling the [`Scheduler::tick`] or
+//! [`StaticScheduler::tick`] method on a  scheduler runs that scheduler for a
+//! single tick, returning a [`Tick`] struct with data describing the events
+//! that occurred during that tick.
+//!
+//! The scheduler API is tick-based, rather than providing methods that
+//! continuously tick the scheduler until all tasks have completed, because
+//! ticking a scheduler is often only one step of a system's run loop. A
+//! scheduler is responsible for polling the tasks that have been woken, but it
+//! does *not* wake tasks which are waiting for other runtime services, such as
+//! timers and I/O resources.
+//!
+//! Typically, an iteration of a system's run loop consists of the following steps:
+//!
+//! - **Tick the scheduler**, executing any tasks that have been woken,
+//! - **Tick a [timer][^1]**, to advance the system clock and wake any tasks waiting
+//!   for time-based events,
+//! - **Process wakeups from I/O resources**, such as hardware interrupts that
+//!   occurred during the tick. The component responsible for this is often
+//!   referred to as an [I/O reactor].
+//! - Optionally, **spawn tasks from external sources**, such as work-stealing
+//!   tasks from other schedulers, or receiving tasks from a remote system.
+//!
+//! The implementation of the timer and I/O runtime services in a bare-metal
+//! system typically depend on details of the hardware platform in use.
+//! Therefore, `maitake` does not provide a batteries-included runtime that
+//! bundles together a scheduler, timer, and I/O reactor. Instead, the
+//! lower-level tick-based scheduler interface allows running a `maitake`
+//! scheduler as part of a run loop implementation that also drives other parts
+//! of the runtime.
+//!
+//! A single call to [`Scheduler::tick`] will dequeue and poll up to
+//! [`Scheduler::DEFAULT_TICK_SIZE`] tasks from the run queue, rather than
+//! looping until all tasks in the queue have been dequeued.
+//!
+//! ## Examples
+//!
+//! A simple implementation of a system's run loop might look like this:
+//!
+//! ```rust
+//! use maitake::scheduler::Scheduler;
+//!
+//! /// Process any time-based events that have occurred since this function
+//! /// was last called.
+//! fn process_timeouts() {
+//!     // this might tick a `maitake::time::Timer` or run some other form of
+//!     // time driver implementation.
+//! }
+//!
+//!
+//! /// Process any I/O events that have occurred since this function
+//! /// was last called.
+//! fn process_io_events() {
+//!     // this function would handle dispatching any I/O interrupts that
+//!     // occurred during the tick to tasks that are waiting for those I/O
+//!     // events.
+//! }
+//!
+//! /// Put the system into a low-power state until a hardware interrupt
+//! /// occurs.
+//! fn wait_for_interrupts() {
+//!     // the implementation of this function would, of course, depend on the
+//!     // hardware platform in use...
+//! }
+//!
+//! /// The system's main run loop.
+//! fn run_loop() {
+//!     let scheduler = Scheduler::new();
+//!
+//!     loop {
+//!         // process time-based events
+//!         process_timeouts();
+//!
+//!         // process I/O events
+//!         process_io_events();
+//!
+//!         // tick the scheduler, running any tasks woken by processing time
+//!         // and I/O events, as well as tasks woken by other tasks during the
+//!         // tick.
+//!         let tick = scheduler.tick();
+//!
+//!         if !tick.has_remaining {
+//!             // if the scheduler's run queue is empty, wait for an interrupt
+//!             // to occur before ticking the scheduler again.
+//!             wait_for_interrupts();
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! [^1]: The [`maitake::time`](crate::time) module provides one
+//!     [`Timer`](crate::time::Timer) implementation, but other timers could be
+//!     used as well.
+//!
+//! [woken]: task::Waker::wake
 //! [polling]: core::future::Future::poll
 //! [task]: crate::task
+//! [feature]: crate#features
+//! [kit]: crate#maitake-is-not-a-complete-asynchronous-runtime
+//! [timer]: crate::time
+//! [I/O reactor]: https://en.wikipedia.org/wiki/Reactor_pattern
 #![warn(missing_docs, missing_debug_implementations)]
 use crate::{
     loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering::*},
@@ -45,6 +176,105 @@ use mycelium_util::fmt;
 mod tests;
 
 /// A statically-initialized scheduler implementation.
+///
+/// This type stores the core of the scheduler behind an `&'static` reference,
+/// which is passed into each task spawned on the scheduler. This means that, in
+/// order to spawn tasks, the `StaticScheduler` *must* be stored in a `static`
+/// variable.
+///
+/// The use of a `&'static` reference allows `StaticScheduler`s to be used
+/// without `liballoc`. In addition, spawning and deallocating tasks is slightly
+/// cheaper than when using the reference-counted [`Scheduler`] type, because an
+/// atomic reference count increment/decrement is not required.
+///
+/// # Usage
+///
+/// A `StaticScheduler` may be created one of two ways, depending on how the
+/// [stub task] used by the MPSC queue algorithm is created: either with a
+/// statically-allocated stub task by using the
+/// [`StaticScheduler::new_with_static_stub`] function, or with a heap-allocated
+/// stub task using [`StaticScheduler::new`] or [`StaticScheduler::default`]
+/// (which require the ["alloc" feature][features]).
+///
+/// The [`new_with_static_stub`] function is a `const fn`, which allows a
+/// `StaticScheduler` to be constructed directly in a `static` initializer.
+/// However, it requires the [`TaskStub`] to be constructed manually by the
+/// caller and passed in to initialize the scheduler. Furthermore, this function
+/// is `unsafe` to call, as it requires that the provided [`TaskStub`] *not* be
+/// used by any other `StaticScheduler` instance, which the function cannot
+/// ensure.
+///
+/// For example:
+///
+/// ```rust
+/// use maitake::scheduler::{self, StaticScheduler};
+///
+/// static SCHEDULER: StaticScheduler = {
+///     // create a new static stub task *inside* the initializer for the
+///     // `StaticScheduler`. since the stub task static cannot be referenced
+///     // outside of this block, we can ensure that it is not used by any
+///     // other calls to `StaticScheduler::new_with_static_stub`.
+///     static STUB_TASK: scheduler::TaskStub = scheduler::TaskStub::new();
+///
+///     // now, create the scheduler itself:
+///     unsafe {
+///         // safety: creating the stub task inside the block used as an
+///         // initializer expression for the scheduler static ensures that
+///         // the stub task is not used by any other scheduler instance.
+///         StaticScheduler::new_with_static_stub(&STUB_TASK)
+///     }
+/// };
+///
+/// // now, we can use the scheduler to spawn tasks:
+/// SCHEDULER.spawn(async { /* ... */ });
+/// ```
+///
+/// The [`scheduler::new_static!`] macro abstracts over the above code, allowing
+/// a `static StaticScheduler` to be initialized without requiring the caller to
+/// manually write `unsafe` code:
+///
+/// ```rust
+/// use maitake::scheduler::{self, StaticScheduler};
+///
+/// // this macro expands to code identical to the previous example.
+/// static SCHEDULER: StaticScheduler = scheduler::new_static!();
+///
+/// // now, we can use the scheduler to spawn tasks:
+/// SCHEDULER.spawn(async { /* ... */ });
+/// ```
+///
+/// Alternatively, the [`new`] and [`default`] constructors can be used to
+/// create a new `StaticScheduler` with a heap-allocated stub task. This does
+/// not require the user to manually create a stub task and ensure that it is
+/// not used by any other `StaticScheduler` instances. However, these
+/// constructors are not `const fn`s and require the ["alloc" feature][features]
+/// to be enabled.
+///
+/// Because [`StaticScheduler::new`] and [`StaticScheduler::default`] are not
+/// `const fn`s, but the scheduler must still be stored in a `static` to be
+/// used, some form of lazy initialization of the `StaticScheduler` is necessary:
+///
+/// ```rust
+/// use maitake::scheduler::StaticScheduler;
+/// use mycelium_util::sync::Lazy;
+///
+/// static SCHEDULER: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
+///
+/// // now, we can use the scheduler to spawn tasks:
+/// SCHEDULER.spawn(async { /* ... */ });
+/// ```
+///
+/// Although the scheduler itself is no longer constructed in a `const fn`
+/// static initializer in this case, storing it in a `static` rather than an
+/// [`Arc`] still provides a minor performance benefit, as it avoids atomic
+/// reference counting when spawning tasks.
+///
+/// [stub task]: TaskStub
+/// [features]: crate#features
+/// [`new_with_static_stub`]: Self::new_with_static_stub
+/// [`scheduler::new_static!`]: new_static!
+/// [`new`]: Self::new
+/// [`default`]: Self::default
 #[derive(Debug)]
 #[cfg_attr(feature = "alloc", derive(Default))]
 pub struct StaticScheduler(Core);
@@ -211,7 +441,7 @@ struct Core {
     /// The scheduler's run queue.
     ///
     /// This is an [atomic multi-producer, single-consumer queue][mpsc] of
-    /// [`TaskRef`s]. When a task is [scheduled], it is pushed to this queue.
+    /// [`TaskRef`]s. When a task is [scheduled], it is pushed to this queue.
     /// When the scheduler polls tasks, they are dequeued from the queue
     /// and polled. If a task is woken during its poll, the scheduler
     /// will push it back to this queue. Otherwise, if the task doesn't
@@ -278,12 +508,20 @@ impl StaticScheduler {
     ///
     /// This method is used to spawn a task that requires some bespoke
     /// procedure of allocation, typically of a custom [`Storage`] implementor.
+    /// See the documentation for the [`Storage`] trait for more details on
+    /// using custom task storage.
     ///
     /// This method returns a [`JoinHandle`] that can be used to await the
     /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
     /// allowing it to run in the background without awaiting its output.
     ///
+    /// When tasks are spawned on a scheduler, the scheduler must be
+    /// [ticked](Self::tick) in order to drive those tasks to completion.
+    /// See the [module-level documentation][run-loops] for more information
+    /// on implementing a system's run loop.
+    ///
     /// [`Storage`]: crate::task::Storage
+    /// [run-loops]: crate::scheduler#executing-tasks
     #[inline]
     #[track_caller]
     pub fn spawn_allocated<F, STO>(&'static self, task: STO::StoredTask) -> JoinHandle<F::Output>
@@ -308,21 +546,45 @@ impl StaticScheduler {
 
     /// Returns a [`TaskRef`] referencing the task currently being polled by
     /// this scheduler, if a task is currently being polled.
+    ///
+    /// # Returns
+    ///
+    /// - [`Some`]`(`[`TaskRef`]`)` referencing the currently-polling task, if a
+    ///   task is currently being polled (i.e., the scheduler is
+    ///   [ticking](Self::tick) and the queue of scheduled tasks is non-empty).
+    ///
+    /// - [`None`] if the scheduler is not currently being polled (i.e., the
+    ///   scheduler is not ticking or its run queue is empty and all polls have
+    ///   completed).
     #[must_use]
     #[inline]
     pub fn current_task(&'static self) -> Option<TaskRef> {
         self.0.current_task()
     }
 
-    /// Tick this scheduler, polling up to [`DEFAULT_TICK_SIZE`] tasks from the
-    /// scheduler's run queue.
+    /// Tick this scheduler, polling up to [`Self::DEFAULT_TICK_SIZE`] tasks
+    /// from the scheduler's run queue.
+    ///
+    /// Only a single CPU core/thread may tick a given scheduler at a time. If
+    /// another call to `tick` is in progress on a different core, this method
+    /// will wait until that call to `tick` completes before ticking the scheduler.
+    ///
+    /// See [the module-level documentation][run-loops] for more information on
+    /// using this function to implement a system's run loop.
+    ///
+    /// # Returns
+    ///
+    /// A [`Tick`] struct with data describing what occurred during the
+    /// scheduler tick.
+    ///
+    /// [run-loops]: crate::scheduler::#executing-tasks
     pub fn tick(&'static self) -> Tick {
         self.0.tick_n(Self::DEFAULT_TICK_SIZE)
     }
 }
 
 impl Core {
-    /// How many tasks are polled per call to [`Core::tick`].
+    /// How many tasks are polled per scheduler tick.
     ///
     /// Chosen by fair dice roll, guaranteed to be random.
     const DEFAULT_TICK_SIZE: usize = 256;
@@ -444,6 +706,18 @@ feature! {
     };
     use alloc::boxed::Box;
 
+    /// An atomically reference-counted single-core scheduler implementation.
+    ///
+    /// This type stores the core of the scheduler inside an [`Arc`], which is
+    /// cloned by each task spawned on the scheduler. The use of [`Arc`] allows
+    /// schedulers to be created and dropped dynamically at runtime. This is in
+    /// contrast to the [`StaticScheduler`] type, which must be stored in a
+    /// `static` variable for the entire lifetime of the program.
+    ///
+    /// Due to the use of [`Arc`], this type requires [the "alloc" feature
+    /// flag][features] to be enabled.
+    ///
+    /// [features]: crate#features
     #[derive(Clone, Debug, Default)]
     pub struct Scheduler(Arc<Core>);
 
@@ -454,6 +728,8 @@ feature! {
         /// Chosen by fair dice roll, guaranteed to be random.
         pub const DEFAULT_TICK_SIZE: usize = Core::DEFAULT_TICK_SIZE;
 
+        /// Returns a new `Scheduler`.
+        #[must_use]
         pub fn new() -> Self {
             Self::default()
         }
@@ -507,6 +783,57 @@ feature! {
         /// This method returns a [`JoinHandle`] that can be used to await the
         /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
         /// allowing it to run in the background without awaiting its output.
+        ///
+        /// When tasks are spawned on a scheduler, the scheduler must be
+        /// [ticked](Self::tick) in order to drive those tasks to completion.
+        /// See the [module-level documentation][run-loops] for more information
+        /// on implementing a system's run loop.
+        ///
+        /// # Examples
+        ///
+        /// Spawning a task and awaiting its output:
+        /// ```
+        /// use maitake::scheduler::Scheduler;
+        ///
+        /// let scheduler = Scheduler::new();
+        ///
+        /// // spawn a new task, returning a `JoinHandle`.
+        /// let task = scheduler.spawn(async move {
+        ///     // ... do stuff ...
+        ///    42
+        /// });
+        ///
+        /// // spawn another task that awaits the output of the first task.
+        /// scheduler.spawn(async move {
+        ///     // await the `JoinHandle` future, which completes when the task
+        ///     // finishes, and unwrap its output.
+        ///     let output = task.await.expect("task is not cancelled");
+        ///     assert_eq!(output, 42);
+        /// });
+        ///
+        /// // run the scheduler, driving the spawned tasks to completion.
+        /// while scheduler.tick().has_remaining {}
+        /// ```
+        ///
+        /// Spawning a task to run in the background, without awaiting its
+        /// output:
+        ///
+        /// ```
+        /// use maitake::scheduler::Scheduler;
+        /// # async fn docs() {
+        /// let scheduler = Scheduler::new();
+        ///
+        /// // dropping the `JoinHandle` allows the task to run in the background
+        /// // without awaiting its output.
+        /// scheduler.spawn(async move {
+        ///     // ... do stuff ...
+        /// });
+        ///
+        /// // run the scheduler, driving the spawned tasks to completion.
+        /// while scheduler.tick().has_remaining {}
+        /// ```
+        ///
+        /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
         pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
@@ -523,13 +850,21 @@ feature! {
         /// Spawn a pre-allocated task
         ///
         /// This method is used to spawn a task that requires some bespoke
-        /// procedure of allocation, typically of a custom [`Storage`] implementor.
+        /// procedure of allocation, typically of a custom [`Storage`]
+        /// implementor. See the documentation for the [`Storage`] trait for
+        /// more details on using custom task storage.
         ///
         /// This method returns a [`JoinHandle`] that can be used to await the
         /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
         /// allowing it to run in the background without awaiting its output.
         ///
+        /// When tasks are spawned on a scheduler, the scheduler must be
+        /// [ticked](Self::tick) in order to drive those tasks to completion.
+        /// See the [module-level documentation][run-loops] for more information
+        /// on implementing a system's run loop.
+        ///
         /// [`Storage`]: crate::task::Storage
+        /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
         pub fn spawn_allocated<F>(&'static self, task: Box<Task<Self, F, BoxStorage>>) -> JoinHandle<F::Output>
@@ -542,17 +877,43 @@ feature! {
             join
         }
 
-
         /// Returns a [`TaskRef`] referencing the task currently being polled by
         /// this scheduler, if a task is currently being polled.
+        ///
+        /// # Returns
+        ///
+        /// - [`Some`]`(`[`TaskRef`]`)` referencing the currently-polling task,
+        ///   if a task is currently being polled (i.e., the scheduler is
+        ///   [ticking](Self::tick) and the queue of scheduled tasks is
+        ///   non-empty).
+        ///
+        /// - [`None`] if the scheduler is not currently being polled (i.e., the
+        ///   scheduler is not ticking or its run queue is empty and all polls
+        ///   have completed).
         #[must_use]
         #[inline]
         pub fn current_task(&self) -> Option<TaskRef> {
             self.0.current_task()
         }
 
-        /// Tick this scheduler, polling up to [`DEFAULT_TICK_SIZE`] tasks from the
-        /// scheduler's run queue.
+
+    /// Tick this scheduler, polling up to [`Self::DEFAULT_TICK_SIZE`] tasks
+    /// from the scheduler's run queue.
+    ///
+    /// Only a single CPU core/thread may tick a given scheduler at a time. If
+    /// another call to `tick` is in progress on a different core, this method
+    /// will wait until that call to `tick` completes before ticking the
+    /// scheduler.
+    ///
+    /// See [the module-level documentation][run-loops] for more information on
+    /// using this function to implement a system's run loop.
+    ///
+    /// # Returns
+    ///
+    /// A [`Tick`] struct with data describing what occurred during the
+    /// scheduler tick.
+    ///
+    /// [run-loops]: crate::scheduler::#executing-tasks
         pub fn tick(&self) -> Tick {
             self.0.tick_n(Self::DEFAULT_TICK_SIZE)
         }
@@ -570,6 +931,16 @@ feature! {
     }
 
     impl StaticScheduler {
+        /// Returns a new `StaticScheduler` with a heap-allocated stub task.
+        ///
+        /// Unlike [`StaticScheduler::new_with_static_stub`], this is *not* a
+        /// `const fn`, as it performs a heap allocation for the stub task.
+        /// However, the returned `StaticScheduler` must still be stored in a
+        /// `static` variable in order to be used.
+        ///
+        /// This method is generally used with lazy initialization of the
+        /// scheduler `static`.
+        #[must_use]
         pub fn new() -> Self {
             Self::default()
         }
@@ -579,6 +950,55 @@ feature! {
         /// This method returns a [`JoinHandle`] that can be used to await the
         /// task's output. Dropping the [`JoinHandle`] _detaches_ the spawned task,
         /// allowing it to run in the background without awaiting its output.
+        ///
+        /// When tasks are spawned on a scheduler, the scheduler must be
+        /// [ticked](Self::tick) in order to drive those tasks to completion.
+        /// See the [module-level documentation][run-loops] for more information
+        /// on implementing a system's run loop.
+        ///
+        /// # Examples
+        ///
+        /// Spawning a task and awaiting its output:
+        /// ```
+        /// use maitake::scheduler::{self, StaticScheduler};
+        /// static SCHEDULER: StaticScheduler = scheduler::new_static!();
+        ///
+        /// // spawn a new task, returning a `JoinHandle`.
+        /// let task = SCHEDULER.spawn(async move {
+        ///     // ... do stuff ...
+        ///    42
+        /// });
+        ///
+        /// // spawn another task that awaits the output of the first task.
+        /// SCHEDULER.spawn(async move {
+        ///     // await the `JoinHandle` future, which completes when the task
+        ///     // finishes, and unwrap its output.
+        ///     let output = task.await.expect("task is not cancelled");
+        ///     assert_eq!(output, 42);
+        /// });
+        ///
+        /// // run the scheduler, driving the spawned tasks to completion.
+        /// while SCHEDULER.tick().has_remaining {}
+        ///
+        /// Spawning a task to run in the background, without awaiting its
+        /// output:
+        ///
+        /// ```
+        /// use maitake::scheduler::{self, StaticScheduler};
+        /// static SCHEDULER: StaticScheduler = scheduler::new_static!();
+        ///
+        /// # async fn docs() {
+        /// // dropping the `JoinHandle` allows the task to run in the background
+        /// // without awaiting its output.
+        /// SCHEDULER.spawn(async move {
+        ///     // ... do stuff ...
+        /// });
+        ///
+        /// // run the scheduler, driving the spawned tasks to completion.
+        /// while SCHEDULER.tick().has_remaining {}
+        /// ```
+        ///
+        /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
         pub fn spawn<F>(&'static self, future: F) -> JoinHandle<F::Output>


### PR DESCRIPTION
This branch enables `#[warn(missing_docs)]` in the `maitake::scheduler`
module, and adds a bunch of new documentation. I also fixed a minor
issue in the `justfile` where running `just docs` didn't set
`RUSTDOCFLAGS="--cfg docsrs"` so the README wasn't included in the docs
build.