### PR TITLE
feat(maitake): return next deadline from `Timer::advance`

### DIFF
--- a/maitake/src/time/timer/wheel.rs
+++ b/maitake/src/time/timer/wheel.rs
@@ -41,7 +41,7 @@ struct Wheel {
 
 #[derive(Debug)]
 struct Deadline {
-    ticks: Ticks,
+    pub(super) ticks: Ticks,
     slot: usize,
     wheel: usize,
 }
@@ -100,15 +100,19 @@ impl Core {
     }
 
     #[inline(never)]
-    pub(super) fn advance(&mut self, ticks: Ticks) -> usize {
+    pub(super) fn advance(&mut self, ticks: Ticks) -> (usize, Option<Deadline>) {
         let now = self.now + ticks;
         let mut fired = 0;
+
         // sleeps that need to be rescheduled on lower-level wheels need to be
         // processed after we have finished turning the wheel, to avoid looping
         // infinitely.
-
         let mut pending_reschedule = List::<sleep::Entry>::new();
-        while let Some(deadline) = self.next_deadline() {
+
+        // we will stop looping if the next deadline is after `now`, but we
+        // still need to be able to return it.
+        let mut next_deadline = self.next_deadline();
+        while let Some(deadline) = next_deadline {
             if deadline.ticks > now {
                 break;
             }
@@ -147,6 +151,8 @@ impl Core {
 
             self.now = deadline.ticks;
             fired += fired_this_turn;
+
+            next_deadline = self.next_deadline();
         }
 
         self.now = now;
@@ -156,6 +162,7 @@ impl Core {
             now = self.now,
             fired,
             rescheduled = pending_reschedule.len(),
+            ?next_deadline,
             "wheel turned to"
         );
         for entry in pending_reschedule {
@@ -164,7 +171,7 @@ impl Core {
             self.insert_sleep_at(deadline, entry)
         }
 
-        fired
+        (fired, next_deadline)
     }
 
     pub(super) fn cancel_sleep(&mut self, sleep: Pin<&mut sleep::Entry>) {


### PR DESCRIPTION
On hardware platforms with a variable-duration one-shot timer interrupt, the timer interrupt can be configured to fire at the next deadline on the timer wheel, rather than at a fixed interval. This is more efficient than advancing the wheel every time a periodic timer fires, as in many cases, most of those interrupts may not correspond to the deadline of any pending timer. It also permits more precise timing, as a periodic timer interval may "overshoot" the deadline of a particular sleep future. Currently, the `maitake::time::Timer` API doesn't expose the deadline of the next firing timer, though, so it's not currently possible to implement this pattern.

This branch changes the `Timer::advance`, `Timer::advance_ticks`, `Timer::force_advance`, and `Timer::force_advance_ticks` methods to return a `Turn` structure, which described what occurred while advancing the timer. This is very similar to the `Tick` structure returned by `Scheduler::tick`. Among other data, the `Turn` struct contains the time until the next expiring deadline. This can be used to configure the hardware timer in oneshot mode.

We could probably also add a method on `Timer` to just return the next deadline without advancing the wheel. However, this would currently require acquiring the lock. Since advancing the timer already requires locking the wheel, and we will generally care about the next deadline when we have just advanced the wheel, it seems more efficient to return it from `advance` (and friends), without re-locking.

Closes #440