### PR TITLE
Address lint ambiguous_wide_pointer_comparisons

### DIFF
--- a/cordyceps/Cargo.toml
+++ b/cordyceps/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://mycelium.elizas.website"
 readme = "README.md"
 keywords = ["intrusive", "no_std", "list", "queue", "lock-free"]
 categories = ["data-structures", "no-std"]
-rust-version = "1.61.0"
+rust-version = "1.76.0"
 
 [features]
 default = []

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -494,7 +494,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
         let tail_links = unsafe { T::links(tail) };
         let head_links = unsafe { head_links.as_ref() };
         let tail_links = unsafe { tail_links.as_ref() };
-        if head == tail {
+        if core::ptr::addr_eq(head.as_ptr(), tail.as_ptr()) {
             assert_eq!(
                 head_links, tail_links,
                 "{name}if the head and tail nodes are the same, their links must be the same"
@@ -963,7 +963,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
         let start_links = T::links(splice_start).as_mut();
         let end_links = T::links(splice_end).as_mut();
         debug_assert!(
-            splice_start == splice_end
+            core::ptr::addr_eq(splice_start.as_ptr(), splice_end.as_ptr())
                 || (start_links.next().is_some() && end_links.prev().is_some()),
             "splice_start must be ahead of splice_end!\n   \
             splice_start: {splice_start:?}\n    \

--- a/maitake-sync/Cargo.toml
+++ b/maitake-sync/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
     "concurrency"
 ]
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.76.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/maitake/Cargo.toml
+++ b/maitake/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
     "async",
 ]
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.76.0"
 
 # NOTE! As a workaround for https://github.com/rust-lang/rust/issues/97708,
 # maitake uses some `no_mangle` functions. This will cause linker errors if

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mycelium-util"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@elizas.website>"]
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.76.0"
 readme = "README.md"
 
 # See more keys and their definitions at


### PR DESCRIPTION
Noticed this warning:

```
warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> /Users/james/personal/mycelium/cordyceps/src/list.rs:497:12
    |
497 |         if head == tail {
    |            ^^^^^^^^^^^^
    |
    = note: `#[warn(ambiguous_wide_pointer_comparisons)]` on by default
help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
497 |         if std::ptr::addr_eq(head.as_ptr(), tail.as_ptr()) {
    |            ++++++++++++++++++    ~~~~~~~~~~     ++++++++++
help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
497 |         if std::ptr::eq(head.as_ptr(), tail.as_ptr()) {
    |            +++++++++++++    ~~~~~~~~~~     ++++++++++

warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> /Users/james/personal/mycelium/cordyceps/src/list.rs:966:13
    |
966 |             splice_start == splice_end
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
966 |             std::ptr::addr_eq(splice_start.as_ptr(), splice_end.as_ptr())
    |             ++++++++++++++++++            ~~~~~~~~~~           ++++++++++
help: use explicit `std::ptr::eq` method to compare metadata and addresses
    |
966 |             std::ptr::eq(splice_start.as_ptr(), splice_end.as_ptr())
    |             +++++++++++++            ~~~~~~~~~~           ++++++++++
    ```