### PR TITLE
feat(trace): make framebuffer trace text 6x13px

### DIFF
--- a/trace/src/embedded_graphics.rs
+++ b/trace/src/embedded_graphics.rs
@@ -178,5 +178,5 @@ where
 }
 
 fn default_text_style() -> MonoTextStyle<'static, pixelcolor::Rgb888> {
-    MonoTextStyle::new(&mono_font::ascii::FONT_6X10, pixelcolor::Rgb888::WHITE)
+    MonoTextStyle::new(&mono_font::ascii::FONT_6X13, pixelcolor::Rgb888::WHITE)
 }


### PR DESCRIPTION
this is significantly less eye-hurty, imo.
![image](https://user-images.githubusercontent.com/2796466/194780586-a8cc9c6e-9e86-42d9-9a6c-193d4d56948d.png)
