### PR TITLE
docs: link to changelogs in published crate READMEs

### DIFF
--- a/bitfield/README.md
+++ b/bitfield/README.md
@@ -3,6 +3,7 @@
 🍄 bitfield utilities, courtesy of [Mycelium].
 
 [![crates.io][crates-badge]][crates-url]
+[![Changelog][changelog-badge]][changelog-url]
 [![Documentation][docs-badge]][docs-url]
 [![Documentation (HEAD)][docs-main-badge]][docs-main-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -11,6 +12,9 @@
 
 [crates-badge]: https://img.shields.io/crates/v/mycelium-bitfield.svg
 [crates-url]: https://crates.io/crates/mycelium-bitfield
+[changelog-badge]:
+    https://img.shields.io/crates/v/mycelium-bitfield?label=changelog&color=blue
+[changelog-url]: https://github.com/hawkw/mycelium/blob/main/mycelium-bitfield/CHANGELOG.md
 [docs-badge]: https://docs.rs/mycelium-bitfield/badge.svg
 [docs-url]: https://docs.rs/mycelium-bitfield
 [docs-main-badge]: https://img.shields.io/netlify/3ec00bb5-251a-4f83-ac7f-3799d95db0e6?label=docs%20%28main%20branch%29

--- a/cordyceps/README.md
+++ b/cordyceps/README.md
@@ -3,6 +3,7 @@
 🍄 the [Mycelium] intrusive data structures library.
 
 [![crates.io][crates-badge]][crates-url]
+[![Changelog][changelog-badge]][changelog-url]
 [![Documentation][docs-badge]][docs-url]
 [![Documentation (HEAD)][docs-main-badge]][docs-main-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -11,6 +12,9 @@
 
 [crates-badge]: https://img.shields.io/crates/v/cordyceps.svg
 [crates-url]: https://crates.io/crates/cordyceps
+[changelog-badge]:
+    https://img.shields.io/crates/v/cordyceps?label=changelog&color=blue
+[changelog-url]: https://github.com/hawkw/mycelium/blob/main/cordyceps/CHANGELOG.md
 [docs-badge]: https://docs.rs/cordyceps/badge.svg
 [docs-url]: https://docs.rs/cordyceps
 [docs-main-badge]: https://img.shields.io/netlify/3ec00bb5-251a-4f83-ac7f-3799d95db0e6?label=docs%20%28main%20branch%29

--- a/maitake-sync/README.md
+++ b/maitake-sync/README.md
@@ -4,6 +4,7 @@
 primitives from [`maitake`]
 
 [![crates.io][crates-badge]][crates-url]
+[![Changelog][changelog-badge]][changelog-url]
 [![Documentation][docs-badge]][docs-url]
 [![Documentation (HEAD)][docs-main-badge]][docs-main-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -11,7 +12,10 @@ primitives from [`maitake`]
 [![Sponsor @hawkw on GitHub Sponsors][sponsor-badge]][sponsor-url]
 
 [crates-badge]: https://img.shields.io/crates/v/maitake-sync.svg
-[crates-url]: https://crates.io/crates/maitake-sync-sync
+[crates-url]: https://crates.io/crates/maitake-sync
+[changelog-badge]:
+    https://img.shields.io/crates/v/maitake-sync?label=changelog&color=blue
+[changelog-url]: https://github.com/hawkw/mycelium/blob/main/maitake-sync/CHANGELOG.md
 [docs-badge]: https://docs.rs/maitake-sync/badge.svg
 [docs-url]: https://docs.rs/maitake-sync
 [docs-main-badge]: https://img.shields.io/netlify/3ec00bb5-251a-4f83-ac7f-3799d95db0e6?label=docs%20%28main%20branch%29


### PR DESCRIPTION
This just seemed kinda nice to add.