### PR TITLE
test(maitake-sync): test futures impl `Future`

### DIFF
--- a/maitake-sync/src/mutex.rs
+++ b/maitake-sync/src/mutex.rs
@@ -348,8 +348,12 @@ where
 
 // === impl Lock ===
 
-impl<'a, T> Future for Lock<'a, T> {
-    type Output = MutexGuard<'a, T>;
+impl<'a, T, L> Future for Lock<'a, T, L>
+where
+    T: ?Sized,
+    L: ScopedRawMutex,
+{
+    type Output = MutexGuard<'a, T, L>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();

--- a/maitake-sync/src/mutex/tests.rs
+++ b/maitake-sync/src/mutex/tests.rs
@@ -57,26 +57,26 @@ fn basic_multi_threaded() {
     });
 }
 
-#[test]
-fn lock_future_impls_future() {
-    struct NopRawMutex;
+struct NopRawMutex;
 
-    unsafe impl ScopedRawMutex for NopRawMutex {
-        fn try_with_lock<R>(&self, _: impl FnOnce() -> R) -> Option<R> {
-            None
-        }
-
-        fn with_lock<R>(&self, _: impl FnOnce() -> R) -> R {
-            unimplemented!("this doesn't actually do anything")
-        }
-
-        fn is_locked(&self) -> bool {
-            true
-        }
+unsafe impl ScopedRawMutex for NopRawMutex {
+    fn try_with_lock<R>(&self, _: impl FnOnce() -> R) -> Option<R> {
+        None
     }
 
-    fn assert_future<F: core::future::Future>(_: F) {}
+    fn with_lock<R>(&self, _: impl FnOnce() -> R) -> R {
+        unimplemented!("this doesn't actually do anything")
+    }
 
+    fn is_locked(&self) -> bool {
+        true
+    }
+}
+
+fn assert_future<F: core::future::Future>(_: F) {}
+
+#[test]
+fn lock_future_impls_future() {
     loom::model(|| {
         // Mutex with `DefaultMutex` as the `ScopedRawMutex` implementation
         let mutex = Mutex::new(());
@@ -85,5 +85,21 @@ fn lock_future_impls_future() {
         // Mutex with a custom `ScopedRawMutex` implementation
         let mutex = Mutex::new_with_raw_mutex((), NopRawMutex);
         assert_future(mutex.lock());
+    })
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn lock_owned_future_impls_future() {
+    loom::model(|| {
+        use alloc::sync::Arc;
+
+        // Mutex with `DefaultMutex` as the `ScopedRawMutex` implementation
+        let mutex = Arc::new(Mutex::new(()));
+        assert_future(mutex.lock_owned());
+
+        // Mutex with a custom `ScopedRawMutex` implementation
+        let mutex = Arc::new(Mutex::new_with_raw_mutex((), NopRawMutex));
+        assert_future(mutex.lock_owned());
     })
 }

--- a/maitake-sync/src/rwlock/tests.rs
+++ b/maitake-sync/src/rwlock/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::util::test::{assert_future, assert_send_sync, NopRawMutex};
+use crate::util::test::assert_send_sync;
 
 #[cfg(any(loom, feature = "alloc"))]
 mod loom;
@@ -20,30 +20,4 @@ fn read_guard_is_send_sync() {
 #[test]
 fn write_guard_is_send_sync() {
     assert_send_sync::<RwLockWriteGuard<'_, usize>>();
-}
-
-#[test]
-fn read_future_is_future() {
-    crate::loom::model(|| {
-        // RwLock with default mutex.
-        let q = RwLock::new(1);
-        assert_future(q.read());
-
-        // RwLock with overridden `ScopedRawMutex`.
-        let q = RwLock::new_with_raw_mutex(1, NopRawMutex);
-        assert_future(q.read());
-    })
-}
-
-#[test]
-fn write_future_is_future() {
-    crate::loom::model(|| {
-        // RwLock with default mutex.
-        let q = RwLock::new(1);
-        assert_future(q.write());
-
-        // RwLock with overridden `ScopedRawMutex`.
-        let q = RwLock::new_with_raw_mutex(1, NopRawMutex);
-        assert_future(q.write());
-    })
 }

--- a/maitake-sync/src/rwlock/tests.rs
+++ b/maitake-sync/src/rwlock/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::util;
+use crate::util::test::{assert_future, assert_send_sync, NopRawMutex};
 
 #[cfg(any(loom, feature = "alloc"))]
 mod loom;
@@ -9,15 +9,41 @@ mod sequential;
 
 #[test]
 fn lock_is_send_sync() {
-    util::test::assert_send_sync::<RwLock<usize>>();
+    assert_send_sync::<RwLock<usize>>();
 }
 
 #[test]
 fn read_guard_is_send_sync() {
-    util::test::assert_send_sync::<RwLockReadGuard<'_, usize>>();
+    assert_send_sync::<RwLockReadGuard<'_, usize>>();
 }
 
 #[test]
 fn write_guard_is_send_sync() {
-    util::test::assert_send_sync::<RwLockWriteGuard<'_, usize>>();
+    assert_send_sync::<RwLockWriteGuard<'_, usize>>();
+}
+
+#[test]
+fn read_future_is_future() {
+    crate::loom::model(|| {
+        // RwLock with default mutex.
+        let q = RwLock::new(1);
+        assert_future(q.read());
+
+        // RwLock with overridden `ScopedRawMutex`.
+        let q = RwLock::new_with_raw_mutex(1, NopRawMutex);
+        assert_future(q.read());
+    })
+}
+
+#[test]
+fn write_future_is_future() {
+    crate::loom::model(|| {
+        // RwLock with default mutex.
+        let q = RwLock::new(1);
+        assert_future(q.write());
+
+        // RwLock with overridden `ScopedRawMutex`.
+        let q = RwLock::new_with_raw_mutex(1, NopRawMutex);
+        assert_future(q.write());
+    })
 }

--- a/maitake-sync/src/semaphore/tests.rs
+++ b/maitake-sync/src/semaphore/tests.rs
@@ -18,15 +18,11 @@ fn acquire_is_send_and_sync() {
 
 #[test]
 fn acquire_is_future() {
-    crate::loom::model(|| {
-        // Semaphore with `DefaultRawMutex`
-        let sem = Semaphore::new(1);
-        assert_future(sem.acquire(1));
+    // Semaphore with `DefaultRawMutex`
+    assert_future::<Acquire<'_>>();
 
-        // Semaphore with overridden `ScopedRawMutex`
-        let sem = Semaphore::new_with_raw_mutex(1, NopRawMutex);
-        assert_future(sem.acquire(1));
-    });
+    // Semaphore with overridden `ScopedRawMutex`
+    assert_future::<Acquire<'_, NopRawMutex>>();
 }
 
 #[cfg(feature = "alloc")]
@@ -45,15 +41,8 @@ mod owned {
 
     #[test]
     fn acquire_owned_is_future() {
-        crate::loom::model(|| {
-            // Semaphore with `DefaultRawMutex`
-            let sem = alloc::sync::Arc::new(Semaphore::new(1));
-            assert_future(sem.acquire_owned(1));
-
-            // Semaphore with overridden `ScopedRawMutex`
-            let sem = alloc::sync::Arc::new(Semaphore::new(1));
-            assert_future(sem.acquire_owned(1));
-        });
+        assert_future::<AcquireOwned>();
+        assert_future::<AcquireOwned<NopRawMutex>>();
     }
 }
 

--- a/maitake-sync/src/semaphore/tests.rs
+++ b/maitake-sync/src/semaphore/tests.rs
@@ -1,19 +1,32 @@
 use super::*;
-use crate::util;
+use crate::util::test::{assert_future, assert_send_sync, NopRawMutex};
 
 #[test]
 fn semaphore_is_send_and_sync() {
-    util::test::assert_send_sync::<Semaphore>();
+    assert_send_sync::<Semaphore>();
 }
 
 #[test]
 fn permit_is_send_and_sync() {
-    util::test::assert_send_sync::<Permit<'_>>();
+    assert_send_sync::<Permit<'_>>();
 }
 
 #[test]
 fn acquire_is_send_and_sync() {
-    util::test::assert_send_sync::<crate::semaphore::Acquire<'_>>();
+    assert_send_sync::<crate::semaphore::Acquire<'_>>();
+}
+
+#[test]
+fn acquire_is_future() {
+    crate::loom::model(|| {
+        // Semaphore with `DefaultRawMutex`
+        let sem = Semaphore::new(1);
+        assert_future(sem.acquire(1));
+
+        // Semaphore with overridden `ScopedRawMutex`
+        let sem = Semaphore::new_with_raw_mutex(1, NopRawMutex);
+        assert_future(sem.acquire(1));
+    });
 }
 
 #[cfg(feature = "alloc")]
@@ -22,12 +35,25 @@ mod owned {
 
     #[test]
     fn owned_permit_is_send_and_sync() {
-        util::test::assert_send_sync::<OwnedPermit>();
+        assert_send_sync::<OwnedPermit>();
     }
 
     #[test]
     fn acquire_owned_is_send_and_sync() {
-        util::test::assert_send_sync::<AcquireOwned>();
+        assert_send_sync::<AcquireOwned>();
+    }
+
+    #[test]
+    fn acquire_owned_is_future() {
+        crate::loom::model(|| {
+            // Semaphore with `DefaultRawMutex`
+            let sem = alloc::sync::Arc::new(Semaphore::new(1));
+            assert_future(sem.acquire_owned(1));
+
+            // Semaphore with overridden `ScopedRawMutex`
+            let sem = alloc::sync::Arc::new(Semaphore::new(1));
+            assert_future(sem.acquire_owned(1));
+        });
     }
 }
 

--- a/maitake-sync/src/util.rs
+++ b/maitake-sync/src/util.rs
@@ -264,7 +264,7 @@ pub(crate) mod test {
     pub(crate) fn assert_sync<T: Sync>() {}
     pub(crate) fn assert_send_sync<T: Send + Sync>() {}
 
-    pub(crate) fn assert_future<F: core::future::Future>(_: F) {}
+    pub(crate) fn assert_future<F: core::future::Future>() {}
 
     pub(crate) struct NopRawMutex;
 

--- a/maitake-sync/src/util.rs
+++ b/maitake-sync/src/util.rs
@@ -263,4 +263,27 @@ pub(crate) mod test {
     #[allow(dead_code)]
     pub(crate) fn assert_sync<T: Sync>() {}
     pub(crate) fn assert_send_sync<T: Send + Sync>() {}
+
+    pub(crate) fn assert_future<F: core::future::Future>(_: F) {}
+
+    pub(crate) struct NopRawMutex;
+
+    unsafe impl mutex_traits::RawMutex for NopRawMutex {
+        type GuardMarker = ();
+        fn lock(&self) {
+            unimplemented!("don't actually try to lock this thing")
+        }
+
+        fn is_locked(&self) -> bool {
+            unimplemented!("don't actually try to lock this thing")
+        }
+
+        fn try_lock(&self) -> bool {
+            unimplemented!("don't actually try to lock this thing")
+        }
+
+        unsafe fn unlock(&self) {
+            unimplemented!("don't actually try to lock this thing")
+        }
+    }
 }

--- a/maitake-sync/src/wait_map/tests.rs
+++ b/maitake-sync/src/wait_map/tests.rs
@@ -1,5 +1,36 @@
 use super::*;
+use crate::util::test::{assert_future, NopRawMutex};
 #[cfg(all(not(loom), feature = "alloc"))]
 mod alloc_tests;
 #[cfg(any(loom, feature = "alloc"))]
 mod loom;
+
+#[test]
+fn wait_future_is_future() {
+    crate::loom::model(|| {
+        // WaitMap with default mutex.
+        let m = WaitMap::<i32, i32>::new();
+        assert_future(m.wait(1));
+
+        // WaitMap with overridden `ScopedRawMutex`.
+        let m = WaitMap::<i32, i32, _>::new_with_raw_mutex(NopRawMutex);
+        assert_future(m.wait(1));
+    })
+}
+
+#[test]
+fn subscribe_future_is_future() {
+    crate::loom::model(|| {
+        // WaitMap with default mutex.
+        let m = WaitMap::<i32, i32>::new();
+        let f = m.wait(1);
+        let f = core::pin::pin!(f);
+        assert_future(f.subscribe());
+
+        // WaitMap with overridden `ScopedRawMutex`.
+        let m = WaitMap::<i32, i32, _>::new_with_raw_mutex(NopRawMutex);
+        let f = m.wait(1);
+        let f = core::pin::pin!(f);
+        assert_future(f.subscribe());
+    })
+}

--- a/maitake-sync/src/wait_map/tests.rs
+++ b/maitake-sync/src/wait_map/tests.rs
@@ -7,30 +7,18 @@ mod loom;
 
 #[test]
 fn wait_future_is_future() {
-    crate::loom::model(|| {
-        // WaitMap with default mutex.
-        let m = WaitMap::<i32, i32>::new();
-        assert_future(m.wait(1));
+    // WaitMap with default mutex.
+    assert_future::<Wait<'_, i32, i32>>();
 
-        // WaitMap with overridden `ScopedRawMutex`.
-        let m = WaitMap::<i32, i32, _>::new_with_raw_mutex(NopRawMutex);
-        assert_future(m.wait(1));
-    })
+    // WaitMap with overridden `ScopedRawMutex`.
+    assert_future::<Wait<'_, i32, i32, NopRawMutex>>();
 }
 
 #[test]
 fn subscribe_future_is_future() {
-    crate::loom::model(|| {
-        // WaitMap with default mutex.
-        let m = WaitMap::<i32, i32>::new();
-        let f = m.wait(1);
-        let f = core::pin::pin!(f);
-        assert_future(f.subscribe());
+    // WaitMap with default mutex.
+    assert_future::<Subscribe<'_, '_, i32, i32>>();
 
-        // WaitMap with overridden `ScopedRawMutex`.
-        let m = WaitMap::<i32, i32, _>::new_with_raw_mutex(NopRawMutex);
-        let f = m.wait(1);
-        let f = core::pin::pin!(f);
-        assert_future(f.subscribe());
-    })
+    // WaitMap with overridden `ScopedRawMutex`.
+    assert_future::<Subscribe<'_, '_, i32, i32, NopRawMutex>>();
 }

--- a/maitake-sync/src/wait_map/tests/alloc_tests.rs
+++ b/maitake-sync/src/wait_map/tests/alloc_tests.rs
@@ -406,13 +406,9 @@ fn drop_wake_bailed() {
 
 #[test]
 fn wait_owned_future_is_future() {
-    crate::loom::model(|| {
-        // WaitMap with default mutex.
-        let m = Arc::new(WaitMap::<i32, i32>::new());
-        assert_future(m.wait_owned(1));
+    // WaitMap with default mutex.
+    assert_future::<WaitOwned<i32, i32>>();
 
-        // WaitMap with overridden `ScopedRawMutex`.
-        let m = Arc::new(WaitMap::<i32, i32, _>::new_with_raw_mutex(NopRawMutex));
-        assert_future(m.wait_owned(1));
-    })
+    // WaitMap with overridden `ScopedRawMutex`.
+    assert_future::<WaitOwned<i32, i32, NopRawMutex>>();
 }

--- a/maitake-sync/src/wait_queue/tests.rs
+++ b/maitake-sync/src/wait_queue/tests.rs
@@ -1,8 +1,21 @@
-#[cfg(any(loom, feature = "alloc"))]
 use super::*;
+use crate::util::test::{assert_future, NopRawMutex};
 
 #[cfg(all(not(loom), feature = "alloc"))]
 mod alloc_tests;
 
 #[cfg(any(loom, feature = "alloc"))]
 mod loom;
+
+#[test]
+fn wait_future_is_future() {
+    crate::loom::model(|| {
+        // WaitQueue with default mutex.
+        let q = WaitQueue::new();
+        assert_future(q.wait());
+
+        // WaitQueue with overridden `ScopedRawMutex`.
+        let q = WaitQueue::new_with_raw_mutex(NopRawMutex);
+        assert_future(q.wait());
+    })
+}

--- a/maitake-sync/src/wait_queue/tests.rs
+++ b/maitake-sync/src/wait_queue/tests.rs
@@ -9,13 +9,8 @@ mod loom;
 
 #[test]
 fn wait_future_is_future() {
-    crate::loom::model(|| {
-        // WaitQueue with default mutex.
-        let q = WaitQueue::new();
-        assert_future(q.wait());
-
-        // WaitQueue with overridden `ScopedRawMutex`.
-        let q = WaitQueue::new_with_raw_mutex(NopRawMutex);
-        assert_future(q.wait());
-    })
+    // WaitQueue with default raw mutex
+    assert_future::<Wait<'_>>();
+    // WaitQueue with overridden raw mutex
+    assert_future::<Wait<'_, NopRawMutex>>();
 }

--- a/maitake-sync/src/wait_queue/tests/alloc_tests.rs
+++ b/maitake-sync/src/wait_queue/tests/alloc_tests.rs
@@ -173,13 +173,9 @@ fn subscribe_consumes_wakeup() {
 
 #[test]
 fn wait_owned_future_is_future() {
-    crate::loom::model(|| {
-        // WaitQueue with default mutex.
-        let q = Arc::new(WaitQueue::new());
-        assert_future(q.wait_owned());
+    // WaitQueue with default raw mutex
+    assert_future::<WaitOwned>();
 
-        // WaitQueue with overridden `ScopedRawMutex`.
-        let q = Arc::new(WaitQueue::new_with_raw_mutex(NopRawMutex));
-        assert_future(q.wait_owned());
-    })
+    // WaitQueue with overridden raw mutex
+    assert_future::<WaitOwned<NopRawMutex>>();
 }


### PR DESCRIPTION
Depends on #517

As described in #516, this commit adds tests ensuring that `Future` impls are always present for sync primitive future types when using user-provided `ScopedRawMutex`/`RawMutex` impls. This should help protect against future regressions.

Fixes #516