### PR TITLE
fix(hal-x86_64): fix race in interrupt controller init

### DIFF
--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -219,12 +219,16 @@ impl Controller {
         };
         tracing::trace!(interrupt_model = ?model);
 
+        let controller = INTERRUPT_CONTROLLER.init(Self { model });
+
+        // `sti` may not be called until the interrupt controller static is
+        // fully initialized, as an interrupt that occurs before it is
+        // initialized may attempt to access the static to finish the interrupt!
         unsafe {
             crate::cpu::intrinsics::sti();
         }
 
-        let controller = Self { model };
-        INTERRUPT_CONTROLLER.init(controller)
+        controller
     }
 
     /// Starts a periodic timer which fires the `timer_tick` interrupt of the


### PR DESCRIPTION
The interrupt controller is stored in an `InitOnce` cell, so that it may be accessed in interrupt handlers to send an EOI on completion of an interrupt. Currently, the `enable_hardware_interrupts` function will execute an `sti` instruction (enabling interrupts) *before* it initializes the interrupt controller's `InitOnce` cell. This means that if an interrupt occurs immediately after the `sti`, it can cause a race where the static is accessed before it's initialized.

Fixes #383