### PR TITLE
chore(ci): actually build a kernel image on nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,8 +65,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: print current nightly
       run: rustc --version && cargo --version
-    - name: run cargo clippy
-      uses: actions-rs/cargo@v1.0.1
-      with:
-        command: clippy
-        args: --all --all-features
+    - name: install Just
+      uses: extractions/setup-just@v1
+    - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
+    - name: cargo clippy
+      run: just clippy

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,8 +34,25 @@ jobs:
   # file. this job checks to see if we can build mycelium on whatever the most
   # recent nightly is. if this fails, there are breaking changes we need to
   # address before updating to a newer nightly build.
+  kernel-x86_64-nightly:
+    name: build x86_64 boot image (latest nightly)
+    runs-on: ubuntu-latest
+    steps:
+    - name: install rust toolchain
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        profile: minimal
+        # needed to build the kernel
+        components: rust-src, llvm-tools-preview
+        toolchain: nightly
+        override: true
+    - uses: actions/checkout@v2
+    - name: print current nightly
+      run: rustc --version && cargo --version
+      run: cargo build-x64
+
   clippy-nightly:
-    name: check latest nightly
+    name: check (latest nightly)
     runs-on: ubuntu-latest
     steps:
     - name: install rust toolchain


### PR DESCRIPTION
Currently, the "latest nightly" CI cronjob only runs clippy checks. This
doesn't catch issues where nightly breaks actually compiling the kernel
image.

This branch updates the nightly CI workflow to actually build a bootable
mycelium image, so that we can catch issues like
rust-osdev/bootloader#271 earlier, instead of having to wait until I
manually try to update nightly.