### PR TITLE
more shell commands + fixups

### DIFF
--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -1,8 +1,5 @@
 use super::apic::IoApic;
-use crate::{
-    cpu::{self, DescriptorTable},
-    segment,
-};
+use crate::{cpu, segment};
 use mycelium_util::{bits, fmt};
 
 #[repr(C)]

--- a/src/arch/x86_64/shell.rs
+++ b/src/arch/x86_64/shell.rs
@@ -1,4 +1,4 @@
-use crate::shell::{self, Command};
+use crate::shell::Command;
 
 pub const DUMP_ARCH: Command = Command::new("arch")
     .with_help("dump architecture-specific structures")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,29 +157,6 @@ pub fn kernel_start(bootinfo: impl BootInfo, archinfo: crate::arch::ArchInfo) ->
 }
 
 fn kernel_main() -> ! {
-    use maitake::{task, time};
-
-    fn spawn_sleep(duration: time::Duration) -> task::JoinHandle<()> {
-        tracing::info!(?duration, "spawning a sleep");
-
-        rt::spawn(async move {
-            tracing::info!(?duration, "sleeping");
-            time::sleep(duration).await;
-            tracing::info!(?duration, "slept");
-        })
-    }
-
-    // rt::spawn(async move {
-    //     loop {
-    //         futures_util::try_join! {
-    //             spawn_sleep(time::Duration::from_secs(2)),
-    //             spawn_sleep(time::Duration::from_secs(5)),
-    //             spawn_sleep(time::Duration::from_secs(10)),
-    //         }
-    //         .expect("sleep futures failed!");
-    //     }
-    // });
-
     rt::spawn(keyboard_demo());
 
     let mut core = rt::Core::new();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -3,7 +3,6 @@
 //!
 use crate::rt;
 use mycelium_util::fmt::{self, Write};
-
 pub struct Command {
     name: &'static str,
     help: &'static str,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,14 +1,13 @@
 //! A rudimentary kernel-mode command shell, primarily for debugging and testing
 //! purposes.
 //!
-use core::fmt::Write;
-
-use mycelium_util::fmt;
+use crate::rt;
+use mycelium_util::fmt::{self, Write};
 
 pub struct Command {
     pub name: &'static str,
     pub help: &'static str,
-    pub func: Option<fn(&str) -> Result<(), Error<'_>>>,
+    pub func: Option<fn(&str) -> Result<'_>>,
     pub subcommands: Option<&'static [Command]>,
 }
 
@@ -17,6 +16,8 @@ pub struct Error<'a> {
     line: &'a str,
     kind: ErrorKind<'a>,
 }
+
+pub type Result<'a> = core::result::Result<(), Error<'a>>;
 
 #[derive(Debug)]
 enum ErrorKind<'a> {
@@ -31,30 +32,35 @@ enum ErrorKind<'a> {
 }
 
 pub fn eval(line: &str) {
-    static COMMANDS: &[Command] = &[Command::new("dump")
-        .with_help("print formatted representations of a kernel structure")
-        .with_subcommands(&[
-            Command::new("bootinfo")
-                .with_help("print the boot information structure")
-                .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
-            Command::new("archinfo")
-                .with_help("print the architecture information structure")
-                .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
-            Command::new("timer")
-                .with_help("print the timer wheel")
-                .with_fn(|_| {
-                    tracing::info!(timer = ?crate::rt::TIMER);
-                    Ok(())
-                }),
-            crate::rt::DUMP_RT,
-            crate::arch::shell::DUMP_ARCH,
-            Command::new("heap")
-                .with_help("print kernel heap statistics")
-                .with_fn(|_| {
-                    tracing::info!(heap = ?crate::ALLOC.state());
-                    Ok(())
-                }),
-        ])];
+    static COMMANDS: &[Command] = &[
+        Command::new("dump")
+            .with_help("print formatted representations of a kernel structure")
+            .with_subcommands(&[
+                Command::new("bootinfo")
+                    .with_help("print the boot information structure")
+                    .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
+                Command::new("archinfo")
+                    .with_help("print the architecture information structure")
+                    .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
+                Command::new("timer")
+                    .with_help("print the timer wheel")
+                    .with_fn(|_| {
+                        tracing::info!(timer = ?rt::TIMER);
+                        Ok(())
+                    }),
+                rt::DUMP_RT,
+                crate::arch::shell::DUMP_ARCH,
+                Command::new("heap")
+                    .with_help("print kernel heap statistics")
+                    .with_fn(|_| {
+                        tracing::info!(heap = ?crate::ALLOC.state());
+                        Ok(())
+                    }),
+            ]),
+        Command::new("sleep")
+            .with_help("spawns a task to sleep for the given number of seconds")
+            .with_fn(spawn_sleep),
+    ];
 
     tracing::info!("executing shell command: {line:?}\n");
 
@@ -70,7 +76,7 @@ pub fn eval(line: &str) {
     }
 }
 
-pub fn handle_command<'cmd>(line: &'cmd str, commands: &'cmd [Command]) -> Result<(), Error<'cmd>> {
+pub fn handle_command<'cmd>(line: &'cmd str, commands: &'cmd [Command]) -> Result<'cmd> {
     let line = line.trim();
     for cmd in commands {
         if let Some(line) = line.strip_prefix(cmd.name) {
@@ -105,14 +111,14 @@ impl Command {
         }
     }
 
-    pub const fn with_fn(self, func: fn(&str) -> Result<(), Error<'_>>) -> Self {
+    pub const fn with_fn(self, func: fn(&str) -> Result<'_>) -> Self {
         Self {
             func: Some(func),
             ..self
         }
     }
 
-    pub fn run<'cmd>(&self, line: &'cmd str) -> Result<(), Error<'cmd>> {
+    pub fn run<'cmd>(&self, line: &'cmd str) -> Result<'cmd> {
         let line = line.trim();
 
         if line == "help" {
@@ -238,4 +244,29 @@ fn print_help(commands: &[Command]) {
     for Command { name, help, .. } in commands {
         tracing::info!(" - {name}: {help}");
     }
+}
+
+fn spawn_sleep(line: &str) -> Result<'_> {
+    use maitake::time;
+
+    let line = line.trim();
+    if line.is_empty() {
+        return Err(Error::invalid_argument(
+            line,
+            "expected a number of seconds to sleep for",
+        ));
+    }
+
+    let secs: u64 = line
+        .parse()
+        .map_err(|_| Error::invalid_argument(line, "number of seconds must be an integer"))?;
+    let duration = time::Duration::from_secs(secs);
+
+    tracing::info!(?duration, "spawning a sleep");
+    rt::spawn(async move {
+        time::sleep(duration).await;
+        tracing::info!(?duration, "slept");
+    });
+
+    Ok(())
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -270,4 +270,5 @@ fn print_help(commands: &[Command]) {
     for Command { name, help, .. } in commands {
         tracing::info!(" - {name}: {help}");
     }
+    tracing::info!(" - help: prints this help message");
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -5,10 +5,11 @@ use crate::rt;
 use mycelium_util::fmt::{self, Write};
 
 pub struct Command {
-    pub name: &'static str,
-    pub help: &'static str,
-    pub func: Option<fn(&str) -> Result<'_>>,
-    pub subcommands: Option<&'static [Command]>,
+    name: &'static str,
+    help: &'static str,
+    func: Option<fn(Context<'_>) -> Result<'_>>,
+    usage: &'static str,
+    subcommands: Option<&'static [Command]>,
 }
 
 #[derive(Debug)]
@@ -23,41 +24,48 @@ pub type Result<'a> = core::result::Result<(), Error<'a>>;
 enum ErrorKind<'a> {
     UnknownCommand(&'a [Command]),
 
-    SubcommandRequired {
-        name: &'static str,
-        subcommands: &'a [Command],
-    },
-    InvalidArguments(&'static str),
+    SubcommandRequired(&'a [Command]),
+    InvalidArguments { help: &'static str, arg: &'a str },
     Other(&'static str),
 }
 
 pub fn eval(line: &str) {
     static COMMANDS: &[Command] = &[DUMP, SLEEP];
 
-    tracing::info!("executing shell command: {line:?}\n");
+    let _span = tracing::info_span!(target: "shell", "$", message = %line).entered();
+    tracing::info!(target: "shell", "");
 
     if line == "help" {
-        tracing::info!("available commands:");
-        print_help(COMMANDS);
+        tracing::info!(target: "shell", "available commands:");
+        print_help("", COMMANDS);
+        tracing::info!(target: "shell", "");
         return;
     }
 
-    match handle_command(line, COMMANDS) {
+    match handle_command(Context::new(line), COMMANDS) {
         Ok(_) => {}
-        Err(error) => tracing::warn!("could not execute {line:?}: {error}"),
+        Err(error) => tracing::warn!(target: "shell", "error: {error}"),
     }
+
+    tracing::info!(target: "shell", "");
 }
 
-pub fn handle_command<'cmd>(line: &'cmd str, commands: &'cmd [Command]) -> Result<'cmd> {
-    let line = line.trim();
+#[derive(Copy, Clone)]
+pub struct Context<'cmd> {
+    line: &'cmd str,
+    current: &'cmd str,
+}
+
+pub fn handle_command<'cmd>(ctx: Context<'cmd>, commands: &'cmd [Command]) -> Result<'cmd> {
+    let chunk = ctx.current.trim();
     for cmd in commands {
-        if let Some(line) = line.strip_prefix(cmd.name) {
-            let line = line.trim();
-            return cmd.run(line);
+        if let Some(current) = chunk.strip_prefix(cmd.name) {
+            let current = current.trim();
+            return cmd.run(Context { current, ..ctx });
         }
     }
 
-    Err(Error::unknown_command(line, commands))
+    Err(ctx.unknown_command(commands))
 }
 
 // === commands ===
@@ -67,14 +75,14 @@ const DUMP: Command = Command::new("dump")
     .with_subcommands(&[
         Command::new("bootinfo")
             .with_help("print the boot information structure")
-            .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
+            .with_fn(|ctx| Err(ctx.other_error("not yet implemented"))),
         Command::new("archinfo")
             .with_help("print the architecture information structure")
-            .with_fn(|line| Err(Error::other(line, "not yet implemented"))),
+            .with_fn(|ctx| Err(ctx.other_error("not yet implemented"))),
         Command::new("timer")
             .with_help("print the timer wheel")
             .with_fn(|_| {
-                tracing::info!(timer = ?rt::TIMER);
+                tracing::info!(target: "shell", timer = ?rt::TIMER);
                 Ok(())
             }),
         rt::DUMP_RT,
@@ -82,45 +90,44 @@ const DUMP: Command = Command::new("dump")
         Command::new("heap")
             .with_help("print kernel heap statistics")
             .with_fn(|_| {
-                tracing::info!(heap = ?crate::ALLOC.state());
+                tracing::info!(target: "shell", heap = ?crate::ALLOC.state());
                 Ok(())
             }),
     ]);
 
 const SLEEP: Command = Command::new("sleep")
-    .with_help("spawns a task to sleep for the given number of seconds")
-    .with_fn(|line| {
+    .with_help("spawns a task to sleep for SECONDS")
+    .with_usage("<SECONDS>")
+    .with_fn(|ctx| {
         use maitake::time;
 
-        let line = line.trim();
+        let line = ctx.command().trim();
         if line.is_empty() {
-            return Err(Error::invalid_argument(
-                line,
-                "expected a number of seconds to sleep for",
-            ));
+            return Err(ctx.invalid_argument("expected a number of seconds to sleep for"));
         }
 
         let secs: u64 = line
             .parse()
-            .map_err(|_| Error::invalid_argument(line, "number of seconds must be an integer"))?;
+            .map_err(|_| ctx.invalid_argument("number of seconds must be an integer"))?;
         let duration = time::Duration::from_secs(secs);
 
-        tracing::info!(?duration, "spawning a sleep");
+        tracing::info!(target: "shell", ?duration, "spawning a sleep");
         rt::spawn(async move {
             time::sleep(duration).await;
-            tracing::info!(?duration, "slept");
+            tracing::info!(target: "shell", ?duration, "slept");
         });
 
         Ok(())
     });
 
-// === impl Error ===
+// === impl Command ===
 
 impl Command {
     pub const fn new(name: &'static str) -> Self {
         Self {
             name,
             help: "",
+            usage: "",
             func: None,
             subcommands: None,
         }
@@ -137,44 +144,50 @@ impl Command {
         }
     }
 
-    pub const fn with_fn(self, func: fn(&str) -> Result<'_>) -> Self {
+    pub const fn with_fn(self, func: fn(Context<'_>) -> Result<'_>) -> Self {
         Self {
             func: Some(func),
             ..self
         }
     }
 
-    pub fn run<'cmd>(&self, line: &'cmd str) -> Result<'cmd> {
-        let line = line.trim();
+    pub const fn with_usage(self, usage: &'static str) -> Self {
+        Self { usage, ..self }
+    }
 
-        if line == "help" {
-            tracing::info!("{}: {}", self.name, self.help);
+    pub fn run<'cmd>(&self, ctx: Context<'cmd>) -> Result<'cmd> {
+        let current = ctx.current.trim();
+
+        if current == "help" {
+            let name = ctx.line.strip_suffix(" help").unwrap_or("<???BUG???>");
             if let Some(subcommands) = self.subcommands {
-                tracing::info!("subcommands:");
-                print_help(subcommands);
+                tracing::info!(target: "shell", "{name} <COMMAND>: {help}", help = self.help);
+                tracing::info!(target: "shell", "commands:");
+                print_help(name, subcommands);
+            } else {
+                tracing::info!(target: "shell", "{name}");
             }
             return Ok(());
         }
 
         if let Some(subcommands) = self.subcommands {
-            match (handle_command(line, subcommands), self.func) {
-                (
-                    Err(Error {
-                        kind: ErrorKind::UnknownCommand(_),
-                        ..
-                    }),
-                    Some(func),
-                ) => return func(line),
-                (result, _) => return result,
-            }
+            return match handle_command(ctx, subcommands) {
+                Err(e) if e.is_unknown_command() => {
+                    if let Some(func) = self.func {
+                        func(ctx)
+                    } else if current.is_empty() {
+                        Err(ctx.subcommand_required(subcommands))
+                    } else {
+                        Err(e)
+                    }
+                }
+                res => res,
+            };
         }
+
         match self.func {
-            Some(func) => func(line),
-            None => Err(Error::subcommand_required(
-                line,
-                self.name,
-                self.subcommands.unwrap_or(&[]),
-            )),
+            Some(func) => func(ctx),
+            None => Err(ctx.subcommand_required(self.subcommands.unwrap_or(&[]))),
         }
     }
 }
@@ -185,11 +198,13 @@ impl fmt::Debug for Command {
             func,
             name,
             help,
+            usage,
             subcommands,
         } = self;
         f.debug_struct("Command")
             .field("name", name)
             .field("help", help)
+            .field("usage", usage)
             .field("func", &func.map(|func| fmt::ptr(func as *const ())))
             .field("subcommands", subcommands)
             .finish()
@@ -202,73 +217,115 @@ impl fmt::Display for Command {
             func: _func,
             name,
             help,
+            usage,
             subcommands: _subcommands,
         } = self;
-        write!(f, "{name}: {help}")
+
+        let usage = if self.subcommands.is_some() && usage.is_empty() {
+            "<COMMAND>"
+        } else {
+            usage
+        };
+
+        write!(
+            f,
+            "{name}{usage_pad}{usage} --- {help}",
+            usage_pad = if !usage.is_empty() { " " } else { "" },
+        )
     }
 }
 
 // === impl Error ===
 
-impl<'a> Error<'a> {
-    fn unknown_command(line: &'a str, commands: &'a [Command]) -> Self {
-        Self {
-            line,
-            kind: ErrorKind::UnknownCommand(commands),
-        }
-    }
-
-    fn subcommand_required(line: &'a str, name: &'static str, subcommands: &'a [Command]) -> Self {
-        Self {
-            line,
-            kind: ErrorKind::SubcommandRequired { name, subcommands },
-        }
-    }
-
-    pub fn invalid_argument(line: &'a str, help: &'static str) -> Self {
-        Self {
-            line,
-            kind: ErrorKind::InvalidArguments(help),
-        }
-    }
-
-    pub fn other(line: &'a str, msg: &'static str) -> Self {
-        Self {
-            line,
-            kind: ErrorKind::Other(msg),
-        }
+impl Error<'_> {
+    fn is_unknown_command(&self) -> bool {
+        matches!(self.kind, ErrorKind::UnknownCommand(_))
     }
 }
 
 impl fmt::Display for Error<'_> {
     fn fmt(&self, mut f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
+        fn command_names(cmds: &[Command]) -> impl Iterator<Item = &str> + '_ {
+            cmds.iter()
+                .map(|Command { name, .. }| *name)
+                .chain(core::iter::once("help"))
+        }
+
+        let Self { line, kind } = self;
+        match kind {
             ErrorKind::UnknownCommand(commands) => {
-                f.write_str("unknown command, expected one of: [")?;
-                fmt::comma_delimited(&mut f, commands.iter().map(|Command { name, .. }| name))?;
+                write!(f, "unknown command {line:?}, expected one of: [")?;
+                fmt::comma_delimited(&mut f, command_names(commands))?;
                 f.write_char(']')?;
             }
-            ErrorKind::InvalidArguments(help) => {
-                write!(f, "invalid arguments: {:?}, usage: {help}", self.line)?
+            ErrorKind::InvalidArguments { arg, help } => {
+                write!(f, "invalid argument {arg:?}: {help}")?
             }
-            ErrorKind::SubcommandRequired { name, subcommands } => {
+            ErrorKind::SubcommandRequired(subcommands) => {
                 writeln!(
                     f,
-                    "the '{name}' command requires one of the following subcommands: ["
+                    "the '{line}' command requires one of the following subcommands: ["
                 )?;
-                fmt::comma_delimited(&mut f, subcommands.iter().map(|Command { name, .. }| name))?;
+                fmt::comma_delimited(&mut f, command_names(subcommands))?;
                 f.write_char(']')?;
             }
-            ErrorKind::Other(msg) => f.write_str(msg)?,
+            ErrorKind::Other(msg) => write!(f, "could not execute {line:?}: {msg}")?,
         }
 
         Ok(())
     }
 }
 
-fn print_help(commands: &[Command]) {
-    for Command { name, help, .. } in commands {
-        tracing::info!(" - {name}: {help}");
+// === impl Context ===
+
+impl<'cmd> Context<'cmd> {
+    pub const fn new(line: &'cmd str) -> Self {
+        Self {
+            line,
+            current: line,
+        }
     }
-    tracing::info!(" - help: prints this help message");
+
+    pub fn command(&self) -> &'cmd str {
+        self.current
+    }
+
+    fn unknown_command(&self, commands: &'cmd [Command]) -> Error<'cmd> {
+        Error {
+            line: self.line,
+            kind: ErrorKind::UnknownCommand(commands),
+        }
+    }
+
+    fn subcommand_required(&self, subcommands: &'cmd [Command]) -> Error<'cmd> {
+        Error {
+            line: self.line,
+            kind: ErrorKind::SubcommandRequired(subcommands),
+        }
+    }
+
+    pub fn invalid_argument(&self, help: &'static str) -> Error<'cmd> {
+        Error {
+            line: self.line,
+            kind: ErrorKind::InvalidArguments {
+                arg: self.current,
+                help,
+            },
+        }
+    }
+
+    pub fn other_error(&self, msg: &'static str) -> Error<'cmd> {
+        Error {
+            line: self.line,
+            kind: ErrorKind::Other(msg),
+        }
+    }
+}
+
+fn print_help(parent_cmd: &str, commands: &[Command]) {
+    let parent_cmd_pad = if parent_cmd.is_empty() { "" } else { " " };
+    for command in commands {
+        tracing::info!(target: "shell", "  {parent_cmd}{parent_cmd_pad}{command}");
+    }
+    tracing::info!(target: "shell", "  {parent_cmd}{parent_cmd_pad}help --- prints this help message");
 }


### PR DESCRIPTION
this branch adds a `sleep` command for spawning  tasks that sleep for a number of seconds, for demoing/testing the timer wheel. in addition, it refactors the command-parsing code and prettifies the output for shell commands and error handling.
![image](https://user-images.githubusercontent.com/2796466/205454167-47d33c7a-6dfc-4c95-bda7-f8246d086c58.png)
