### PR TITLE
refac: use exhaustive bindings manual `fmt::Debug` impls

### DIFF
--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -760,10 +760,11 @@ unsafe impl Linked<list::Links<Self>> for Free {
 
 impl fmt::Debug for Free {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { magic, links, meta } = self;
         f.debug_struct("Free")
-            .field("magic", &fmt::hex(&self.magic))
-            .field("links", &self.links)
-            .field("meta", &self.meta)
+            .field("magic", &fmt::hex(magic))
+            .field("links", links)
+            .field("meta", meta)
             .finish()
     }
 }

--- a/bitfield/src/pack.rs
+++ b/bitfield/src/pack.rs
@@ -714,9 +714,10 @@ macro_rules! make_packers {
 
             impl<T, F> fmt::Debug for $Pack<T, F> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { mask, shift, _dst_ty } = self;
                     f.debug_struct(stringify!($Pack))
-                        .field("mask", &format_args!("{:#b}", self.mask))
-                        .field("shift", &self.shift)
+                        .field("mask", &format_args!("{:#b}", mask))
+                        .field("shift", shift)
                         .field("dst_type", &format_args!("{}", type_name::<T>()))
                         .finish()
                 }
@@ -724,9 +725,10 @@ macro_rules! make_packers {
 
             impl<T, F> fmt::UpperHex for $Pack<T, F> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { mask, shift, _dst_ty } = self;
                     f.debug_struct(stringify!($Pack))
-                        .field("mask", &format_args!("{:#X}", self.mask))
-                        .field("shift", &self.shift)
+                        .field("mask", &format_args!("{:#X}", mask))
+                        .field("shift", shift)
                         .field("dst_type", &format_args!("{}", type_name::<T>()))
                         .finish()
                 }
@@ -734,9 +736,10 @@ macro_rules! make_packers {
 
             impl<T, F> fmt::LowerHex for $Pack<T, F> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { mask, shift, _dst_ty } = self;
                     f.debug_struct(stringify!($Pack))
-                        .field("mask", &format_args!("{:#x}", self.mask))
-                        .field("shift", &self.shift)
+                        .field("mask", &format_args!("{:#x}", mask))
+                        .field("shift", shift)
                         .field("dst_type", &format_args!("{}", type_name::<T>()))
                         .finish()
                 }
@@ -744,9 +747,10 @@ macro_rules! make_packers {
 
             impl<T, F> fmt::Binary for $Pack<T, F> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { mask, shift, _dst_ty } = self;
                     f.debug_struct(stringify!($Pack))
-                        .field("mask", &format_args!("{:#b}", self.mask))
-                        .field("shift", &self.shift)
+                        .field("mask", &format_args!("{:#b}", mask))
+                        .field("shift", shift)
                         .field("dst_type", &format_args!("{}", type_name::<T>()))
                         .finish()
                 }
@@ -1000,44 +1004,48 @@ macro_rules! make_packers {
 
             impl<T> fmt::Debug for $Pair<T> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { src, dst, dst_shl, dst_shr } = self;
                     f.debug_struct(stringify!($Pair))
-                        .field("src", &self.src)
-                        .field("dst", &self.dst)
-                        .field("dst_shl", &self.dst_shl)
-                        .field("dst_shr", &self.dst_shr)
+                        .field("src", src)
+                        .field("dst", dst)
+                        .field("dst_shl", dst_shl)
+                        .field("dst_shr", dst_shr)
                         .finish()
                 }
             }
 
             impl<T> fmt::UpperHex for $Pair<T> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { src, dst, dst_shl, dst_shr } = self;
                     f.debug_struct(stringify!($Pair))
-                        .field("src", &self.src)
-                        .field("dst", &self.dst)
-                        .field("dst_shl", &self.dst_shl)
-                        .field("dst_shr", &self.dst_shr)
+                        .field("src", src)
+                        .field("dst", dst)
+                        .field("dst_shl", dst_shl)
+                        .field("dst_shr", dst_shr)
                         .finish()
                 }
             }
 
             impl<T> fmt::LowerHex for $Pair<T> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { src, dst, dst_shl, dst_shr } = self;
                     f.debug_struct(stringify!($Pair))
-                        .field("src", &self.src)
-                        .field("dst", &self.dst)
-                        .field("dst_shl", &self.dst_shl)
-                        .field("dst_shr", &self.dst_shr)
+                        .field("src", src)
+                        .field("dst", dst)
+                        .field("dst_shl", dst_shl)
+                        .field("dst_shr", dst_shr)
                         .finish()
                 }
             }
 
             impl<T> fmt::Binary for $Pair<T> {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    let Self { src, dst, dst_shl, dst_shr } = self;
                     f.debug_struct(stringify!($Pair))
-                        .field("src", &self.src)
-                        .field("dst", &self.dst)
-                        .field("dst_shl", &self.dst_shl)
-                        .field("dst_shr", &self.dst_shr)
+                        .field("src", src)
+                        .field("dst", dst)
+                        .field("dst_shl", dst_shl)
+                        .field("dst_shr", dst_shr)
                         .finish()
                 }
             }

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -1013,10 +1013,11 @@ unsafe impl<T: Linked<Links<T>> + ?Sized> Sync for List<T> where T: Sync {}
 
 impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for List<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { head, tail, len } = self;
         f.debug_struct("List")
-            .field("head", &FmtOption::new(&self.head))
-            .field("tail", &FmtOption::new(&self.tail))
-            .field("len", &self.len())
+            .field("head", &FmtOption::new(head))
+            .field("tail", &FmtOption::new(tail))
+            .field("len", len)
             .finish()
     }
 }
@@ -1322,7 +1323,8 @@ impl<'list, T: Linked<Links<T>> + ?Sized> iter::FusedIterator for IterMut<'list,
 
 impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for IntoIter<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("IntoIter").field(&self.list).finish()
+        let Self { list } = self;
+        f.debug_tuple("IntoIter").field(list).finish()
     }
 }
 
@@ -1381,8 +1383,9 @@ where
     T: Linked<Links<T>> + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { cursor, pred: _ } = self;
         f.debug_struct("DrainFilter")
-            .field("cursor", &self.cursor)
+            .field("cursor", cursor)
             .field("pred", &format_args!("..."))
             .finish()
     }

--- a/cordyceps/src/list/cursor.rs
+++ b/cordyceps/src/list/cursor.rs
@@ -446,10 +446,13 @@ impl<'list, T: Linked<Links<T>> + ?Sized> CursorMut<'list, T> {
 
 impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for CursorMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            core: CursorCore { list, curr, index },
+        } = self;
         f.debug_struct("CursorMut")
-            .field("curr", &FmtOption::new(&self.core.curr))
-            .field("list", &self.core.list)
-            .field("index", &self.core.index)
+            .field("curr", &FmtOption::new(curr))
+            .field("list", list)
+            .field("index", index)
             .finish()
     }
 }
@@ -556,10 +559,13 @@ impl<'list, T: Linked<Links<T>> + ?Sized> Cursor<'list, T> {
 
 impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for Cursor<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            core: CursorCore { list, curr, index },
+        } = self;
         f.debug_struct("Cursor")
-            .field("curr", &FmtOption::new(&self.core.curr))
-            .field("list", &self.core.list)
-            .field("index", &self.core.index)
+            .field("curr", &FmtOption::new(curr))
+            .field("list", list)
+            .field("index", index)
             .finish()
     }
 }

--- a/hal-core/src/interrupt.rs
+++ b/hal-core/src/interrupt.rs
@@ -129,8 +129,9 @@ impl RegistrationError {
 
 impl fmt::Debug for RegistrationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { kind } = self;
         f.debug_struct("RegistrationError")
-            .field("kind", &self.kind)
+            .field("kind", kind)
             .finish()
     }
 }

--- a/hal-core/src/mem.rs
+++ b/hal-core/src/mem.rs
@@ -156,10 +156,11 @@ where
     A: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { base, size, kind } = self;
         f.debug_struct("Region")
-            .field("base", &self.base)
-            .field("size", &self.size)
-            .field("kind", &self.kind)
+            .field("base", base)
+            .field("size", size)
+            .field("kind", kind)
             .finish()
     }
 }

--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -531,9 +531,10 @@ impl<A: Address, S: StaticSize> cmp::Ord for Page<A, S> {
 
 impl<A: fmt::Debug, S: Size + fmt::Display> fmt::Debug for Page<A, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { base, size } = self;
         f.debug_struct("Page")
-            .field("base", &self.base)
-            .field("size", &format_args!("{}", self.size))
+            .field("base", base)
+            .field("size", &format_args!("{size}"))
             .finish()
     }
 }
@@ -635,9 +636,10 @@ where
     S: Size + fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { start, end } = self;
         f.debug_struct("PageRange")
-            .field("start", &self.start)
-            .field("end", &self.end)
+            .field("start", start)
+            .field("end", end)
             .finish()
     }
 }
@@ -656,8 +658,9 @@ unsafe impl<S: Size> Alloc<S> for EmptyAlloc {
 
 impl<S: Size + fmt::Display> fmt::Debug for NotAligned<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { size } = self;
         f.debug_struct("NotAligned")
-            .field("size", &format_args!("{}", self.size))
+            .field("size", &format_args!("{size}"))
             .finish()
     }
 }

--- a/hal-x86_64/src/cpu.rs
+++ b/hal-x86_64/src/cpu.rs
@@ -80,8 +80,9 @@ pub fn halt() -> ! {
 
 impl fmt::Debug for Port {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { num } = self;
         f.debug_struct("Port")
-            .field("num", &format_args!("{:#02x}", self.num))
+            .field("num", &format_args!("{num:#02x}"))
             .finish()
     }
 }
@@ -213,10 +214,9 @@ impl fmt::Debug for DtablePtr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // avoid creating misaligned references by moving these i guess? idk why
         // rustc is okay with this but i'll trust it.
-        let limit = self.limit;
-        let base = self.base;
+        let Self { limit, base } = *self;
         f.debug_struct("DtablePtr")
-            .field("base", &format_args!("{:0p}", base))
+            .field("base", &format_args!("{base:0p}",))
             .field("limit", &limit)
             .finish()
     }

--- a/hal-x86_64/src/framebuffer.rs
+++ b/hal-x86_64/src/framebuffer.rs
@@ -106,9 +106,11 @@ where
     B: Deref<Target = [u8]>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { cfg, len, buf: _ } = self;
         f.debug_struct("Framebuffer")
-            .field("len", &self.len)
-            .field("cfg", &self.cfg)
+            .field("len", len)
+            .field("cfg", cfg)
+            // don't print every pixel value in the entire framebuffer...
             .field("buf", &format_args!("[..]"))
             .finish()
     }

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -381,12 +381,21 @@ impl hal_core::interrupt::Control for Idt {
 
 impl fmt::Debug for Registers {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            instruction_ptr,
+            code_segment,
+            stack_ptr,
+            stack_segment,
+            _pad: _,
+            cpu_flags,
+            _pad2: _,
+        } = self;
         f.debug_struct("Registers")
-            .field("instruction_ptr", &self.instruction_ptr)
-            .field("code_segment", &self.code_segment)
-            .field("cpu_flags", &format_args!("{:#b}", self.cpu_flags))
-            .field("stack_ptr", &self.stack_ptr)
-            .field("stack_segment", &self.stack_segment)
+            .field("instruction_ptr", instruction_ptr)
+            .field("code_segment", code_segment)
+            .field("cpu_flags", &format_args!("{cpu_flags:#b}"))
+            .field("stack_ptr", stack_ptr)
+            .field("stack_segment", stack_segment)
             .finish()
     }
 }

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -183,7 +183,8 @@ impl Idt {
 
 impl fmt::Debug for Idt {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_list().entries(self.descriptors[..].iter()).finish()
+        let Self { descriptors } = self;
+        f.debug_list().entries(descriptors[..].iter()).finish()
     }
 }
 
@@ -191,13 +192,22 @@ impl fmt::Debug for Idt {
 
 impl fmt::Debug for Descriptor {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self {
+            offset_low,
+            segment,
+            ist_offset,
+            attrs,
+            offset_mid,
+            offset_hi,
+            _zero: _,
+        } = self;
         f.debug_struct("Descriptor")
-            .field("offset_low", &format_args!("{:#x}", self.offset_low))
-            .field("segment", &self.segment)
-            .field("ist_offset", &format_args!("{:#x}", self.ist_offset))
-            .field("attrs", &self.attrs)
-            .field("offset_mid", &format_args!("{:#x}", self.offset_mid))
-            .field("offset_high", &format_args!("{:#x}", self.offset_hi))
+            .field("offset_low", &format_args!("{offset_low:#x}"))
+            .field("segment", segment)
+            .field("ist_offset", &format_args!("{ist_offset:#x}"))
+            .field("attrs", attrs)
+            .field("offset_mid", &format_args!("{offset_mid:#x}"))
+            .field("offset_high", &format_args!("{offset_hi:#x}"))
             .finish()
     }
 }

--- a/hal-x86_64/src/task.rs
+++ b/hal-x86_64/src/task.rs
@@ -67,16 +67,19 @@ impl Default for StateSegment {
 
 impl fmt::Debug for StateSegment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            privilege_stacks,
+            interrupt_stacks,
+            iomap_offset,
+            _reserved_1: _,
+            _reserved_2: _,
+            _reserved_3: _,
+            _reserved_4: _,
+        } = *self;
         f.debug_struct("task::StateSegment")
-            .field(
-                "privilege_stacks",
-                &format_args!("{:?}", &{ self.privilege_stacks }),
-            )
-            .field(
-                "interrupt_stacks",
-                &format_args!("{:?}", &{ self.interrupt_stacks }),
-            )
-            .field("iomap_offset", &fmt::hex(self.iomap_offset))
+            .field("privilege_stacks", &privilege_stacks)
+            .field("interrupt_stacks", &interrupt_stacks)
+            .field("iomap_offset", &fmt::hex(iomap_offset))
             .field("iomap_addr", &self.iomap_addr())
             .finish()
     }

--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -172,10 +172,11 @@ impl fmt::Write for Buffer {
 
 impl fmt::Debug for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Buffer")
-            .field("row", &self.row)
-            .field("col", &self.col)
-            .field("color", &self.color)
+        let Self { row, col, color, buf: _} = self;
+        f.debug_struct("vga::Buffer")
+            .field("row", row)
+            .field("col", col)
+            .field("color", color)
             .field("buf", &format_args!("[..]"))
             .finish()
     }

--- a/maitake/src/sync/mutex.rs
+++ b/maitake/src/sync/mutex.rs
@@ -242,9 +242,10 @@ impl<T: ?Sized> Mutex<T> {
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { data: _, wait } = self;
         f.debug_struct("Mutex")
             .field("data", &fmt::opt(&self.try_lock()).or_else("<locked>"))
-            .field("wait", &self.wait)
+            .field("wait", wait)
             .finish()
     }
 }

--- a/maitake/src/sync/rwlock.rs
+++ b/maitake/src/sync/rwlock.rs
@@ -405,8 +405,9 @@ impl<T: ?Sized> RwLock<T> {
 
 impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { sem, data: _ } = self;
         f.debug_struct("RwLock")
-            .field("sem", &self.sem)
+            .field("sem", sem)
             .field("data", &fmt::opt(&self.try_read()).or_else("<locked>"))
             .finish()
     }

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -727,8 +727,18 @@ where
     F: Future,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            schedulable:
+                Schedulable {
+                    header,
+                    scheduler: _,
+                },
+            inner: _,
+            join_waker: _,
+            storage: _,
+        } = self;
         f.debug_struct("Task")
-            .field("header", &self.header())
+            .field("header", header)
             .field("inner", &format_args!("UnsafeCell(<{}>)", type_name::<F>()))
             .field("join_waker", &format_args!("UnsafeCell(<Waker>)"))
             .field("scheduler", &fmt::display(type_name::<S>()))
@@ -865,8 +875,12 @@ impl<S: Schedule> Schedulable<S> {
 
 impl<S> fmt::Debug for Schedulable<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            header,
+            scheduler: _,
+        } = self;
         f.debug_struct("Schedulable")
-            .field("header", &self.header)
+            .field("header", header)
             .field("scheduler", &fmt::display(type_name::<S>()))
             .finish()
     }
@@ -1073,7 +1087,6 @@ impl fmt::Debug for TaskRef {
 }
 
 impl fmt::Pointer for TaskRef {
-
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.0, f)
@@ -1267,10 +1280,17 @@ impl<F: Future> fmt::Debug for Cell<F> {
 
 impl fmt::Debug for Vtable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let &Self {
+            poll,
+            poll_join,
+            deallocate,
+            wake_by_ref,
+        } = self;
         f.debug_struct("Vtable")
-            .field("poll", &fmt::ptr(self.poll))
-            .field("poll_join", &fmt::ptr(self.poll_join as *const ()))
-            .field("deallocate", &fmt::ptr(self.deallocate))
+            .field("poll", &fmt::ptr(poll))
+            .field("poll_join", &fmt::ptr(poll_join as *const ()))
+            .field("deallocate", &fmt::ptr(deallocate))
+            .field("wake_by_ref", &fmt::ptr(wake_by_ref))
             .finish()
     }
 }

--- a/maitake/src/time/timer/sleep.rs
+++ b/maitake/src/time/timer/sleep.rs
@@ -148,11 +148,12 @@ impl PinnedDrop for Sleep<'_> {
 
 impl fmt::Debug for Sleep<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { state, entry, timer } = self;
         f.debug_struct("Sleep")
             .field("duration", &self.duration())
-            .field("state", &self.state)
-            .field("addr", &fmt::ptr(&self.entry))
-            .field("timer", &fmt::ptr(&self.timer))
+            .field("state", state)
+            .field("addr", &fmt::ptr(entry))
+            .field("timer", &fmt::ptr(*timer))
             .finish()
     }
 }

--- a/maitake/src/time/timer/wheel.rs
+++ b/maitake/src/time/timer/wheel.rs
@@ -430,12 +430,13 @@ impl Wheel {
 
 impl fmt::Debug for Wheel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { level, ticks_per_slot, ticks_per_wheel, wheel_mask, occupied_slots, slots: _ } = self;
         f.debug_struct("Wheel")
-            .field("level", &self.level)
-            .field("ticks_per_slot", &self.ticks_per_slot)
-            .field("ticks_per_wheel", &self.ticks_per_wheel)
-            .field("wheel_mask", &fmt::bin(self.wheel_mask))
-            .field("occupied_slots", &fmt::bin(&self.occupied_slots))
+            .field("level", level)
+            .field("ticks_per_slot", ticks_per_slot)
+            .field("ticks_per_wheel", ticks_per_wheel)
+            .field("wheel_mask", &fmt::bin(wheel_mask))
+            .field("occupied_slots", &fmt::bin(occupied_slots))
             .field("slots", &format_args!("[...]"))
             .finish()
     }

--- a/mycotest/src/assert.rs
+++ b/mycotest/src/assert.rs
@@ -143,10 +143,10 @@ macro_rules! assert_binop {
 
 impl core::fmt::Debug for Failed {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self { expr, file, line, col } = self;
         write!(
             f,
-            "assertion failed: `{}`, {}:{}:{}",
-            self.expr, self.file, self.line, self.col
+            "assertion failed: `{expr}`, {file}:{line}:{col}",
         )
     }
 }

--- a/mycotest/src/lib.rs
+++ b/mycotest/src/lib.rs
@@ -131,16 +131,18 @@ impl<S: Ord> cmp::Ord for TestName<'_, S> {
 // Custom impl to skip `PhantomData` field.
 impl<S: fmt::Debug> fmt::Debug for TestName<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { name, module, _lt } = self;
         f.debug_struct("Test")
-            .field("name", &self.name)
-            .field("module", &self.module)
+            .field("name", name)
+            .field("module", module)
             .finish()
     }
 }
 
 impl<S: fmt::Display> fmt::Display for TestName<'_, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}::{}", self.module, self.name)
+        let Self { name, module, _lt } = self;
+        write!(f, "{module}::{name}")
     }
 }
 


### PR DESCRIPTION
By using an exhaustive destructuring in manual `fmt::Debug` impls, we
get a compiler error if an additional field is added to a type with a
manual `Debug` impl which is not used in the `Debug` impl. This is nice,
since it helps guard against accidentally adding a field without
formatting it.

I've applied this refactoring to *most* manual `Debug` impls, with the
exception of a few that do something more weird than just manually
printing all the `Debug`-able field values.

This caught at least one case where I had forgotten to add a field to a
`Debug` impl :)
 
Thanks to Twitter User @cratelyn for this idea <3