### PR TITLE
feat(maitake): use `portable_atomic` for task IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "mycelium-bitfield",
  "mycelium-util",
  "pin-project",
+ "portable-atomic",
  "proptest",
  "tokio-test",
  "tracing 0.1.37",
@@ -1381,6 +1382,12 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac662b3a6490de378b0ee15cf2dfff7127aebfe0b19acc65e7fbca3d299c3788"
 
 [[package]]
 name = "ppv-lite86"

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -38,6 +38,7 @@ mycelium-bitfield = { path = "../bitfield" }
 mycelium-util = { path = "../util" }
 cordyceps = { path = "../cordyceps" }
 pin-project = "1"
+portable-atomic = "0.3"
 
 [dependencies.tracing-02]
 package = "tracing"

--- a/maitake/src/loom.rs
+++ b/maitake/src/loom.rs
@@ -109,7 +109,11 @@ mod inner {
         pub use mycelium_util::sync::spin;
     }
 
-    pub(crate) use core::sync::atomic;
+    pub(crate) mod atomic {
+        pub use portable_atomic::*;
+    }
+
+    pub(crate) use portable_atomic::hint;
 
     #[cfg(test)]
     pub(crate) mod thread {
@@ -161,15 +165,6 @@ mod inner {
     pub(crate) fn model(f: impl FnOnce()) {
         let _trace = crate::util::test::trace_init();
         model::Builder::new().check(f)
-    }
-
-    pub(crate) mod hint {
-        #[inline(always)]
-        pub(crate) fn spin_loop() {
-            // MSRV: std::hint::spin_loop() stabilized in 1.49.0
-            #[allow(deprecated)]
-            super::atomic::spin_loop_hint()
-        }
     }
 
     pub(crate) mod cell {

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -31,44 +31,6 @@ macro_rules! feature {
     }
 }
 
-macro_rules! if_atomic_u64 {
-    ($($item:item)*) => {
-        $(
-            // NOTE: `target_arch` values of "arm", "mips", and
-            // "powerpc" refer specifically to the 32-bit versions
-            // of those architectures; the 64-bit architectures get
-            // the `target_arch` strings "aarch64", "mips64", and
-            // "powerpc64", respectively.
-            #[cfg(not(any(
-                target_arch = "arm",
-                target_arch = "mips",
-                target_arch = "powerpc",
-                target_arch = "riscv32",
-            )))]
-            $item
-        )*
-    }
-}
-
-macro_rules! if_no_atomic_u64 {
-    ($($item:item)*) => {
-        $(
-            // NOTE: `target_arch` values of "arm", "mips", and
-            // "powerpc" refer specifically to the 32-bit versions
-            // of those architectures; the 64-bit architectures get
-            // the `target_arch` strings "aarch64", "mips64", and
-            // "powerpc64", respectively.
-            #[cfg(any(
-                target_arch = "arm",
-                target_arch = "mips",
-                target_arch = "powerpc",
-                target_arch = "riscv32",
-            ))]
-            $item
-        )*
-    }
-}
-
 macro_rules! loom_const_fn {
     (
         $(#[$meta:meta])*


### PR DESCRIPTION
This replaces the fallback implementation of task IDs using a `Mutex<u64>` on platforms without 64-bit atomics with the `portable_atomic` crate's `AtomicU64`. `portable_atomic`'s fallback impl uses a sequence lock, which should be more efficient than a spinlock.