### PR TITLE
feat(maitake): add `WaitCell::subscribe` and `poll_wait`

### DIFF
--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -134,7 +134,7 @@ impl WaitCell {
                 Err(actual) if test_dbg!(actual.is(State::CLOSED)) => {
                     return Err(RegisterError::Closed);
                 }
-                Err(actual) if actual == State::WOKEN => {
+                Err(actual) if actual.is(State::WOKEN) => {
                     cur = actual;
                 }
 
@@ -260,7 +260,7 @@ impl WaitCell {
         if close {
             bits.0 |= State::CLOSED.0;
         }
-        if test_dbg!(self.fetch_or(bits, AcqRel)) == State::WAITING {
+        if test_dbg!(self.fetch_or(bits, AcqRel)).is(State::WAITING) {
             // we have the lock!
             let waker = self.waker.with_mut(|thread| unsafe { (*thread).take() });
 
@@ -386,11 +386,11 @@ impl<'cell> Future for Subscribe<'cell> {
 // === impl State ===
 
 impl State {
-    const WAITING: Self = Self(0b00);
-    const REGISTERING: Self = Self(0b01);
-    const WAKING: Self = Self(0b10);
-    const CLOSED: Self = Self(0b100);
-    const WOKEN: Self = Self(0b1000);
+    const WAITING: Self = Self(1 << 1);
+    const REGISTERING: Self = Self(1 << 2);
+    const WAKING: Self = Self(1 << 3);
+    const CLOSED: Self = Self(1 << 4);
+    const WOKEN: Self = Self(1 << 5);
 
     fn is(self, Self(state): Self) -> bool {
         self.0 & state == state

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -359,8 +359,8 @@ impl<'cell> Future for Subscribe<'cell> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let already_closed = loop {
             match test_dbg!(self.cell.register_wait(cx.waker())) {
-                Ok(_) => break true,
-                Err(RegisterError::Closed) => break false,
+                Ok(_) => break false,
+                Err(RegisterError::Closed) => break true,
                 _ => {}
             }
         };

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -465,11 +465,11 @@ impl<'cell> Future for Subscribe<'cell> {
 // === impl State ===
 
 impl State {
-    const WAITING: Self = Self(1 << 0);
-    const REGISTERING: Self = Self(1 << 1);
-    const WAKING: Self = Self(1 << 2);
-    const WOKEN: Self = Self(1 << 3);
-    const CLOSED: Self = Self(1 << 4);
+    const WAITING: Self = Self(0b0000);
+    const REGISTERING: Self = Self(0b0001);
+    const WAKING: Self = Self(0b0010);
+    const WOKEN: Self = Self(0b0100);
+    const CLOSED: Self = Self(0b1000);
 
     fn contains(self, Self(state): Self) -> bool {
         self.0 & state > 0

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -118,7 +118,7 @@ impl WaitCell {
     ///   [`wake`] while the [`Waker`] was being registered.
     /// - [`Poll::Ready`]`(`[`Err`](`[`Error::Closed`]`))` if the [`WaitCell`]
     ///   has been closed.
-    /// - [`Poll::Ready`]`(`[`Err`](`[`Error::Busy`]`)`) if another task wasre
+    /// - [`Poll::Ready`]`(`[`Err`](`[`Error::Busy`]`)`) if another task was
     ///   concurrently registering its [`Waker`] with this [`WaitCell`].
     ///
     /// [`wake`]: Self::wake

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -116,9 +116,9 @@ impl WaitCell {
     ///   subsequent call to [`wake`].
     /// - [`Poll::Ready`]`(`[`Ok`]`(()))` if the cell was woken by a call to
     ///   [`wake`] while the [`Waker`] was being registered.
-    /// - [`Poll::Ready`]`(`[`Err`](`[`Error::Closed`]`))` if the [`WaitCell`]
+    /// - [`Poll::Ready`]`(`[`Err`]`(`[`Error::Closed`]`))` if the [`WaitCell`]
     ///   has been closed.
-    /// - [`Poll::Ready`]`(`[`Err`](`[`Error::Busy`]`))` if another task was
+    /// - [`Poll::Ready`]`(`[`Err`]`(`[`Error::Busy`]`))` if another task was
     ///   concurrently registering its [`Waker`] with this [`WaitCell`].
     ///
     /// [`wake`]: Self::wake

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -116,10 +116,11 @@ impl WaitCell {
     ///   subsequent call to [`wake`].
     /// - [`Poll::Ready`]`(`[`Ok`]`(()))` if the cell was woken by a call to
     ///   [`wake`] while the [`Waker`] was being registered.
-    /// - [`Poll::Ready`]`(`[`Err`]`(`[`Error::Closed`]`))` if the [`WaitCell`]
-    ///   has been closed.
-    /// - [`Poll::Ready`]`(`[`Err`]`(`[`Error::Busy`]`))` if another task was
-    ///   concurrently registering its [`Waker`] with this [`WaitCell`].
+    /// - [`Poll::Ready`]`(`[`Err`]`(`[`PollWaitError::Closed`]`))` if the
+    ///   [`WaitCell`] has been closed.
+    /// - [`Poll::Ready`]`(`[`Err`]`(`[`PollWaitError::Busy`]`))` if another
+    ///   task was concurrently registering its [`Waker`] with this
+    ///   [`WaitCell`].
     ///
     /// [`wake`]: Self::wake
     pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<Result<(), PollWaitError>> {

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -197,7 +197,7 @@ impl WaitCell {
     pub fn wait(&self) -> Wait<'_> {
         Wait {
             cell: self,
-            already_closed: false,
+            presubscribe: Poll::Pending,
         }
     }
 

--- a/maitake/src/sync/wait_cell.rs
+++ b/maitake/src/sync/wait_cell.rs
@@ -324,6 +324,10 @@ impl Future for Wait<'_> {
     type Output = Result<(), super::Closed>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.already_closed {
+            return super::closed();
+        }
+
         // Try to take the cell's `WOKEN` bit to see if we were previously
         // waiting and then received a notification.
         if test_dbg!(self.cell.fetch_and(!State::WOKEN, AcqRel)).is(State::WOKEN) {

--- a/maitake/src/sync/wait_queue.rs
+++ b/maitake/src/sync/wait_queue.rs
@@ -26,7 +26,7 @@ use core::{
     task::{Context, Poll, Waker},
 };
 use mycelium_bitfield::{bitfield, enum_from_bits, FromBits};
-#[cfg(test)]
+#[cfg(any(test, maitake_ultraverbose))]
 use mycelium_util::fmt;
 use mycelium_util::sync::CachePadded;
 use pin_project::{pin_project, pinned_drop};

--- a/maitake/src/trace.rs
+++ b/maitake/src/trace.rs
@@ -101,6 +101,18 @@ macro_rules! test_dbg {
 }
 
 #[cfg(all(not(test), not(maitake_ultraverbose)))]
+macro_rules! enter_test_debug_span {
+    ($($args:tt)+) => {};
+}
+
+#[cfg(any(test, maitake_ultraverbose))]
+macro_rules! enter_test_debug_span {
+    ($($args:tt)+) => {
+        let _span = debug_span!($($args)+).entered();
+    };
+}
+
+#[cfg(all(not(test), not(maitake_ultraverbose)))]
 macro_rules! test_debug {
     ($($args:tt)+) => {};
 }

--- a/maitake/src/trace.rs
+++ b/maitake/src/trace.rs
@@ -76,14 +76,14 @@ macro_rules! debug_span {
     };
 }
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(maitake_ultraverbose)))]
 macro_rules! test_dbg {
     ($e:expr) => {
         $e
     };
 }
 
-#[cfg(test)]
+#[cfg(any(test, maitake_ultraverbose))]
 macro_rules! test_dbg {
     ($e:expr) => {
         match $e {
@@ -100,24 +100,24 @@ macro_rules! test_dbg {
     };
 }
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(maitake_ultraverbose)))]
 macro_rules! test_debug {
     ($($args:tt)+) => {};
 }
 
-#[cfg(test)]
+#[cfg(any(test, maitake_ultraverbose))]
 macro_rules! test_debug {
     ($($args:tt)+) => {
         debug!($($args)+);
     };
 }
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(maitake_ultraverbose)))]
 macro_rules! test_trace {
     ($($args:tt)+) => {};
 }
 
-#[cfg(test)]
+#[cfg(any(test, maitake_ultraverbose))]
 macro_rules! test_trace {
     ($($args:tt)+) => {
         trace!($($args)+);

--- a/maitake/src/util.rs
+++ b/maitake/src/util.rs
@@ -6,7 +6,7 @@ pub(crate) use self::wake_batch::WakeBatch;
 macro_rules! fmt_bits {
     ($self: expr, $f: expr, $has_states: ident, $($name: ident),+) => {
         $(
-            if $self.is(Self::$name) {
+            if $self.contains(Self::$name) {
                 if $has_states {
                     $f.write_str(" | ")?;
                 }


### PR DESCRIPTION
This branch rewrites the `maitake::sync::WaitCell` type a bit to fix
potential lost wakeups accidentally introduced in #453. In addition, it
changes the API a bit:
- Replace `register_wait` with `poll_wait`, which I think is a bit
  nicer,
- Removed the `RegisterError::Waking` variant since `poll_wait` returns
  `Ready` if the cell was woken, and renamed `RegisterError` to just
  `Error`,
- Introduced a `WaitCell::subscribe` method to eagerly pre-register the
  task's `Waker` in the `WaitCell`. This is intended to be used to
  register the task to be woken *before* performing an operation that
  results in a wakeup, such as enabling an interrupt that will wake the
  task.

Closes #455 