### PR TITLE
feat(maitake): dequeue one task at a time in scheduler

### DIFF
--- a/maitake/src/scheduler.rs
+++ b/maitake/src/scheduler.rs
@@ -623,7 +623,7 @@ impl StaticScheduler {
     ///
     /// Only a single CPU core/thread may tick a given scheduler at a time. If
     /// another call to `tick` is in progress on a different core, this method
-    /// will wait until that call to `tick` completes before ticking the scheduler.
+    /// will immediately return.
     ///
     /// See [the module-level documentation][run-loops] for more information on
     /// using this function to implement a system's run loop.
@@ -746,7 +746,7 @@ impl LocalStaticScheduler {
     ///
     /// Only a single CPU core/thread may tick a given scheduler at a time. If
     /// another call to `tick` is in progress on a different core, this method
-    /// will wait until that call to `tick` completes before ticking the scheduler.
+    /// will immediately return.
     ///
     /// See [the module-level documentation][run-loops] for more information on
     /// using this function to implement a system's run loop.
@@ -1224,8 +1224,7 @@ feature! {
         ///
         /// Only a single CPU core/thread may tick a given scheduler at a time. If
         /// another call to `tick` is in progress on a different core, this method
-        /// will wait until that call to `tick` completes before ticking the
-        /// scheduler.
+        /// will immediately return.
         ///
         /// See [the module-level documentation][run-loops] for more information on
         /// using this function to implement a system's run loop.
@@ -1568,8 +1567,7 @@ feature! {
         ///
         /// Only a single CPU core/thread may tick a given scheduler at a time. If
         /// another call to `tick` is in progress on a different core, this method
-        /// will wait until that call to `tick` completes before ticking the
-        /// scheduler.
+        /// will immediately return.
         ///
         /// See [the module-level documentation][run-loops] for more information on
         /// using this function to implement a system's run loop.

--- a/maitake/tests/scheduler/alloc.rs
+++ b/maitake/tests/scheduler/alloc.rs
@@ -1,5 +1,5 @@
 use super::*;
-use mycelium_util::sync::Lazy;
+use mycelium_util::sync::{Lazy, spin::Mutex};
 
 #[test]
 fn basically_works() {
@@ -65,4 +65,51 @@ fn many_yields() {
     assert_eq!(tick.completed, TASKS);
     assert_eq!(COMPLETED.load(Ordering::SeqCst), TASKS);
     assert!(!tick.has_remaining);
+}
+
+#[test]
+fn steal_blocked() {
+    static SCHEDULER_1: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
+    static SCHEDULER_2: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
+    static MUTEX: Mutex<()> = Mutex::new(());
+    static READY: AtomicBool = AtomicBool::new(false);
+    static IT_WORKED: AtomicBool = AtomicBool::new(false);
+
+    util::trace_init();
+
+    let guard = MUTEX.lock();
+
+    let thread = std::thread::spawn(|| {
+        SCHEDULER_1.spawn(async {
+            READY.store(true, Ordering::Release);
+
+            // block this thread
+            let _guard = MUTEX.lock();
+        });
+
+        SCHEDULER_1.spawn(async {
+            IT_WORKED.store(true, Ordering::Release);
+        });
+
+        SCHEDULER_1.tick()
+    });
+
+    while !READY.load(Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
+
+    assert!(SCHEDULER_1.current_task().is_some());
+
+    let stolen = SCHEDULER_1.try_steal().unwrap().spawn_n(&SCHEDULER_2.get(), 1);
+    assert_eq!(stolen, 1);
+
+    let tick = SCHEDULER_2.tick();
+    assert!(IT_WORKED.load(Ordering::Acquire));
+    assert_eq!(tick.polled, 1);
+    assert_eq!(tick.completed, 1);
+
+    drop(guard);
+    let tick = thread.join().unwrap();
+    assert_eq!(tick.polled, 1);
+    assert_eq!(tick.completed, 1);
 }

--- a/maitake/tests/scheduler/main.rs
+++ b/maitake/tests/scheduler/main.rs
@@ -1,5 +1,6 @@
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use maitake::{future, scheduler::*};
+use mycelium_util::sync::{Lazy, spin::Mutex};
 
 #[path = "../util.rs"]
 mod util;
@@ -7,3 +8,50 @@ mod util;
 #[cfg(feature = "alloc")]
 mod alloc;
 mod custom_storage;
+
+#[test]
+fn steal_blocked() {
+    static SCHEDULER_1: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
+    static SCHEDULER_2: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
+    static MUTEX: Mutex<()> = Mutex::new(());
+    static READY: AtomicBool = AtomicBool::new(false);
+    static IT_WORKED: AtomicBool = AtomicBool::new(false);
+
+    util::trace_init();
+
+    let guard = MUTEX.lock();
+
+    let thread = std::thread::spawn(|| {
+        SCHEDULER_1.spawn(async {
+            READY.store(true, Ordering::Release);
+
+            // block this thread
+            let _guard = MUTEX.lock();
+        });
+
+        SCHEDULER_1.spawn(async {
+            IT_WORKED.store(true, Ordering::Release);
+        });
+
+        SCHEDULER_1.tick()
+    });
+
+    while !READY.load(Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
+
+    assert!(SCHEDULER_1.current_task().is_some());
+
+    let stolen = SCHEDULER_1.try_steal().unwrap().spawn_n(&SCHEDULER_2.get(), 1);
+    assert_eq!(stolen, 1);
+
+    let tick = SCHEDULER_2.tick();
+    assert!(IT_WORKED.load(Ordering::Acquire));
+    assert_eq!(tick.polled, 1);
+    assert_eq!(tick.completed, 1);
+
+    drop(guard);
+    let tick = thread.join().unwrap();
+    assert_eq!(tick.polled, 1);
+    assert_eq!(tick.completed, 1);
+}

--- a/maitake/tests/scheduler/main.rs
+++ b/maitake/tests/scheduler/main.rs
@@ -1,6 +1,5 @@
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use maitake::{future, scheduler::*};
-use mycelium_util::sync::{Lazy, spin::Mutex};
 
 #[path = "../util.rs"]
 mod util;
@@ -8,50 +7,3 @@ mod util;
 #[cfg(feature = "alloc")]
 mod alloc;
 mod custom_storage;
-
-#[test]
-fn steal_blocked() {
-    static SCHEDULER_1: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
-    static SCHEDULER_2: Lazy<StaticScheduler> = Lazy::new(StaticScheduler::new);
-    static MUTEX: Mutex<()> = Mutex::new(());
-    static READY: AtomicBool = AtomicBool::new(false);
-    static IT_WORKED: AtomicBool = AtomicBool::new(false);
-
-    util::trace_init();
-
-    let guard = MUTEX.lock();
-
-    let thread = std::thread::spawn(|| {
-        SCHEDULER_1.spawn(async {
-            READY.store(true, Ordering::Release);
-
-            // block this thread
-            let _guard = MUTEX.lock();
-        });
-
-        SCHEDULER_1.spawn(async {
-            IT_WORKED.store(true, Ordering::Release);
-        });
-
-        SCHEDULER_1.tick()
-    });
-
-    while !READY.load(Ordering::Acquire) {
-        core::hint::spin_loop();
-    }
-
-    assert!(SCHEDULER_1.current_task().is_some());
-
-    let stolen = SCHEDULER_1.try_steal().unwrap().spawn_n(&SCHEDULER_2.get(), 1);
-    assert_eq!(stolen, 1);
-
-    let tick = SCHEDULER_2.tick();
-    assert!(IT_WORKED.load(Ordering::Acquire));
-    assert_eq!(tick.polled, 1);
-    assert_eq!(tick.completed, 1);
-
-    drop(guard);
-    let tick = thread.join().unwrap();
-    assert_eq!(tick.polled, 1);
-    assert_eq!(tick.completed, 1);
-}


### PR DESCRIPTION
In order to allow stealing tasks from blocked cores, don't hold a Consumer for `run_queue` while polling.

I think as-is, this changes the documented behavior:

> Only a single CPU core/thread may tick a given scheduler at a time. If another call to tick is in progress on a different core, this method will wait until that call to tick completes before ticking the scheduler.

and allows interleaving calls to `tick`. Is this a property worth maintaining? I think a lock could be introduced to do so if necessary.