### PR TITLE
inoculate test fixes

### DIFF
--- a/inoculate/src/qemu.rs
+++ b/inoculate/src/qemu.rs
@@ -31,9 +31,15 @@ pub enum Cmd {
     Test {
         /// Timeout for failing test run, in seconds.
         ///
-        /// If a test run doesn't complete before this timeout has elapsed, it's
-        /// considered to have failed.
-        #[clap(long, value_parser = parse_secs, default_value = "60")]
+        /// If a test run doesn't complete before this timeout has elapsed, the
+        /// QEMU VM is killed and the test run is assumed to have failed.
+        ///
+        /// Note that this timeout applies to the entire test run, including
+        /// booting the kernel and running the whole kernel test suite, rather
+        /// than to each individual test.
+        ///
+        /// By default, this is 20 minutes (1200 seconds).
+        #[clap(long, value_parser = parse_secs, default_value = "1200")]
         timeout_secs: Duration,
 
         /// Disables capturing test serial output.


### PR DESCRIPTION
Currently, the inoculate test command sets a timeout of 60 seconds, and
abruptly kills QEMU if it takes longer than that. This is no longer
nearly long enough to run our tests. This commit increases the timeout
to 1200 seconds (20 minutes). This is a long time, but our tests take a
while to run, and recall that this timeout applies to booting the kernel
*and running all the tests*, rather than being enforced on a per-test
basis.

We should probably make the timeout much smarter than just "kill the
QEMU process after 20 minutes", and instead do it only if we don't see
any interesting test output, or something. But, this is better than just
always failing test runs because we're stupid about timeouts, I guess.

I also fixed a bug where `--nocapture` disables the test protocol output parsing, breaking our detection of test failure/successes. Whoopsie.