### PR TITLE
feat(maitake): add feature-flagged `core::error::Error` impls

### DIFF
--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -32,6 +32,7 @@ links = "maitake"
 default = ["alloc"]
 alloc = ["cordyceps/alloc"]
 no-cache-pad = ["mycelium-util/no-cache-pad", "cordyceps/no-cache-pad"]
+core-error = []
 
 [dependencies]
 mycelium-bitfield = { path = "../bitfield" }

--- a/maitake/README.md
+++ b/maitake/README.md
@@ -250,9 +250,11 @@ The following features are available (this list is incomplete; you can help by [
 | :---           | :---    | :---        |
 | `alloc`        | `true`  | Enables [`liballoc`] dependency |
 | `no-cache-pad` | `false` | Inhibits cache padding for the [`CachePadded`] struct. When this feature is NOT enabled, the size will be determined based on target platform. |
-| `tracing-01`   | `false`  | Enables support for v0.1.x of [`tracing`] (the current release version). Requires `liballoc`.|
-| `tracing-02`   | `false`  | Enables support for the upcoming v0.2 of [`tracing`] (via a Git dependency). |
+| `tracing-01`   | `false` | Enables support for v0.1.x of [`tracing`] (the current release version). Requires `liballoc`.|
+| `tracing-02`   | `false` | Enables support for the upcoming v0.2 of [`tracing`] (via a Git dependency). |
+| `core-error`   | `false` | Enables implementations of the [`core::error::Error` trait][core-error] for `maitake`'s error types. *Requires a nightly Rust toolchain*. |
 
 [`liballoc`]: https://doc.rust-lang.org/alloc/
 [`CachePadded`]: https://mycelium.elizas.website/mycelium_util/sync/struct.cachepadded
 [`tracing`]: https://crates.io/crates/tracing
+[core-error]: https://doc.rust-lang.org/stable/core/error/index.html

--- a/maitake/src/lib.rs
+++ b/maitake/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(docsrs, loom)))]
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(feature = "core-error", feature(error_in_core))]
 #![allow(unused_unsafe)]
 
 #[cfg(feature = "alloc")]

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -88,6 +88,6 @@ impl core::fmt::Display for Closed {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for Closed {}
 }

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -88,6 +88,6 @@ impl core::fmt::Display for Closed {
 }
 
 feature! {
-    #![mycelium_core_error]
+    #![feature = "core-error"]
     impl core::error::Error for Closed {}
 }

--- a/maitake/src/sync.rs
+++ b/maitake/src/sync.rs
@@ -80,3 +80,14 @@ impl Closed {
         Self(())
     }
 }
+
+impl core::fmt::Display for Closed {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.pad("closed")
+    }
+}
+
+feature! {
+    #![maitake_unstable]
+    impl core::error::Error for Closed {}
+}

--- a/maitake/src/sync/semaphore.rs
+++ b/maitake/src/sync/semaphore.rs
@@ -788,7 +788,7 @@ impl fmt::Display for TryAcquireError {
 }
 
 feature! {
-    #![mycelium_core_error]
+    #![feature = "core-error"]
     impl core::error::Error for TryAcquireError {}
 }
 

--- a/maitake/src/sync/semaphore.rs
+++ b/maitake/src/sync/semaphore.rs
@@ -788,7 +788,7 @@ impl fmt::Display for TryAcquireError {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for TryAcquireError {}
 }
 

--- a/maitake/src/sync/wait_map.rs
+++ b/maitake/src/sync/wait_map.rs
@@ -624,6 +624,24 @@ pub enum WakeOutcome<V> {
     Closed(V),
 }
 
+// === impl WaitError ===
+
+impl fmt::Display for WaitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Closed => f.pad("WaitMap closed"),
+            Self::Duplicate => f.pad("duplicate key"),
+            &Self::AlreadyConsumed => f.pad("received data has already been consumed"),
+            Self::NeverAdded => f.pad("Wait was never added to WaitMap"),
+        }
+    }
+}
+
+feature! {
+    #![maitake_unstable]
+    impl core::error::Error for TimerError {}
+}
+
 // === impl Waiter ===
 
 /// A future that ensures a [`Wait`] has been added to a [`WaitMap`].

--- a/maitake/src/sync/wait_map.rs
+++ b/maitake/src/sync/wait_map.rs
@@ -638,7 +638,7 @@ impl fmt::Display for WaitError {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for TimerError {}
 }
 

--- a/maitake/src/sync/wait_map.rs
+++ b/maitake/src/sync/wait_map.rs
@@ -638,8 +638,8 @@ impl fmt::Display for WaitError {
 }
 
 feature! {
-    #![mycelium_core_error]
-    impl core::error::Error for TimerError {}
+    #![feature = "core-error"]
+    impl core::error::Error for WaitError {}
 }
 
 // === impl Waiter ===

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -308,3 +308,8 @@ impl<T> fmt::Debug for JoinError<T> {
             .finish()
     }
 }
+
+feature! {
+    #![maitake_unstable]
+    impl core::error::Error for JoinError {}
+}

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -311,5 +311,5 @@ impl<T> fmt::Debug for JoinError<T> {
 
 feature! {
     #![mycelium_core_error]
-    impl core::error::Error for JoinError {}
+    impl<T> core::error::Error for JoinError<T> {}
 }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -310,6 +310,6 @@ impl<T> fmt::Debug for JoinError<T> {
 }
 
 feature! {
-    #![mycelium_core_error]
+    #![feature = "core-error"]
     impl<T> core::error::Error for JoinError<T> {}
 }

--- a/maitake/src/task/join_handle.rs
+++ b/maitake/src/task/join_handle.rs
@@ -310,6 +310,6 @@ impl<T> fmt::Debug for JoinError<T> {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for JoinError {}
 }

--- a/maitake/src/time/timeout.rs
+++ b/maitake/src/time/timeout.rs
@@ -140,7 +140,7 @@ impl Elapsed {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for Elapsed {}
 }
 

--- a/maitake/src/time/timeout.rs
+++ b/maitake/src/time/timeout.rs
@@ -138,6 +138,12 @@ impl Elapsed {
         self.0
     }
 }
+
+feature! {
+    #![maitake_unstable]
+    impl core::error::Error for Elapsed {}
+}
+
 // === impl Timer ===
 
 impl Timer {

--- a/maitake/src/time/timeout.rs
+++ b/maitake/src/time/timeout.rs
@@ -140,7 +140,7 @@ impl Elapsed {
 }
 
 feature! {
-    #![mycelium_core_error]
+    #![feature = "core-error"]
     impl core::error::Error for Elapsed {}
 }
 

--- a/maitake/src/time/timer.rs
+++ b/maitake/src/time/timer.rs
@@ -542,6 +542,6 @@ impl fmt::Display for TimerError {
 }
 
 feature! {
-    #![maitake_unstable]
+    #![mycelium_core_error]
     impl core::error::Error for TimerError {}
 }

--- a/maitake/src/time/timer.rs
+++ b/maitake/src/time/timer.rs
@@ -542,6 +542,6 @@ impl fmt::Display for TimerError {
 }
 
 feature! {
-    #![mycelium_core_error]
+    #![feature = "core-error"]
     impl core::error::Error for TimerError {}
 }

--- a/maitake/src/time/timer.rs
+++ b/maitake/src/time/timer.rs
@@ -540,3 +540,8 @@ impl fmt::Display for TimerError {
         }
     }
 }
+
+feature! {
+    #![maitake_unstable]
+    impl core::error::Error for TimerError {}
+}


### PR DESCRIPTION
This branch adds implementations of the `core::error::Error` trait for
`maitake`'s error types. This is feature flagged, as it requires a
nightly Rust toolchain.