### PR TITLE
feat(x86_64): real abstraction for ISA IRQs, unfuck I/O APIC

### DIFF
--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -137,7 +137,7 @@ pub enum MaskError {
 
 /// ISA interrupt vectors
 ///
-/// See: https://wiki.osdev.org/Interrupts#General_IBM-PC_Compatible_Interrupt_Information
+/// See: [the other wiki](https://wiki.osdev.org/Interrupts#General_IBM-PC_Compatible_Interrupt_Information)
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum IsaInterrupt {

--- a/hal-x86_64/src/interrupt.rs
+++ b/hal-x86_64/src/interrupt.rs
@@ -1,4 +1,4 @@
-use crate::{cpu, mm, segment, time, PAddr, VAddr};
+use crate::{cpu, mm, segment, time, VAddr};
 use core::{arch::asm, marker::PhantomData, time::Duration};
 use hal_core::interrupt::Control;
 use hal_core::interrupt::{ctx, Handlers};
@@ -15,7 +15,7 @@ pub mod apic;
 pub mod idt;
 pub mod pic;
 
-use self::apic::{IoApic, LocalApic};
+use self::apic::{IoApicSet, LocalApic};
 pub use idt::Idt;
 pub use pic::CascadedPic;
 
@@ -69,10 +69,7 @@ enum InterruptModel {
     /// [apics]: apic
     Apic {
         local: apic::LocalApic,
-        // TODO(eliza): allow further configuration of the I/O APIC (e.g.
-        // masking/unmasking stuff...)
-        #[allow(dead_code)]
-        io: Mutex<apic::IoApic, Spinlock>,
+        io: apic::IoApicSet,
     },
 }
 
@@ -134,6 +131,67 @@ pub struct Registers {
 static IDT: Mutex<idt::Idt, Spinlock> = Mutex::new_with_raw_mutex(idt::Idt::new(), Spinlock::new());
 static INTERRUPT_CONTROLLER: InitOnce<Controller> = InitOnce::uninitialized();
 
+pub enum MaskError {
+    NotHwIrq,
+}
+
+/// ISA interrupt vectors
+///
+/// See: https://wiki.osdev.org/Interrupts#General_IBM-PC_Compatible_Interrupt_Information
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub enum IsaInterrupt {
+    /// Programmable Interval Timer (PIT) timer interrupt.
+    PitTimer = 0,
+    /// PS/2 keyboard controller interrupt.
+    Ps2Keyboard = 1,
+    // IRQ 2 is reserved for the PIC cascade interrupt and isn't user accessible!
+    /// COM2 / COM4 serial port interrupt.
+    Com2 = 3,
+    /// COM1 / COM3 serial port interrupt.
+    Com1 = 4,
+    /// LPT2 parallel port interrupt.
+    Lpt2 = 5,
+    /// Floppy disk
+    Floppy = 6,
+    /// LPT1 parallel port interrupt, or spurious.
+    Lpt1 = 7,
+    /// CMOS real-time clock.
+    CmosRtc = 8,
+    /// Free for peripherals/SCSI/NIC
+    Periph1 = 9,
+    Periph2 = 10,
+    Periph3 = 11,
+    /// PS/2 Mouse
+    Ps2Mouse = 12,
+    /// FPU
+    Fpu = 13,
+    /// Primary ATA hard disk
+    AtaPrimary = 14,
+    /// Secondary ATA hard disk
+    AtaSecondary = 15,
+}
+
+impl IsaInterrupt {
+    pub const ALL: [IsaInterrupt; 15] = [
+        IsaInterrupt::PitTimer,
+        IsaInterrupt::Ps2Keyboard,
+        IsaInterrupt::Com2,
+        IsaInterrupt::Com1,
+        IsaInterrupt::Lpt2,
+        IsaInterrupt::Floppy,
+        IsaInterrupt::Lpt1,
+        IsaInterrupt::CmosRtc,
+        IsaInterrupt::Periph1,
+        IsaInterrupt::Periph2,
+        IsaInterrupt::Periph3,
+        IsaInterrupt::Ps2Mouse,
+        IsaInterrupt::Fpu,
+        IsaInterrupt::AtaPrimary,
+        IsaInterrupt::AtaSecondary,
+    ];
+}
+
 impl Controller {
     // const DEFAULT_IOAPIC_BASE_PADDR: u64 = 0xFEC00000;
 
@@ -149,6 +207,31 @@ impl Controller {
         idt.register_handlers::<H>().unwrap();
         unsafe {
             idt.load_raw();
+        }
+    }
+
+    pub fn mask_isa_irq(&self, irq: IsaInterrupt) {
+        match self.model {
+            InterruptModel::Pic(ref pics) => pics.lock().mask(irq),
+            InterruptModel::Apic { ref io, .. } => io.set_isa_masked(irq, true),
+        }
+    }
+
+    pub fn unmask_isa_irq(&self, irq: IsaInterrupt) {
+        match self.model {
+            InterruptModel::Pic(ref pics) => pics.lock().unmask(irq),
+            InterruptModel::Apic { ref io, .. } => io.set_isa_masked(irq, false),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Calling this when there isn't actually an ISA interrupt pending can do
+    /// arbitrary bad things (which I think is basically just faulting the CPU).
+    pub unsafe fn end_isa_irq(&self, irq: IsaInterrupt) {
+        match self.model {
+            InterruptModel::Pic(ref pics) => pics.lock().end_interrupt(irq),
+            InterruptModel::Apic { ref local, .. } => local.end_interrupt(),
         }
     }
 
@@ -181,48 +264,17 @@ impl Controller {
                 }
                 tracing::info!("disabled 8259 PICs");
 
-                // configure the I/O APIC
-                let mut io = {
-                    // TODO(eliza): consider actually using other I/O APICs? do
-                    // we need them for anything??
-                    tracing::trace!(?apic_info.io_apics, "found {} IO APICs", apic_info.io_apics.len());
-
-                    let io_apic = &apic_info.io_apics[0];
-                    let addr = PAddr::from_u64(io_apic.address as u64);
-
-                    tracing::debug!(ioapic.paddr = ?addr, "IOAPIC");
-                    IoApic::new(addr, &mut pagectrl, frame_alloc)
-                };
-
-                // map the standard ISA hardware interrupts to I/O APIC
-                // redirection entries.
-                io.map_isa_irqs(Idt::IOAPIC_START as u8);
+                // configure the I/O APIC(s)
+                let io = IoApicSet::new(apic_info, frame_alloc, &mut pagectrl, Idt::ISA_BASE as u8);
 
                 // enable the local APIC
                 let local = LocalApic::new(&mut pagectrl, frame_alloc);
                 local.enable(Idt::LOCAL_APIC_SPURIOUS as u8);
 
-                let model = InterruptModel::Apic {
-                    local,
-                    io: Mutex::new_with_raw_mutex(io, Spinlock::new()),
-                };
+                let model = InterruptModel::Apic { local, io };
 
                 tracing::trace!(interrupt_model = ?model);
-                let controller = INTERRUPT_CONTROLLER.init(Self { model });
-
-                // GOD THIS SUCKS SO BAD
-                let InterruptModel::Apic { ref io, .. } = controller.model else {
-                    unreachable!("lol")
-                };
-                let mut io = io.lock();
-
-                // unmask the PIT timer vector --- we'll need this for calibrating
-                // the local APIC timer...
-                io.set_masked(IoApic::PIT_TIMER_IRQ, false);
-
-                // unmask the PS/2 keyboard interrupt as well.
-                io.set_masked(IoApic::PS2_KEYBOARD_IRQ, false);
-                controller
+                INTERRUPT_CONTROLLER.init(Self { model })
             }
             model => {
                 if model.is_none() {
@@ -250,6 +302,8 @@ impl Controller {
             crate::cpu::intrinsics::sti();
         }
 
+        controller.unmask_isa_irq(IsaInterrupt::PitTimer);
+        controller.unmask_isa_irq(IsaInterrupt::Ps2Keyboard);
         controller
     }
 
@@ -411,12 +465,9 @@ impl hal_core::interrupt::Control for Idt {
                 tracing::trace!("PIT sleep completed");
             }
             unsafe {
-                match INTERRUPT_CONTROLLER.get_unchecked().model {
-                    InterruptModel::Pic(ref pics) => {
-                        pics.lock().end_interrupt(Idt::PIC_PIT_TIMER as u8)
-                    }
-                    InterruptModel::Apic { ref local, .. } => local.end_interrupt(),
-                }
+                INTERRUPT_CONTROLLER
+                    .get_unchecked()
+                    .end_isa_irq(IsaInterrupt::PitTimer);
             }
         }
 
@@ -438,12 +489,9 @@ impl hal_core::interrupt::Control for Idt {
             let scancode = unsafe { PORT.readb() };
             H::ps2_keyboard(scancode);
             unsafe {
-                match INTERRUPT_CONTROLLER.get_unchecked().model {
-                    InterruptModel::Pic(ref pics) => {
-                        pics.lock().end_interrupt(Idt::PIC_PS2_KEYBOARD as u8)
-                    }
-                    InterruptModel::Apic { ref local, .. } => local.end_interrupt(),
-                }
+                INTERRUPT_CONTROLLER
+                    .get_unchecked()
+                    .end_isa_irq(IsaInterrupt::Ps2Keyboard);
             }
         }
 
@@ -597,11 +645,10 @@ impl hal_core::interrupt::Control for Idt {
         // === hardware interrupts ===
         // ISA standard hardware interrupts mapped on both the PICs and IO APIC
         // interrupt models.
-        self.register_isr(Self::PIC_PIT_TIMER, pit_timer_isr::<H> as *const ());
-        self.register_isr(Self::IOAPIC_PIT_TIMER, pit_timer_isr::<H> as *const ());
-        self.register_isr(Self::PIC_PS2_KEYBOARD, keyboard_isr::<H> as *const ());
-        self.register_isr(Self::IOAPIC_PS2_KEYBOARD, keyboard_isr::<H> as *const ());
-        // local APIC specific hardware itnerrupts
+        self.register_isa_isr(IsaInterrupt::PitTimer, pit_timer_isr::<H> as *const ());
+        self.register_isa_isr(IsaInterrupt::Ps2Keyboard, keyboard_isr::<H> as *const ());
+
+        // local APIC specific hardware interrupts
         self.register_isr(Self::LOCAL_APIC_SPURIOUS, spurious_isr as *const ());
         self.register_isr(Self::LOCAL_APIC_TIMER, apic_timer_isr::<H> as *const ());
 

--- a/hal-x86_64/src/interrupt/apic.rs
+++ b/hal-x86_64/src/interrupt/apic.rs
@@ -1,7 +1,7 @@
 //! Advanced Programmable Interrupt Controller (APIC).
 pub mod io;
 pub mod local;
-pub use io::IoApic;
+pub use io::{IoApic, IoApicSet};
 pub use local::LocalApic;
 
 use mycelium_util::bits::enum_from_bits;

--- a/hal-x86_64/src/interrupt/apic/io.rs
+++ b/hal-x86_64/src/interrupt/apic/io.rs
@@ -201,6 +201,8 @@ impl IoApicSet {
                 .iter()
                 .find(|o| o.isa_source == irq as u8)
             {
+                // put the defaults through an extruder that maybe messes with
+                // them.
                 use acpi::platform::interrupt::{
                     Polarity as AcpiPolarity, TriggerMode as AcpiTriggerMode,
                 };

--- a/hal-x86_64/src/interrupt/apic/io.rs
+++ b/hal-x86_64/src/interrupt/apic/io.rs
@@ -208,12 +208,22 @@ impl IoApicSet {
                 match src_override.polarity {
                     AcpiPolarity::ActiveHigh => polarity = PinPolarity::High,
                     AcpiPolarity::ActiveLow => polarity = PinPolarity::Low,
+                    // TODO(eliza): if the MADT override entry says that the pin
+                    // polarity is "same as bus", we should probably actually
+                    // make it be the same as the bus, instead of just assuming
+                    // that it's active high. But...just assuming that "same as
+                    // bus" means active high seems to basically work so far...
                     AcpiPolarity::SameAsBus => {}
                 }
                 match src_override.trigger_mode {
                     AcpiTriggerMode::Edge => trigger = TriggerMode::Edge,
                     AcpiTriggerMode::Level => trigger = TriggerMode::Level,
-                    _ => {}
+                    // TODO(eliza): As above, when the MADT says this is "same
+                    // as bus", we should make it be the same as the bus instead
+                    // of going "ITS EDGE TRIGGERED LOL LMAO" which is what
+                    // we're currently doing. But, just like above, this Seems
+                    // To Work?
+                    AcpiTriggerMode::SameAsBus => {}
                 }
                 global_system_interrupt = src_override.global_system_interrupt.try_into().expect(
                     "if this exceeds u8::MAX, what the fuck! \

--- a/hal-x86_64/src/interrupt/apic/io.rs
+++ b/hal-x86_64/src/interrupt/apic/io.rs
@@ -220,7 +220,7 @@ impl IoApicSet {
                         that's bigger than the entire IDT...",
                 );
             }
-            // Now, scan to find which I/OAPIC this IRQ corresponds to. if the
+            // Now, scan to find which I/O APIC this IRQ corresponds to. if the
             // system only has one I/O APIC, this will always be 0, but we gotta
             // handle systems with more than one. So, we'll this by traversing
             // the list of I/O APICs, seeing if the GSI number is less than the

--- a/hal-x86_64/src/interrupt/apic/io.rs
+++ b/hal-x86_64/src/interrupt/apic/io.rs
@@ -150,7 +150,7 @@ impl IoApicSet {
         // Fortunately, ACPI is here to help (statements dreamed up by the
         // utterly deranged).
         //
-        // The MADT includes a list of "interrupt source  overrides" that
+        // The MADT includes a list of "interrupt source overrides" that
         // describe any ISA interrupts that are not mapped to I/O APIC pins in
         // numeric order. Each entry in the interrupt source overrides list will
         // contain:

--- a/hal-x86_64/src/interrupt/apic/io.rs
+++ b/hal-x86_64/src/interrupt/apic/io.rs
@@ -182,6 +182,12 @@ impl IoApicSet {
         //   because i bet it's awesome.
         //   so, neither inner loop actually loops that many times.
         // - finally, we only do this once on boot, so who cares?
+
+        let base_entry = RedirectionEntry::new()
+            .with(RedirectionEntry::DELIVERY, DeliveryMode::Normal)
+            .with(RedirectionEntry::REMOTE_IRR, false)
+            .with(RedirectionEntry::MASKED, true)
+            .with(RedirectionEntry::DESTINATION, 0xff);
         for irq in IsaInterrupt::ALL {
             // Assume the IRQ is mapped to the I/O APIC pin corresponding to
             // that ISA IRQ number, and is active-high and edge-triggered.
@@ -257,13 +263,9 @@ impl IoApicSet {
                     ?entry_idx,
                     "found IOAPIC for ISA interrupt"
                 );
-                let entry = RedirectionEntry::new()
-                    .with(RedirectionEntry::DELIVERY, DeliveryMode::Normal)
+                let entry = base_entry
                     .with(RedirectionEntry::POLARITY, polarity)
-                    .with(RedirectionEntry::REMOTE_IRR, false)
                     .with(RedirectionEntry::TRIGGER, trigger)
-                    .with(RedirectionEntry::MASKED, true)
-                    .with(RedirectionEntry::DESTINATION, 0xff)
                     .with(RedirectionEntry::VECTOR, isa_base + irq as u8);
                 apic.set_entry(entry_idx, entry);
                 this.isa_map[irq as usize] = IsaOverride {

--- a/hal-x86_64/src/interrupt/idt.rs
+++ b/hal-x86_64/src/interrupt/idt.rs
@@ -1,4 +1,4 @@
-use super::apic::IoApic;
+use super::IsaInterrupt;
 use crate::{cpu, segment};
 use mycelium_util::{bits, fmt};
 
@@ -155,23 +155,10 @@ impl Idt {
     /// Chosen by fair die roll, guaranteed to be random.
     pub const DOUBLE_FAULT_IST_OFFSET: usize = 4;
 
-    /// PIC Programmable Interval Timer (PIT) interrupt vector mapped by
-    /// [`Controller::enable_hardware_interrupts`].
-    ///
-    /// Systems which do not use that function to initialize the PICs may
-    /// map this interrupt to a different IDT vector.
-    ///
-    /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const PIC_PIT_TIMER: usize = Self::PIC_BIG_START;
+    pub const MAX_CPU_EXCEPTION: usize = Self::SECURITY_EXCEPTION;
 
-    /// PIC PS/2 interrupt vector mapped by
-    /// [`Controller::enable_hardware_interrupts`].
-    ///
-    /// Systems which do not use that function to initialize the PICs may
-    /// map this interrupt to a different IDT vector.
-    ///
-    /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const PIC_PS2_KEYBOARD: usize = Self::PIC_BIG_START + 1;
+    /// Base offset for ISA hardware interrupts.
+    pub const ISA_BASE: usize = 0x20;
 
     /// Local APIC timer interrupt vector mapped by
     /// [`Controller::enable_hardware_interrupts`].
@@ -198,7 +185,7 @@ impl Idt {
     /// map this interrupt to a different IDT vector.
     ///
     /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const PIC_BIG_START: usize = 0x20;
+    pub const PIC_BIG_START: usize = Self::ISA_BASE;
 
     /// Base of the secondary PIC's interrupt vector region mapped by
     /// [`Controller::enable_hardware_interrupts`].
@@ -207,35 +194,8 @@ impl Idt {
     /// map this interrupt to a different IDT vector.
     ///
     /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const PIC_LITTLE_START: usize = 0x28;
+    pub const PIC_LITTLE_START: usize = Self::ISA_BASE + 8;
     // put the IOAPIC right after the PICs
-
-    /// Base of the IOAPIC's interrupt vector region mapped by
-    /// [`Controller::enable_hardware_interrupts`].
-    ///
-    /// Systems which do not use that function to initialize the IOAPIC may
-    /// map this interrupt to a different IDT vector.
-    ///
-    /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const IOAPIC_START: usize = 0x30;
-
-    /// IOAPIC Programmable Interval Timer (PIT) interrupt vector region mapped
-    /// by [`Controller::enable_hardware_interrupts`].
-    ///
-    /// Systems which do not use that function to initialize the IOAPIC may
-    /// map this interrupt to a different IDT vector.
-    ///
-    /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const IOAPIC_PIT_TIMER: usize = Self::IOAPIC_START + IoApic::PIT_TIMER_IRQ as usize;
-
-    /// IOAPIC PS/2 keyboard interrupt vector mapped by
-    /// [`Controller::enable_hardware_interrupts`].
-    ///
-    /// Systems which do not use that function to initialize the IOAPIC may
-    /// map this interrupt to a different IDT vector.
-    ///
-    /// [`Controller::enable_hardware_interrupts`]: super::Controller::enable_hardware_interrupts
-    pub const IOAPIC_PS2_KEYBOARD: usize = Self::IOAPIC_START + IoApic::PS2_KEYBOARD_IRQ as usize;
 
     pub const fn new() -> Self {
         Self {
@@ -243,12 +203,19 @@ impl Idt {
         }
     }
 
+    /// Register an interrupt service routine (ISR) for the given ISA standard
+    /// PC interrupt.
+    pub fn register_isa_isr(&mut self, irq: IsaInterrupt, isr: *const ()) {
+        let vector = irq as usize + Self::ISA_BASE;
+        self.register_isr(vector, isr);
+    }
+
     pub fn register_isr(&mut self, vector: usize, isr: *const ()) {
         let descr = self.descriptors[vector].set_handler(isr);
         if vector == Self::DOUBLE_FAULT {
             descr.set_ist_offset(Self::DOUBLE_FAULT_IST_OFFSET as u8);
         }
-        tracing::debug!(vector, ?isr, ?descr, "set isr");
+        tracing::debug!(vector, ?isr, ?descr, "set ISR");
     }
 
     pub fn load(&'static self) {

--- a/hal-x86_64/src/interrupt/pic.rs
+++ b/hal-x86_64/src/interrupt/pic.rs
@@ -32,7 +32,7 @@ impl Pic {
         debug_assert!(num < 8);
         // read the current value of the Interrupt Mask Register (IMR).
         let imr = self.data.readb();
-        // clear the bit corresponding to the interrupt number to 1.
+        // clear the bit corresponding to the interrupt number.
         self.data.writeb(imr & !(1 << num));
     }
 }


### PR DESCRIPTION
Basically, the current way you interact with ISA standard PC interrupts
in the Mycelium x86_64 HAL is nonsensical, in several ways:

1. For some reason, we were mapping the I/O APIC ISA IRQs and the PIC
   ISA IRQs to separate regions in the IDT, even though you can only ever
   have either an I/O APIC *or* a PIC. Because of this, we were creating
   separate entries for each ISA interrupt's ISR in the PIC region and the
   I/O APIC region of the IDT. This doesn't actually break anything, but
   it's stupid and dumb and I don't know why I did that.

2. I made an attempt to have an interface for controlling ISA interrupts
   that abstracts over the I/O APIC and PIC interrupt models. But,
   currently, you can't actually *use* this thing to do anything you might
   want to do in an abstract way (mask/unmask/acknowledge an interrupt).
   Instead, you have to actually inspect which interrupt model you have.
   So, it's pointless.

3. Apparently the motherboard manufacturer gets to route ISA interrupts
   to I/O APIC pins in "whatever random order they want to". Currently, we
   hard-code the PS/2 keyboard and PIT timer interrupts to the vectors they
   *happen* to be on when I run `qemu-system-x86_64 -cpu qemu64` on *my*
   computer, but in real life, they could be anything. There's a thing in
   the ACPI tables that tells you how these are routed, but we're not using
   it. This is bad.

4. Also there's a bug where apparently when we unmask the PIT interrupt,
   it might fire spuriously, even if we haven't actually done an `sti`. I
   don't get this and it seems wrong, but it results in the IRQ being
   raised *before* configuring the static that tells you whether you have
   the APIC or PIC interrupt model so when you try to actually send an EOI,
   you dereference uninitialized memory and the kernel just hangs. This
   happens occasionally when running in QEMU with the default settings, and
   seems to happen consistently with `-machine accel=kvm`, so that suggests
   it is maybe worth worrying about.

This branch, uh, fixes all of that stuff. I made the abstraction for ISA
interrupts actually usable, and you can now mask/unmask/acknowledge them
from ISRs or anywhere else by interrupt name, instead of having to know what
interrupt model we have. Also, we now do the correct thing with regard to
MADT interrupt source overrides (read: we actually know about them), and I
fixed the spooky spurious interrupt behavior with the PIT by not unmasking it
until after the interrupt controller static is initialized.

Please clap.