### PR TITLE
feat(maitake): add local (`!Send`) scheduler types

### DIFF
--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -1648,6 +1648,7 @@ feature! {
         /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
+        #[cfg(not(loom))]
         pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
         where
             F: Future + Send +'static,
@@ -1686,6 +1687,7 @@ feature! {
         /// [run-loops]: crate::scheduler#executing-tasks
         #[inline]
         #[track_caller]
+        #[cfg(not(loom))]
         pub fn spawn_allocated<F>(&self, task: Box<Task<LocalScheduler, F, BoxStorage>>) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -679,7 +679,7 @@ impl LocalStaticScheduler {
 
     /// Spawn a pre-allocated, ![`Send`] task.
     ///
-    /// Unlike [`LocalStaticScheduler::spawn_local`], this method is capable of
+    /// Unlike [`StaticScheduler::spawn_allocated`], this method is capable of
     /// spawning [`Future`]s which do not implement [`Send`].
     ///
     /// This method is used to spawn a task that requires some bespoke
@@ -714,7 +714,7 @@ impl LocalStaticScheduler {
     /// Returns a new [task `Builder`] for configuring tasks prior to spawning
     /// them on this scheduler.
     ///
-    /// To spawn `!`[`Send`] tasks using a [`Builder`], use the
+    /// To spawn `!`[`Send`] tasks using a [`Builder`](task::Builder), use the
     /// [`Builder::spawn_local`](task::Builder::spawn_local) method.
     /// 
     /// [task `Builder`]: task::Builder

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -679,8 +679,8 @@ impl LocalStaticScheduler {
 
     /// Spawn a pre-allocated, ![`Send`] task.
     ///
-    /// Unlike [`StaticScheduler::spawn_local`], this method is capable of
-    /// spawning [`Future`s] which do not implement [`Send`].
+    /// Unlike [`LocalStaticScheduler::spawn_local`], this method is capable of
+    /// spawning [`Future`]s which do not implement [`Send`].
     ///
     /// This method is used to spawn a task that requires some bespoke
     /// procedure of allocation, typically of a custom [`Storage`] implementor.
@@ -714,6 +714,9 @@ impl LocalStaticScheduler {
     /// Returns a new [task `Builder`] for configuring tasks prior to spawning
     /// them on this scheduler.
     ///
+    /// To spawn `!`[`Send`] tasks using a [`Builder`], use the
+    /// [`Builder::spawn_local`](task::Builder::spawn_local) method.
+    /// 
     /// [task `Builder`]: task::Builder
     #[must_use]
     pub fn build_task<'a>(&'static self) -> task::Builder<'a, &'static Self> {
@@ -1383,7 +1386,7 @@ feature! {
         /// them on this scheduler.
         ///
         /// To spawn `!`[`Send`] tasks using a [`Builder`], use the
-        /// [`Builder::spawn_local`] method.
+        /// [`Builder::spawn_local`](task::Builder::spawn_local) method.
         ///
         /// # Examples
         ///

--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -956,10 +956,10 @@ feature! {
     #![feature = "alloc"]
 
     use crate::{
-        loom::sync::{Arc, Weak},
+        loom::sync::{Arc},
         task::{BoxStorage, Task},
     };
-    use alloc::boxed::Box;
+    use alloc::{sync::Weak, boxed::Box};
 
     /// An atomically reference-counted single-core scheduler implementation.
     ///
@@ -1571,6 +1571,7 @@ feature! {
         /// Returns a new [`LocalSpawner`] that can be used by other threads to
         /// spawn [`Send`] tasks on this scheduler.
         #[must_use = "the returned `LocalSpawner` does nothing unless used to spawn tasks"]
+        #[cfg(not(loom))] // Loom's `Arc` does not have a weak reference type...
         pub fn spawner(&self) -> LocalSpawner {
             LocalSpawner(Arc::downgrade(&self.core))
         }

--- a/maitake/src/task.rs
+++ b/maitake/src/task.rs
@@ -19,7 +19,7 @@ pub use core::task::{Context, Poll, Waker};
 
 mod builder;
 mod id;
-mod join_handle;
+pub(crate) mod join_handle;
 mod state;
 mod storage;
 


### PR DESCRIPTION
Currently, `maitake`'s scheduler types require tasks to be `Send`. This is because the scheduler itself is `Send` and `Sync`, and it may be ticked from more than one thread/CPU core. Ticking a scheduler which contains `!Send` tasks spawned from one thread on another thread is essentially equivalent to transferring ownership of those `!Send` tasks across threads, so a `Send + Sync` scheduler cannot execute `!Send` futures.

This branch introduces new `LocalScheduler` and `LocalStaticScheduler` types for executing `!Send` futures. Other than the fact that they can spawn futures which are not `Send`, and are themselves not `Send` or `Sync`, they are functionally the same as the existing `Scheduler` and `StaticScheduler` types. Additionally, in order to support other threads to spawn tasks which *are* `Send` on a local scheduler instance, new `LocalSpawner` and `LocalStaticSpawner` types can be created and shared across thread boundaries. These spawner types can *only* spawn `Send` tasks on the scheduler, and are not capable of ticking the scheduler. Therefore, they cannot accidentally access a `!Send` future.