### PR TITLE
docs: hobby project disclaimer for published libs

### DIFF
--- a/bitfield/README.md
+++ b/bitfield/README.md
@@ -35,6 +35,20 @@ This crate was originally implemented for usage in the [Mycelium operating
 system][Mycelium], although it is usable in other projects and does not depend
 on any Mycelium-specific libraries.
 
+> **Note**
+>
+> This is a hobby project. I'm working on it in my spare time, for my own
+> personal use. I'm very happy to share it with the broader Rust community, and
+> [contributions] and [bug reports] are always welcome. However, please remember
+> that I'm working on this library _for fun_, and if it stops being fun...well,
+> you get the idea.
+>
+> Anyway, feel free to use and enjoy this crate, and to contribute back as much
+> as you want to!
+
+[contributions]: https://github.com/hawkw/mycelium/compare
+[bug reports]: https://github.com/hawkw/mycelium/issues/new
+
 ## comparison with other crates
 
 There are several other crates implementing bitfields or bitfield-related

--- a/cordyceps/README.md
+++ b/cordyceps/README.md
@@ -30,6 +30,20 @@ implemented for the [Mycelium] operating system. Currently, it provides an
 [intrusive doubly-linked list][list] and an [intrusive, lock-free MPSC
 queue][queue].
 
+> **Note**
+>
+> This is a hobby project. I'm working on it in my spare time, for my own
+> personal use. I'm very happy to share it with the broader Rust community, and
+> [contributions] and [bug reports] are always welcome. However, please remember
+> that I'm working on this library _for fun_, and if it stops being fun...well,
+> you get the idea.
+>
+> Anyway, feel free to use and enjoy this crate, and to contribute back as much
+> as you want to!
+
+[contributions]: https://github.com/hawkw/mycelium/compare
+[bug reports]: https://github.com/hawkw/mycelium/issues/new
+
 ## intrusive data structures
 
 [Intrusive data structures][intrusive] are node-based data structures where the

--- a/maitake/README.md
+++ b/maitake/README.md
@@ -43,6 +43,20 @@ I/O resources, to produce a complete, application-specific async runtime.
 `maitake` was initially designed for use in the [mycelium] and [mnemOS]
 operating systems, but may be useful for other projects as well.
 
+> **Note**
+>
+> This is a hobby project. I'm working on it in my spare time, for my own
+> personal use. I'm very happy to share it with the broader Rust community, and
+> [contributions] and [bug reports] are always welcome. However, please remember
+> that I'm working on this library _for fun_, and if it stops being fun...well,
+> you get the idea.
+>
+> Anyway, feel free to use and enjoy this crate, and to contribute back as much
+> as you want to!
+
+[contributions]: https://github.com/hawkw/mycelium/compare
+[bug reports]: https://github.com/hawkw/mycelium/issues/new
+
 [`core::task`]: https://doc.rust-lang.org/stable/core/task/index.html
 [`core::future`]: https://doc.rust-lang.org/stable/core/future/index.html
 [task]: https://mycelium.elizas.website/maitake/task/index.html
@@ -50,7 +64,8 @@ operating systems, but may be useful for other projects as well.
 [timer]: https://mycelium.elizas.website/maitake/time/struct.Timer.html
 [sync]: https://mycelium.elizas.website/maitake/sync/index.html
 [mycelium]: https://github.com/hawkw/mycelium
-[mnemOS]: https://mnemos.jamesmunns.com
+[mnemOS]: https://mnemos.dev
+
 ## a tour of `maitake`
 
 `maitake` currently provides the following major API components:


### PR DESCRIPTION
This adds a disclaimer to the READMEs of all published crates in the
repo, stating that they are hobby projects I'm working on for fun. This
is intended to communicate the level of support and maintainance that
other users of these crates can reasonably expect.