### PR TITLE
chore: roll nightly to `2022-10-07`

### DIFF
--- a/alloc/src/buddy.rs
+++ b/alloc/src/buddy.rs
@@ -318,15 +318,14 @@ impl<const FREE_LISTS: usize> Alloc<FREE_LISTS> {
         tracing::trace!(?min_order);
         let min_order = min_order.ok_or_else(AllocErr::oom)?;
 
-        let size = match self.size_for(layout) {
-            Some(size) => size,
+        let Some(size) = self.size_for(layout) else {
             // XXX(eliza): is it better to just leak it?
-            None => panic!(
+            panic!(
                 "couldn't determine the correct layout for an allocation \
                 we previously allocated successfully, what the actual fuck!\n \
                 addr={:?}; layout={:?}; min_order={}",
                 paddr, layout, min_order,
-            ),
+            )
         };
 
         // Construct a new free block.

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build our helloworld.wast into binary.
     let binary = wat::parse_file("src/helloworld.wast")?;
-    fs::write(out_dir.join("helloworld.wasm"), &binary)?;
+    fs::write(out_dir.join("helloworld.wasm"), binary)?;
     Ok(())
 }

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -312,14 +312,11 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
     ///
     /// This operation should compute in *O*(1) time and *O*(1) memory.
     pub fn append(&mut self, other: &mut Self) {
-        let tail = match self.tail {
+        let Some(tail) = self.tail else {
             // if this list is empty, simply replace it with `other`
-            None => {
-                debug_assert!(self.is_empty());
-                mem::swap(self, other);
-                return;
-            }
-            Some(tail) => tail,
+            debug_assert!(self.is_empty());
+            mem::swap(self, other);
+            return;
         };
 
         // if `other` is empty, do nothing.
@@ -450,19 +447,16 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
     /// Asserts as many of the linked list's invariants as possible.
     #[track_caller]
     pub(crate) fn assert_valid_named(&self, name: &str) {
-        let head = match self.head {
-            Some(head) => head,
-            None => {
-                assert!(
-                    self.tail.is_none(),
-                    "{name}if the linked list's head is null, the tail must also be null"
-                );
-                assert_eq!(
-                    self.len, 0,
-                    "{name}if a linked list's head is null, its length must be 0"
-                );
-                return;
-            }
+        let Some(head) = self.head else {
+            assert!(
+                self.tail.is_none(),
+                "{name}if the linked list's head is null, the tail must also be null"
+            );
+            assert_eq!(
+                self.len, 0,
+                "{name}if a linked list's head is null, its length must be 0"
+            );
+            return;
         };
 
         assert_ne!(
@@ -928,9 +922,8 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
 
     #[inline]
     unsafe fn split_after_node(&mut self, split_node: Link<T>, idx: usize) -> Self {
-        let split_node = match split_node {
-            Some(node) => node,
-            None => return mem::replace(self, Self::new()),
+        let Some(split_node) = split_node else {
+            return mem::replace(self, Self::new());
         };
 
         // the head of the new list is the split node's `next` node (which is

--- a/cordyceps/src/list/cursor.rs
+++ b/cordyceps/src/list/cursor.rs
@@ -334,10 +334,9 @@ impl<'list, T: Linked<Links<T>> + ?Sized> CursorMut<'list, T> {
         let split_at = self.core.index;
         self.core.index = 0;
 
-        let split_node = match self.core.curr {
-            Some(node) => node,
+        let Some(split_node) = self.core.curr else {
             // the split portion is the entire list. just return it.
-            None => return mem::replace(self.core.list, List::new()),
+            return mem::replace(self.core.list, List::new())
         };
 
         // the tail of the new list is the split node's `prev` node (which is
@@ -374,10 +373,9 @@ impl<'list, T: Linked<Links<T>> + ?Sized> CursorMut<'list, T> {
     /// If the cursor is pointing at the null element, then the contents of
     /// `spliced` are inserted at the beginning of the `List` the cursor points to.
     pub fn splice_after(&mut self, mut spliced: List<T>) {
-        let (splice_head, splice_tail, splice_len) = match spliced.take_all() {
-            Some(spliced) => spliced,
+        let Some((splice_head, splice_tail, splice_len)) = spliced.take_all() else {
             // the spliced list is empty, do nothing.
-            None => return,
+            return;
         };
 
         let next = self.core.next_link();
@@ -404,10 +402,9 @@ impl<'list, T: Linked<Links<T>> + ?Sized> CursorMut<'list, T> {
     /// If the cursor is pointing at the null element, then the contents of
     /// `spliced` are inserted at the end of the `List` the cursor points to.
     pub fn splice_before(&mut self, mut spliced: List<T>) {
-        let (splice_head, splice_tail, splice_len) = match spliced.take_all() {
-            Some(spliced) => spliced,
+        let Some((splice_head, splice_tail, splice_len)) = spliced.take_all() else {
             // the spliced list is empty, do nothing.
-            None => return,
+            return;
         };
 
         let prev = self.core.prev_link();

--- a/hal-core/src/addr.rs
+++ b/hal-core/src/addr.rs
@@ -32,7 +32,7 @@ pub trait Address:
             return self;
         }
         let aligned = (u | mask) + 1;
-        Self::from_usize(aligned as usize)
+        Self::from_usize(aligned)
     }
 
     /// Align `self` up to the required alignment for a value of type `T`.

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -305,7 +305,7 @@ mod tests {
         // Z: this bit is 0 for a 64-bit IDT. for a 32-bit IDT, this may be 1 for task gates.
         // Gate Type: 32-bit interrupt gate is 0b1110. that's just how it is.
         assert_eq!(
-            present_32bit_interrupt.0 as u8, 0b1000_1110,
+            present_32bit_interrupt.0, 0b1000_1110,
             "\n attrs: {:#?}",
             present_32bit_interrupt
         );

--- a/hal-x86_64/src/vga.rs
+++ b/hal-x86_64/src/vga.rs
@@ -172,7 +172,12 @@ impl fmt::Write for Buffer {
 
 impl fmt::Debug for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Self { row, col, color, buf: _} = self;
+        let Self {
+            row,
+            col,
+            color,
+            buf: _,
+        } = self;
         f.debug_struct("vga::Buffer")
             .field("row", row)
             .field("col", col)

--- a/inoculate/src/lib.rs
+++ b/inoculate/src/lib.rs
@@ -200,9 +200,9 @@ impl Options {
         let mut cmd = self.cargo_cmd("builder");
         cmd.current_dir(run_dir)
             .arg("--kernel-manifest")
-            .arg(&paths.kernel_manifest())
+            .arg(paths.kernel_manifest())
             .arg("--kernel-binary")
-            .arg(&paths.kernel_bin())
+            .arg(paths.kernel_bin())
             .arg("--out-dir")
             .arg(out_dir)
             .arg("--target-dir")

--- a/justfile
+++ b/justfile
@@ -26,6 +26,9 @@ _fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
     ```
 }
 
+# arguments to pass to all RustDoc invocations
+_rustdoc := _cargo + " doc --no-deps --all-features --document-private-items"
+
 # default recipe to display help information
 default:
     @echo "justfile for Mycelium"
@@ -81,14 +84,13 @@ check-docs crate='': (build-docs crate '--cfg docsrs -Dwarnings') (test-docs cra
 
 # open RustDoc documentation for `crate` (or for the whole workspace).
 docs crate='' $RUSTDOCFLAGS='--cfg docsrs': (build-docs crate RUSTDOCFLAGS)
-    {{ _cargo }} doc \
+    {{ _rustdoc }} \
         {{ if crate == '' { '--workspace' } else { '--package' } }} {{ crate }} \
-        --no-deps --all-features \
         --open
 
 # build RustDoc documentation for the workspace.
 build-docs crate='' $RUSTDOCFLAGS='--cfg docsrs':
-    {{ _cargo }} doc --no-deps --all-features --document-private-items \
+    {{ _rustdoc }} \
         {{ if crate == '' { '--workspace' } else { '--package' } }} {{ crate }} \
         {{ _fmt }}
 

--- a/maitake/src/scheduler/steal.rs
+++ b/maitake/src/scheduler/steal.rs
@@ -192,10 +192,7 @@ impl<'worker, S: Schedule> Stealer<'worker, S> {
     /// - `true` if a task was successfully stolen.
     /// - `false` if the targeted queue is empty.
     pub fn spawn_one(&self, scheduler: &S) -> bool {
-        let task = match self.queue.dequeue() {
-            Some(task) => task,
-            None => return false,
-        };
+        let Some(task) = self.queue.dequeue() else { return false };
         test_trace!(?task, "stole");
 
         // decrement the target queue's task count

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -446,10 +446,7 @@ pub(crate) mod test_util {
             let this = Arc::downgrade(&self);
             drop(self);
             futures_util::future::poll_fn(move |cx| {
-                let this = match this.upgrade() {
-                    Some(this) => this,
-                    None => return Poll::Ready(()),
-                };
+                let Some(this) = this.upgrade() else {return Poll::Ready(()) };
 
                 let res = this.task.wait();
                 futures_util::pin_mut!(res);

--- a/maitake/src/sync/wait_map/tests/loom.rs
+++ b/maitake/src/sync/wait_map/tests/loom.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use crate::loom::{self, future, sync::Arc, thread};
 

--- a/maitake/src/time/timer/sleep.rs
+++ b/maitake/src/time/timer/sleep.rs
@@ -148,7 +148,11 @@ impl PinnedDrop for Sleep<'_> {
 
 impl fmt::Debug for Sleep<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { state, entry, timer } = self;
+        let Self {
+            state,
+            entry,
+            timer,
+        } = self;
         f.debug_struct("Sleep")
             .field("duration", &self.duration())
             .field("state", state)

--- a/maitake/src/time/timer/wheel.rs
+++ b/maitake/src/time/timer/wheel.rs
@@ -430,7 +430,14 @@ impl Wheel {
 
 impl fmt::Debug for Wheel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { level, ticks_per_slot, ticks_per_wheel, wheel_mask, occupied_slots, slots: _ } = self;
+        let Self {
+            level,
+            ticks_per_slot,
+            ticks_per_wheel,
+            wheel_mask,
+            occupied_slots,
+            slots: _,
+        } = self;
         f.debug_struct("Wheel")
             .field("level", level)
             .field("ticks_per_slot", ticks_per_slot)

--- a/maitake/src/time/timer/wheel.rs
+++ b/maitake/src/time/timer/wheel.rs
@@ -49,7 +49,7 @@ struct Deadline {
 /// In loom mode, the slot arrays are apparently a bit too big to pass around
 /// (since loom's `UnsafeCell`s and atomics are larger than "real" ones), and we
 /// apparently segfault when trying to construct a timer wheel. Therefore, it's
-/// necessary to box the slot arrau when running under loom in order to reduce
+/// necessary to box the slot array when running under loom in order to reduce
 /// the stack size of the timer wheel.
 #[cfg(loom)]
 type SlotArray = alloc::boxed::Box<[List<sleep::Entry>; Wheel::SLOTS]>;

--- a/maitake/src/time/timer/wheel/tests.rs
+++ b/maitake/src/time/timer/wheel/tests.rs
@@ -12,7 +12,7 @@ fn wheel_indices() {
         )
     }
 
-    for wheel in 1..Core::WHEELS as usize {
+    for wheel in 1..Core::WHEELS {
         for slot in wheel..Wheel::SLOTS {
             let ticks = (slot * usize::pow(Wheel::SLOTS, wheel as u32)) as u64;
             assert_eq!(
@@ -60,10 +60,7 @@ fn slot_indices() {
         for i in level..Wheel::SLOTS {
             let ticks = i * usize::pow(Wheel::SLOTS, level as u32);
             let slot_index = wheel.slot_index(ticks as u64);
-            assert_eq!(
-                i as usize, slot_index,
-                "wheels[{level}].slot_index({ticks}) == {i}"
-            )
+            assert_eq!(i, slot_index, "wheels[{level}].slot_index({ticks}) == {i}")
         }
     }
 }

--- a/mycotest/src/assert.rs
+++ b/mycotest/src/assert.rs
@@ -143,10 +143,12 @@ macro_rules! assert_binop {
 
 impl core::fmt::Debug for Failed {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let Self { expr, file, line, col } = self;
-        write!(
-            f,
-            "assertion failed: `{expr}`, {file}:{line}:{col}",
-        )
+        let Self {
+            expr,
+            file,
+            line,
+            col,
+        } = self;
+        write!(f, "assertion failed: `{expr}`, {file}:{line}:{col}",)
     }
 }

--- a/mycotest/src/report.rs
+++ b/mycotest/src/report.rs
@@ -61,12 +61,9 @@ impl<'a> TestName<'a> {
 
     #[tracing::instrument(level = "trace")]
     pub fn parse_outcome(line: &'a str) -> Result<Option<(Self, Outcome)>, ParseError> {
-        let line = match line.strip_prefix("MYCELIUM_TEST_") {
-            None => {
-                tracing::trace!("not a test outcome");
-                return Ok(None);
-            }
-            Some(line) => line,
+        let Some(line) = line.strip_prefix("MYCELIUM_TEST_") else {
+            tracing::trace!("not a test outcome");
+            return Ok(None);
         };
         tracing::trace!(?line);
         let (line, result) = if let Some(line) = line.strip_prefix("PASS:") {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-31"
+channel = "nightly-2022-10-07"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-06"
+channel = "nightly-2022-11-11"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-10-07"
+channel = "nightly-2022-11-03"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-15"
+channel = "nightly-2022-11-16"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-03"
+channel = "nightly-2022-11-04"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-05"
+channel = "nightly-2022-11-06"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-04"
+channel = "nightly-2022-11-05"
 components = [
     "clippy",
     "rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-11"
+channel = "nightly-2022-11-15"
 components = [
     "clippy",
     "rustfmt",

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -9,7 +9,7 @@ use hal_core::{
     PAddr,
 };
 use mycelium_alloc::{buddy, bump};
-use mycelium_util::{fmt, math::Logarithm};
+use mycelium_util::fmt;
 
 #[derive(Debug)]
 pub struct Allocator {
@@ -171,7 +171,10 @@ impl fmt::Display for State {
         if bump_mode {
             writeln!(f, "  bump allocator mode only")?;
         } else {
-            let digits = (heap_size).checked_ilog(10).unwrap_or(0) + 1;
+            let digits = {
+                let digits = (heap_size).checked_ilog(10).unwrap_or(0) + 1;
+                digits as usize
+            };
             let free = heap_size - allocated;
             writeln!(f, "buddy heap:")?;
 
@@ -188,7 +191,10 @@ impl fmt::Display for State {
         }
 
         writeln!(f, "bump region:")?;
-        let bump_digits = (bump_size).checked_ilog(10).unwrap_or(0) + 1;
+        let bump_digits = {
+            let digits = (bump_size).checked_ilog(10).unwrap_or(0) + 1;
+            digits as usize
+        };
         let bump_free = bump_size - bump_allocated;
 
         writeln!(f, "  {bump_free:>digits$} B free", digits = bump_digits)?;

--- a/src/arch/x86_64/framebuf.rs
+++ b/src/arch/x86_64/framebuf.rs
@@ -54,11 +54,10 @@ pub(super) fn init(bootinfo: &mut BootInfo) -> bool {
     }
 
     // Okay, try to initialize the framebuffer
-    let framebuffer = match mem::replace(&mut bootinfo.framebuffer, Optional::None) {
-        Optional::Some(framebuffer) => framebuffer,
+    let Optional::Some(framebuffer) = mem::replace(&mut bootinfo.framebuffer, Optional::None) else {
         // The boot info does not contain a framebuffer configuration. Nothing
         // for us to do!
-        Optional::None => return false,
+        return false;
     };
 
     let info = framebuffer.info();

--- a/util/src/math.rs
+++ b/util/src/math.rs
@@ -48,10 +48,10 @@ pub trait Logarithm: Sized {
 
     /// Returns the integer logarithm base `base` of `self`, or `None` if it is
     /// not possible  to take the log base `base` of `self`.
-    fn checked_ilog(self, base: Self) -> Option<Self>;
+    fn checked_log(self, base: Self) -> Option<Self>;
 
     /// Returns the integer logarithm base `base` of `self`.
-    fn ilog(self, base: Self) -> Self;
+    fn log(self, base: Self) -> Self;
 }
 
 impl Logarithm for usize {
@@ -72,15 +72,15 @@ impl Logarithm for usize {
     #[inline(always)]
     #[must_use = "this returns the result of the operation, \
                     without modifying the original"]
-    fn checked_ilog(self, base: usize) -> Option<Self> {
+    fn checked_log(self, base: usize) -> Option<Self> {
         usize_const_checked_log(self, base)
     }
 
     #[inline(always)]
     #[must_use = "this returns the result of the operation, \
                     without modifying the original"]
-    fn ilog(self, base: usize) -> Self {
-        match self.checked_ilog(base) {
+    fn log(self, base: usize) -> Self {
+        match self.checked_log(base) {
             Some(log) => log,
             None => panic!("cannot take log base {} of {}", base, self),
         }


### PR DESCRIPTION
This commit updates Mycelium's pinned nightly version to Rust `nightly-2022-10-09`. Unfortunately, this currently doesn't work, due to linker errors when linking with the bootloader (see rust-osdev/bootloader#271).