### PR TITLE
feat(hal-core): pass page frame allocator immutably

### DIFF
--- a/hal-core/src/mem/page.rs
+++ b/hal-core/src/mem/page.rs
@@ -98,7 +98,7 @@ where
         &mut self,
         virt: Page<VAddr, S>,
         phys: Page<PAddr, S>,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> Handle<'_, S, Self::Entry>;
 
     fn flags_mut(&mut self, virt: Page<VAddr, S>) -> Handle<'_, S, Self::Entry>;
@@ -123,7 +123,7 @@ where
     fn identity_map(
         &mut self,
         phys: Page<PAddr, S>,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> Handle<'_, S, Self::Entry> {
         let base_paddr = phys.base_addr().as_usize();
         let virt = Page::containing(VAddr::from_usize(base_paddr), phys.size());
@@ -173,7 +173,7 @@ where
         virt: PageRange<VAddr, S>,
         phys: PageRange<PAddr, S>,
         mut set_flags: F,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> PageRange<VAddr, S>
     where
         F: FnMut(&mut Handle<'_, S, Self::Entry>),
@@ -257,7 +257,7 @@ where
         &mut self,
         phys: PageRange<PAddr, S>,
         set_flags: F,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> PageRange<VAddr, S>
     where
         F: FnMut(&mut Handle<'_, S, Self::Entry>),
@@ -285,7 +285,7 @@ where
         &mut self,
         virt: Page<VAddr, S>,
         phys: Page<PAddr, S>,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> Handle<'_, S, Self::Entry> {
         (*self).map_page(virt, phys, frame_alloc)
     }
@@ -304,7 +304,7 @@ where
     fn identity_map(
         &mut self,
         phys: Page<PAddr, S>,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> Handle<'_, S, Self::Entry> {
         (*self).identity_map(phys, frame_alloc)
     }

--- a/hal-x86_64/src/mm.rs
+++ b/hal-x86_64/src/mm.rs
@@ -148,7 +148,7 @@ where
         &mut self,
         virt: Page<VAddr, Size4Kb>,
         phys: Page<PAddr, Size4Kb>,
-        frame_alloc: &mut A,
+        frame_alloc: &A,
     ) -> page::Handle<'_, Size4Kb, Self::Entry> {
         // XXX(eliza): most of this fn is *internally* safe and should be
         // factored out into a safe function...
@@ -356,7 +356,7 @@ impl<R: level::Recursive> PageTable<R> {
     fn create_next_table<S: Size>(
         &mut self,
         idx: VirtPage<S>,
-        alloc: &mut impl page::Alloc<Size4Kb>,
+        alloc: &impl page::Alloc<Size4Kb>,
     ) -> &mut PageTable<R::Next> {
         let span = tracing::trace_span!("create_next_table", ?idx, self.level = %R::NAME, next.level = %<R::Next>::NAME);
         let _e = span.enter();
@@ -913,13 +913,13 @@ mycotest::decl_test! {
     fn basic_map() -> mycotest::TestResult {
         let mut ctrl = PageCtrl::current();
         // We shouldn't need to allocate page frames for this test.
-        let mut frame_alloc = page::EmptyAlloc::default();
+        let frame_alloc = page::EmptyAlloc::default();
 
         let frame = Page::containing_fixed(PAddr::from_usize(0xb8000));
         let page = Page::containing_fixed(VAddr::from_usize(0));
 
         let page = unsafe {
-            let mut flags = ctrl.map_page(page, frame, &mut frame_alloc);
+            let mut flags = ctrl.map_page(page, frame, &frame_alloc);
             flags.set_writable(true);
             flags.commit()
         };
@@ -939,10 +939,10 @@ mycotest::decl_test! {
         let mut ctrl = PageCtrl::current();
 
         // We shouldn't need to allocate page frames for this test.
-        let mut frame_alloc = page::EmptyAlloc::default();
+        let frame_alloc = page::EmptyAlloc::default();
         let actual_frame = Page::containing_fixed(PAddr::from_usize(0xb8000));
         unsafe {
-            let mut flags = ctrl.identity_map(actual_frame, &mut frame_alloc);
+            let mut flags = ctrl.identity_map(actual_frame, &frame_alloc);
             flags.set_writable(true);
             flags.commit()
         };


### PR DESCRIPTION
The `page::Alloc` trait's methods take an `&self` receiver, so page frames can be allocated with a shared reference (allocator impls typically perform internal synchronization). However, the `page::Map` trait's methods that require a page frame allocator take an `&mut` reference to the frame allocator. This is an artifact of an earlier version of the `page::Alloc` trait whose methods had a mutable `&mut self` receiver, but is no longer necessary.

This commit changes the `page::Map` trait to take a shared reference to the page-frame allocator when one is required.