### PR TITLE
fix(maitake-sync): add proper `ScopedRawMutex` bound to `wait_map::Wait`

### DIFF
--- a/maitake-sync/src/wait_map.rs
+++ b/maitake-sync/src/wait_map.rs
@@ -997,7 +997,11 @@ unsafe impl<K: PartialEq, V> Linked<list::Links<Waiter<K, V>>> for Waiter<K, V> 
 
 // === impl Wait ===
 
-impl<K: PartialEq, V> Future for Wait<'_, K, V> {
+impl<K, V, Lock> Future for Wait<'_, K, V, Lock>
+where
+    K: PartialEq,
+    Lock: ScopedRawMutex,
+{
     type Output = WaitResult<V>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
I was unable to await the `Wait` when using a mutex defined in the `mutex` crate because a trait bound was not met. The current trait impl is not general enough.