### PR TITLE
feat(maitake-sync): rename `EnqueueWait` to `Subscribe`

### DIFF
--- a/maitake-sync/src/wait_map/tests/alloc_tests.rs
+++ b/maitake-sync/src/wait_map/tests/alloc_tests.rs
@@ -34,7 +34,7 @@ fn enqueue() {
             let wait = q.wait(1);
 
             pin_mut!(wait);
-            wait.as_mut().enqueue().await.unwrap();
+            wait.as_mut().subscribe().await.unwrap();
             ENQUEUED.fetch_add(1, Ordering::Relaxed);
 
             let val = wait.await.unwrap();
@@ -81,7 +81,7 @@ fn duplicate() {
             let wait = q.wait(0);
 
             pin_mut!(wait);
-            wait.as_mut().enqueue().await.unwrap();
+            wait.as_mut().subscribe().await.unwrap();
             ENQUEUED.fetch_add(1, Ordering::Relaxed);
 
             let val = wait.await.unwrap();
@@ -98,7 +98,7 @@ fn duplicate() {
             let wait = q.wait(0);
 
             pin_mut!(wait);
-            wait.as_mut().enqueue().await
+            wait.as_mut().subscribe().await
         }
     });
 


### PR DESCRIPTION
`maitake-sync`'s `waitmap::Wait` future has an `enqueue` method that
does the same thing as the `subscribe` methods on `WaitCell` and
`WaitQueue`...but has a different name. I think this might be due to
`enqueue` being added earlier or something, or maybe we just weren't
paying attention. Regardless, I figured it was nicer to use the same
name for the method that does the same thing on these different types.

This commit renames the `waitmap::Wait::enqueue` method to `subscribe`,
and the future it returns from `EnqueueWait` to `Subscribe`, analogously
to `WaitQueue` and `WaitCell`. I've left a deprecated type alias and a
deprecated function alias in place, so this isn't a breaking change:
users who reference `Wait::enqueue` or `EnqueueWait` will still be able
to compile their code, but they'll get a warning.

cc @jamesmunns, since I believe you added this API?