### PR TITLE
chore(ci): fix `setup-just` rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     - name: install rust toolchain
       run: rustup show
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: run cargo check (debug)
       run: |
         cargo check \
@@ -100,7 +100,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: run rustfmt
       run: cargo fmt --check --message-format=json | cargo-action-fmt
@@ -113,7 +113,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:
@@ -141,7 +141,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:
@@ -160,7 +160,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: x86_64 boot image
       run: cargo build-x64
 
@@ -173,7 +173,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # install QEMU
     - name: install qemu
@@ -193,7 +193,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: install Just
       uses: extractions/setup-just@v1
@@ -213,7 +213,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:
@@ -232,7 +232,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:
@@ -253,7 +253,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: run tests
       # don't run doctests with `no-default-features`, as some of them
       # require liballoc.
@@ -268,7 +268,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:
@@ -289,7 +289,7 @@ jobs:
     steps:
     - name: install rust toolchain
       run: rustup show
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: install Just
       uses: extractions/setup-just@v1
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,9 @@ jobs:
     - name: install rust toolchain
       run: rustup show
     - uses: actions/checkout@v2
-    - name: install Just
-      uses: extractions/setup-just@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: run rustfmt
-      run: just check-fmt
+      run: cargo fmt --check --message-format=json | cargo-action-fmt
 
   # are there any annoying clippy lints we ought to clean up?
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: run rustfmt
       run: just check-fmt
@@ -118,6 +120,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: cargo clippy
       run: just clippy
@@ -144,6 +148,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: cargo nextest run
@@ -195,6 +201,8 @@ jobs:
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: run rustdoc
       run: just check-docs
 
@@ -212,6 +220,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run loom tests
@@ -229,6 +239,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run Miri tests
@@ -263,6 +275,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run loom tests
@@ -282,6 +296,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run loom tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,8 @@ jobs:
       run: rustc --version && cargo --version
     - name: install Just
       uses: extractions/setup-just@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: olix0r/cargo-action-fmt@ee1ef42932e44794821dab57ef1bf7a73df8b21f
     - name: cargo clippy
       run: just clippy

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
         components: rust-src, llvm-tools-preview
         toolchain: nightly
         override: true
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: print current nightly
       run: rustc --version && cargo --version
     - run: cargo build-x64
@@ -62,7 +62,7 @@ jobs:
         components: clippy
         toolchain: nightly
         override: true
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: print current nightly
       run: rustc --version && cargo --version
     - name: install Just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository_owner == 'hawkw'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: taiki-e/create-gh-release-action@v1.3.0
         with:
           prefix: '[a-z]+'


### PR DESCRIPTION
Apparently the extractions/setup-just action gets rate-limited by the GitHub API a lot, and adding an auth token fixes this: https://github.com/extractions/setup-just#examples