### PR TITLE
feat(trace): make traces prettier, add colors

### DIFF
--- a/src/arch/x86_64/oops.rs
+++ b/src/arch/x86_64/oops.rs
@@ -14,7 +14,7 @@ use hal_core::{
     interrupt, Address,
 };
 use hal_x86_64::{cpu, interrupt::Registers as X64Registers, serial, vga};
-use mycelium_trace::{embedded_graphics::MakeTextWriter, writer::MakeWriter};
+use mycelium_trace::{embedded_graphics::TextWriterBuilder, writer::MakeWriter};
 use mycelium_util::fmt::{self, Write};
 
 #[derive(Debug)]
@@ -98,10 +98,9 @@ pub fn oops(oops: Oops<'_>) -> ! {
     .unwrap();
     drop(framebuf);
 
-    let mk_writer = MakeTextWriter::new_at(
-        || unsafe { super::framebuf::mk_framebuf() },
-        Point::new(4, 45),
-    );
+    let mk_writer = TextWriterBuilder::default()
+        .starting_point(Point::new(4, 45))
+        .build(|| unsafe { super::framebuf::mk_framebuf() });
 
     match oops.situation {
         OopsSituation::Fault {

--- a/trace/Cargo.toml
+++ b/trace/Cargo.toml
@@ -10,5 +10,4 @@ tracing-core = {git = "https://github.com/tokio-rs/tracing", default_features = 
 tracing = { git = "https://github.com/tokio-rs/tracing", default_features = false }
 hal-core = { path = "../hal-core" }
 mycelium-util = { path = "../util" }
-
 embedded-graphics = { version = "0.7", optional = true }

--- a/trace/src/color.rs
+++ b/trace/src/color.rs
@@ -1,0 +1,281 @@
+use core::fmt;
+
+use crate::writer::MakeWriter;
+pub trait SetColor {
+    fn set_fg_color(&mut self, color: Color);
+    fn fg_color(&self) -> Color;
+
+    /// Sets bold text.
+    ///
+    /// This may brighten a text color if bold text is not supported.
+    fn set_bold(&mut self, bold: bool);
+
+    fn with_bold(&mut self) -> WithBold<'_, Self>
+    where
+        Self: fmt::Write + Sized,
+    {
+        self.set_bold(true);
+        WithBold { writer: self }
+    }
+
+    #[must_use]
+    fn with_fg_color(&mut self, color: Color) -> WithFgColor<'_, Self>
+    where
+        Self: fmt::Write + Sized,
+    {
+        let prev_color = self.fg_color();
+        self.set_fg_color(color);
+        WithFgColor {
+            writer: self,
+            prev_color,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum Color {
+    Black = 0,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    Default,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct WithFgColor<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    writer: &'writer mut W,
+    prev_color: Color,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct WithBold<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    writer: &'writer mut W,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct AnsiEscapes<W> {
+    writer: W,
+    current_fg: Color,
+}
+
+impl<W: SetColor> SetColor for &'_ mut W {
+    #[inline]
+    fn set_fg_color(&mut self, color: Color) {
+        W::set_fg_color(self, color)
+    }
+
+    #[inline]
+    fn fg_color(&self) -> Color {
+        W::fg_color(self)
+    }
+
+    #[inline]
+    fn set_bold(&mut self, bold: bool) {
+        W::set_bold(self, bold)
+    }
+}
+
+// === impl WithFgColor ===
+
+impl<'writer, W> fmt::Write for WithFgColor<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.writer.write_str(s)
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.writer.write_char(c)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
+        self.writer.write_fmt(args)
+    }
+}
+
+impl<'writer, W> Drop for WithFgColor<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    fn drop(&mut self) {
+        self.writer.set_fg_color(self.prev_color);
+    }
+}
+
+// === impl WithBold ===
+
+impl<'writer, W> fmt::Write for WithBold<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.writer.write_str(s)
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.writer.write_char(c)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
+        self.writer.write_fmt(args)
+    }
+}
+
+impl<'writer, W> Drop for WithBold<'writer, W>
+where
+    W: fmt::Write + SetColor,
+{
+    fn drop(&mut self) {
+        self.writer.set_bold(false);
+    }
+}
+
+// === impl AnsiEscapes ===
+
+impl<W> AnsiEscapes<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            current_fg: Color::Default,
+        }
+    }
+}
+
+impl<'mk, W> MakeWriter<'mk> for AnsiEscapes<W>
+where
+    W: MakeWriter<'mk>,
+{
+    type Writer = AnsiEscapes<W::Writer>;
+
+    fn make_writer(&'mk self) -> Self::Writer {
+        AnsiEscapes {
+            writer: self.writer.make_writer(),
+            current_fg: self.current_fg,
+        }
+    }
+
+    fn enabled(&self, meta: &tracing_core::Metadata<'_>) -> bool {
+        self.writer.enabled(meta)
+    }
+
+    /// Returns a [`Writer`] for writing data from the span or event described
+    /// by the provided [`Metadata`].
+    ///
+    /// By default, this calls [`self.make_writer()`][make_writer], ignoring
+    /// the provided metadata, but implementations can override this to provide
+    /// metadata-specific behaviors.
+    ///
+    /// This method allows `MakeWriter` implementations to implement different
+    /// behaviors based on the span or event being written. The `MakeWriter`
+    /// type might return different writers based on the provided metadata, or
+    /// might write some values to the writer before or after providing it to
+    /// the caller.
+    ///
+    /// [`Writer`]: MakeWriter::Writer
+    /// [`Metadata`]: tracing_core::Metadata
+    /// [make_writer]: MakeWriter::make_writer
+    /// [`WARN`]: tracing_core::Level::WARN
+    /// [`ERROR`]: tracing_core::Level::ERROR
+    #[inline]
+    fn make_writer_for(&'mk self, meta: &tracing_core::Metadata<'_>) -> Option<Self::Writer> {
+        self.writer.make_writer_for(meta).map(|writer| AnsiEscapes {
+            writer,
+            current_fg: self.current_fg,
+        })
+    }
+
+    fn line_len(&self) -> usize {
+        self.writer.line_len()
+    }
+}
+
+impl<W> fmt::Write for AnsiEscapes<W>
+where
+    W: fmt::Write,
+{
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.writer.write_str(s)
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.writer.write_char(c)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
+        self.writer.write_fmt(args)
+    }
+}
+
+impl<W> AnsiEscapes<W> {
+    const ANSI_FG_COLOR_TABLE: [&str; 17] = [
+        "30", // black
+        "31", // red
+        "32", // green
+        "33", // yellow
+        "34", // blue
+        "35", // magenta
+        "36", // cyan
+        "37", // white
+        "39", // default
+        "90", // bright black
+        "91", // bright red
+        "92", // bright green
+        "93", // bright yellow
+        "94", // bright blue
+        "95", // bright magenta
+        "96", // bright cyan
+        "97", // bright white
+    ];
+
+    fn fg_code(&self) -> &'static str {
+        Self::ANSI_FG_COLOR_TABLE[self.current_fg as usize]
+    }
+}
+
+impl<W: fmt::Write> SetColor for AnsiEscapes<W> {
+    fn set_fg_color(&mut self, color: Color) {
+        self.current_fg = color;
+        let _ = write!(self.writer, "\x1b[{}m", self.fg_code());
+    }
+
+    fn fg_color(&self) -> Color {
+        self.current_fg
+    }
+
+    fn set_bold(&mut self, bold: bool) {
+        let _ = if bold {
+            self.writer.write_str("\x1b[1m")
+        } else {
+            self.writer.write_str("\x1b[22m")
+        };
+    }
+}

--- a/trace/src/embedded_graphics.rs
+++ b/trace/src/embedded_graphics.rs
@@ -1,10 +1,11 @@
+use crate::color::{Color, SetColor};
 use core::{
     fmt,
     sync::atomic::{AtomicU64, Ordering},
 };
 use embedded_graphics::{
     geometry::Point,
-    mono_font::{self, MonoTextStyle},
+    mono_font::{self, MonoFont, MonoTextStyle},
     pixelcolor::{self, RgbColor},
     text::{self, Text},
     Drawable,
@@ -13,15 +14,23 @@ use hal_core::framebuffer::{Draw, DrawTarget};
 #[derive(Debug)]
 pub struct MakeTextWriter<D> {
     mk: fn() -> D,
+    settings: TextWriterBuilder,
     next_point: AtomicU64,
     line_len: u32,
     char_height: u32,
     last_line: i32,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct TextWriterBuilder {
+    default_color: Color,
+    start_point: Point,
+}
+
 #[derive(Clone, Debug)]
 pub struct TextWriter<'mk, D> {
     target: DrawTarget<D>,
+    color: Color,
     mk: &'mk MakeTextWriter<D>,
 }
 
@@ -97,7 +106,7 @@ where
                 curr_point
             } else {
                 // otherwise, actually draw the text.
-                Text::with_alignment(s, curr_point, default_text_style(), text::Alignment::Left)
+                Text::with_alignment(s, curr_point, self.text_style(), text::Alignment::Left)
                     .draw(&mut self.target)
                     .map_err(|_| fmt::Error)?
             };
@@ -131,22 +140,112 @@ where
     }
 }
 
-impl<D: Draw> MakeTextWriter<D> {
-    pub fn new(mk: fn() -> D) -> Self {
-        Self::new_at(mk, Point { x: 10, y: 10 })
+impl<'mk, D> SetColor for TextWriter<'mk, D>
+where
+    D: Draw,
+{
+    fn set_fg_color(&mut self, color: Color) {
+        let color = if color == Color::Default {
+            self.mk.settings.default_color
+        } else {
+            color
+        };
+        self.color = color;
     }
 
-    pub fn new_at(mk: fn() -> D, point: Point) -> Self {
+    fn fg_color(&self) -> Color {
+        self.color
+    }
+
+    fn set_bold(&mut self, bold: bool) {
+        use Color::*;
+        let next_color = if bold {
+            match self.color {
+                Black => BrightBlack,
+                Red => BrightRed,
+                Green => BrightGreen,
+                Yellow => BrightYellow,
+                Blue => BrightBlue,
+                Magenta => BrightMagenta,
+                Cyan => BrightCyan,
+                White => BrightWhite,
+                x => x,
+            }
+        } else {
+            match self.color {
+                BrightBlack => Black,
+                BrightRed => Red,
+                BrightGreen => Green,
+                BrightYellow => Yellow,
+                BrightBlue => Blue,
+                BrightMagenta => Magenta,
+                BrightCyan => Cyan,
+                BrightWhite => White,
+                x => x,
+            }
+        };
+        self.set_fg_color(next_color);
+    }
+}
+
+impl<'mk, D> TextWriter<'mk, D>
+where
+    D: Draw,
+{
+    fn text_style(&self) -> MonoTextStyle<'static, pixelcolor::Rgb888> {
+        use pixelcolor::Rgb888;
+        const COLOR_TABLE: [Rgb888; 17] = [
+            Rgb888::BLACK,              // black
+            Rgb888::new(128, 0, 0),     // red
+            Rgb888::new(0, 128, 0),     // green
+            Rgb888::new(128, 128, 0),   // yellow
+            Rgb888::new(0, 0, 128),     // blue
+            Rgb888::new(128, 0, 128),   // magenta
+            Rgb888::new(0, 128, 128),   // cyan
+            Rgb888::new(192, 192, 192), // white
+            Rgb888::new(192, 192, 192), // default
+            Rgb888::new(128, 128, 128), // bright black
+            Rgb888::new(255, 0, 0),     // bright red
+            Rgb888::new(0, 255, 0),     // bright green
+            Rgb888::new(255, 255, 0),   // bright yellow
+            Rgb888::new(0, 0, 255),     // bright blue
+            Rgb888::new(255, 0, 255),   // bright magenta
+            Rgb888::new(0, 255, 255),   // bright cyan
+            Rgb888::new(255, 255, 255), // bright white
+        ];
+        MonoTextStyle::new(
+            self.mk.settings.get_font(),
+            COLOR_TABLE[self.color as usize],
+        )
+    }
+}
+
+// === impl MakeTextWriter ===
+impl<D> MakeTextWriter<D> {
+    #[must_use]
+    pub const fn builder() -> TextWriterBuilder {
+        TextWriterBuilder::new()
+    }
+}
+
+impl<D: Draw> MakeTextWriter<D> {
+    #[must_use]
+    pub fn new(mk: fn() -> D) -> Self {
+        Self::build(mk, TextWriterBuilder::new())
+    }
+
+    fn build(mk: fn() -> D, settings: TextWriterBuilder) -> Self {
         let (pixel_width, pixel_height) = {
             let buf = (mk)();
             (buf.width() as u32, buf.height() as u32)
         };
-        let text_style = default_text_style();
+        let text_style = MonoTextStyle::new(settings.get_font(), pixelcolor::Rgb888::WHITE);
         let line_len = Self::line_len(pixel_width, &text_style);
         let char_height = text_style.font.character_size.height;
         let last_line = (pixel_height - char_height - 10) as i32;
         Self {
-            next_point: AtomicU64::new(pack_point(point)),
+            settings,
+            next_point: AtomicU64::new(pack_point(settings.start_point)),
             char_height,
             mk,
             line_len,
@@ -167,6 +266,7 @@ where
 
     fn make_writer(&'a self) -> Self::Writer {
         TextWriter {
+            color: self.settings.default_color,
             target: (self.mk)().into_draw_target(),
             mk: self,
         }
@@ -177,6 +277,57 @@ where
     }
 }
 
-fn default_text_style() -> MonoTextStyle<'static, pixelcolor::Rgb888> {
-    MonoTextStyle::new(&mono_font::ascii::FONT_6X13, pixelcolor::Rgb888::WHITE)
+impl TextWriterBuilder {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            // TODO(eliza): it would be nice if this was configurable via the builder,
+            // but it's not, because `MonoFont` is `!Sync` due to containing a trait
+            // object without a `Sync` bound...this should be fixed upstream in
+            // `embedded-graphics`.
+            // font: &mono_font::ascii::FONT_6X13,
+            default_color: Color::White,
+            start_point: Point { x: 10, y: 10 },
+        }
+    }
+
+    // #[must_use]
+    // pub fn font(self, font: &'static MonoFont<'static>) -> Self {
+    //     Self { font, ..self }
+    // }
+
+    #[must_use]
+    pub fn default_color(self, default_color: Color) -> Self {
+        Self {
+            default_color,
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn starting_point(self, start_point: Point) -> Self {
+        Self {
+            start_point,
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn build<D: Draw>(self, mk: fn() -> D) -> MakeTextWriter<D> {
+        MakeTextWriter::build(mk, self)
+    }
+
+    // TODO(eliza): it would be nice if this was configurable via the builder,
+    // but it's not, because `MonoFont` is `!Sync` due to containing a trait
+    // object without a `Sync` bound...this should be fixed upstream in
+    // `embedded-graphics`.
+    fn get_font(&self) -> &'static MonoFont<'static> {
+        &mono_font::ascii::FONT_6X13
+    }
+}
+
+impl Default for TextWriterBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -266,13 +266,12 @@ where
     S: Write,
 {
     fn indent(&mut self, is_span: bool) -> fmt::Result {
+        let chars = if is_span { " + " } else { " " };
         let err = if let Some(ref mut display) = self.display {
             // "rust has try-catch syntax lol"
             (|| {
                 display.indent()?;
-                if is_span {
-                    display.write_char(' ')?;
-                };
+                display.write_str(chars)?;
                 Ok(())
             })()
         } else {
@@ -280,9 +279,8 @@ where
         };
         if let Some(ref mut serial) = self.serial {
             serial.indent()?;
-            let chars = if is_span { '-' } else { ' ' };
 
-            serial.write_char(chars)?;
+            serial.write_str(chars)?;
         }
         err
     }

--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -366,9 +366,9 @@ impl<'a, W: Write> Drop for Writer<'a, W> {
 #[inline]
 fn write_level(w: &mut impl fmt::Write, level: &Level) -> fmt::Result {
     match *level {
-        Level::TRACE => w.write_str("[+]")?,
-        Level::DEBUG => w.write_str("[-]")?,
-        Level::INFO => w.write_str("[*]")?,
+        Level::TRACE => w.write_str("[*]")?,
+        Level::DEBUG => w.write_str("[?]")?,
+        Level::INFO => w.write_str("[i]")?,
         Level::WARN => w.write_str("[!]")?,
         Level::ERROR => w.write_str("[x]")?,
     };

--- a/trace/src/writer.rs
+++ b/trace/src/writer.rs
@@ -1,6 +1,7 @@
 //! Abstractions for creating [`fmt::Write`] instances.
 //!
 //! [`fmt::Write`]: mycelium_util::fmt::Write
+use crate::color::{Color, SetColor};
 use mycelium_util::{
     fmt::{self, Debug},
     sync::spin::{Mutex, MutexGuard},
@@ -431,6 +432,33 @@ where
     }
 }
 
+impl<A, B> SetColor for EitherWriter<A, B>
+where
+    A: fmt::Write + SetColor,
+    B: fmt::Write + SetColor,
+{
+    fn set_fg_color(&mut self, color: Color) {
+        match self {
+            EitherWriter::A(a) => a.set_fg_color(color),
+            EitherWriter::B(b) => b.set_fg_color(color),
+        }
+    }
+
+    fn fg_color(&self) -> Color {
+        match self {
+            EitherWriter::A(a) => a.fg_color(),
+            EitherWriter::B(b) => b.fg_color(),
+        }
+    }
+
+    fn set_bold(&mut self, bold: bool) {
+        match self {
+            EitherWriter::A(a) => a.set_bold(bold),
+            EitherWriter::B(b) => b.set_bold(bold),
+        }
+    }
+}
+
 // === impl WithMaxLevel ===
 
 impl<M> WithMaxLevel<M> {
@@ -748,6 +776,20 @@ impl<'a> MakeWriter<'a> for NoWriter {
     #[inline]
     fn make_writer_for(&'a self, _: &Metadata<'_>) -> Option<Self::Writer> {
         None
+    }
+}
+
+impl SetColor for NoWriter {
+    fn set_fg_color(&mut self, _: Color) {
+        // nop
+    }
+
+    fn fg_color(&self) -> Color {
+        Color::Default
+    }
+
+    fn set_bold(&mut self, _: bool) {
+        // nop
     }
 }
 


### PR DESCRIPTION
This branch makes the serial port and framebuffer traces a bit prettier,
including adding support for colors (either by setting the color for
drawing pixels to the framebuffer, or sending ANSI escapes on the serial
port). Eventually it might be nice if we only sent the serial port ANSI
escapes if the attached host told us it supports them, but meh.

Traces look like this now: 
![image](https://user-images.githubusercontent.com/2796466/196052949-0e4be3e7-4975-4517-bcfa-6496d81ecf02.png)
