### PR TITLE
feat(cordyceps): singly-linked intrusive `SortedList`

### DIFF
--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -76,7 +76,7 @@ pub use list::List;
 #[doc(inline)]
 pub use mpsc_queue::MpscQueue;
 #[doc(inline)]
-pub use stack::{Stack, TransferStack};
+pub use stack::{Stack, TransferStack, SortedList, SortedListIter};
 
 pub(crate) mod loom;
 

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -69,6 +69,7 @@ pub(crate) mod util;
 
 pub mod list;
 pub mod mpsc_queue;
+pub mod sorted_list;
 pub mod stack;
 
 #[doc(inline)]
@@ -76,7 +77,9 @@ pub use list::List;
 #[doc(inline)]
 pub use mpsc_queue::MpscQueue;
 #[doc(inline)]
-pub use stack::{Stack, TransferStack, SortedList, SortedListIter};
+pub use sorted_list::{SortedList, SortedListIter};
+#[doc(inline)]
+pub use stack::{Stack, TransferStack};
 
 pub(crate) mod loom;
 

--- a/cordyceps/src/sorted_list.rs
+++ b/cordyceps/src/sorted_list.rs
@@ -6,7 +6,12 @@
 //! [Intrusive]: crate#intrusive-data-structures
 
 use crate::{Linked, Stack};
-use core::{cmp::{Ord, Ordering}, marker::PhantomData, ptr::NonNull};
+use core::{
+    cmp::{Ord, Ordering},
+    fmt,
+    marker::PhantomData,
+    ptr::NonNull,
+};
 
 pub use crate::stack::Links;
 
@@ -24,7 +29,6 @@ pub use crate::stack::Links;
 ///
 /// If your type `T` does NOT implement [`Ord`], or you want to use
 /// a custom sorting anyway, consider using [`SortedList::new_with_cmp()`]
-#[derive(Debug)]
 pub struct SortedList<T: Linked<Links<T>>> {
     head: Option<NonNull<T>>,
     // Returns if LHS is less/same/greater than RHS
@@ -189,7 +193,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
         // * insert between cursor and cursor.next (if elem is < c.next)
         // * just iterate (if elem >= c.next)
         loop {
-            // SAFETY: We have exclusive access to the list, we are allowed to
+            // Safety: We have exclusive access to the list, we are allowed to
             // access and mutate it (carefully)
             unsafe {
                 // Get the cursor's links
@@ -272,6 +276,16 @@ impl<T: Linked<Links<T>>> Extend<T::Handle> for SortedList<T> {
     }
 }
 
+impl<T> fmt::Debug for SortedList<T>
+where
+    T: Linked<Links<T>>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { head, func: _ } = self;
+        f.debug_struct("SortedList").field("head", head).finish()
+    }
+}
+
 impl<T: Linked<Links<T>>> Drop for SortedList<T> {
     fn drop(&mut self) {
         // We just turn the list into a stack then run the stack drop code.
@@ -285,7 +299,6 @@ impl<T: Linked<Links<T>>> Drop for SortedList<T> {
 }
 
 /// A borrowing iterator of a [`SortedList`]
-#[derive(Debug)]
 pub struct SortedListIter<'a, T: Linked<Links<T>>> {
     _plt: PhantomData<&'a SortedList<T>>,
     node: Option<NonNull<T>>,

--- a/cordyceps/src/sorted_list.rs
+++ b/cordyceps/src/sorted_list.rs
@@ -23,7 +23,7 @@ pub use crate::stack::Links;
 /// * Consider using [`SortedList::new_max()`] if you want **largest** items sorted first.
 ///
 /// If your type `T` does NOT implement [`Ord`], or you want to use
-/// a custom sorting anyway, consider using [`SortedList::new_custom()`]
+/// a custom sorting anyway, consider using [`SortedList::new_with_cmp()`]
 #[derive(Debug)]
 pub struct SortedList<T: Linked<Links<T>>> {
     head: Option<NonNull<T>>,
@@ -45,39 +45,39 @@ where
     /// Create a new (empty) sorted list, sorted LEAST FIRST
     ///
     /// * Consider using [`SortedList::new_max()`] if you want **largest** items sorted first.
-    /// * Consider using [`SortedList::new_custom()`] if you want to provide your own sorting
+    /// * Consider using [`SortedList::new_with_cmp()`] if you want to provide your own sorting
     ///   implementation.
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
     #[must_use]
     pub const fn new_min() -> Self {
-        Self::new_custom(T::cmp)
+        Self::new_with_cmp(T::cmp)
     }
 
     /// Create a new sorted list, consuming the stack, sorted LEAST FIRST
     #[must_use]
     pub fn from_stack_min(stack: Stack<T>) -> Self {
-        Self::from_stack_custom(stack, T::cmp)
+        Self::from_stack_with_cmp(stack, T::cmp)
     }
 
     /// Create a new (empty) sorted list, sorted GREATEST FIRST
     ///
     /// * Consider using [`SortedList::new_min()`] if you want **smallest** items sorted first.
-    /// * Consider using [`SortedList::new_custom()`] if you want to provide your own sorting
+    /// * Consider using [`SortedList::new_with_cmp()`] if you want to provide your own sorting
     ///   implementation.
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
     #[must_use]
     pub const fn new_max() -> Self {
-        Self::new_custom(invert_sort::<T>)
+        Self::new_with_cmp(invert_sort::<T>)
     }
 
     /// Create a new sorted list, consuming the stack, sorted GREATEST FIRST
     #[must_use]
     pub fn from_stack_max(stack: Stack<T>) -> Self {
-        Self::from_stack_custom(stack, invert_sort::<T>)
+        Self::from_stack_with_cmp(stack, invert_sort::<T>)
     }
 }
 
@@ -104,7 +104,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
-    pub const fn new_custom(f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+    pub const fn new_with_cmp(f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
         Self {
             func: f,
             head: None,
@@ -112,8 +112,8 @@ impl<T: Linked<Links<T>>> SortedList<T> {
     }
 
     /// Create a new sorted list, consuming the stack, using the provided ordering function
-    pub fn from_stack_custom(stack: Stack<T>, f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
-        let mut slist = Self::new_custom(f);
+    pub fn from_stack_with_cmp(stack: Stack<T>, f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+        let mut slist = Self::new_with_cmp(f);
         slist.extend(stack);
         slist
     }
@@ -414,7 +414,7 @@ mod loom {
     #[test]
     fn slist_basic() {
         loom::model(|| {
-            let mut slist = SortedList::<Entry>::new_custom(|lhs, rhs| lhs.val.cmp(&rhs.val));
+            let mut slist = SortedList::<Entry>::new_with_cmp(|lhs, rhs| lhs.val.cmp(&rhs.val));
             // Insert out of order
             slist.insert(Entry::new(20));
             slist.insert(Entry::new(10));

--- a/cordyceps/src/sorted_list.rs
+++ b/cordyceps/src/sorted_list.rs
@@ -6,7 +6,7 @@
 //! [Intrusive]: crate#intrusive-data-structures
 
 use crate::{Linked, Stack};
-use core::{marker::PhantomData, ptr::NonNull};
+use core::{cmp::{Ord, Ordering}, marker::PhantomData, ptr::NonNull};
 
 pub use crate::stack::Links;
 
@@ -28,11 +28,11 @@ pub use crate::stack::Links;
 pub struct SortedList<T: Linked<Links<T>>> {
     head: Option<NonNull<T>>,
     // Returns if LHS is less/same/greater than RHS
-    func: fn(&T, &T) -> core::cmp::Ordering,
+    func: fn(&T, &T) -> Ordering,
 }
 
 #[inline]
-fn invert_sort<T: core::cmp::Ord>(a: &T, b: &T) -> core::cmp::Ordering {
+fn invert_sort<T: Ord>(a: &T, b: &T) -> Ordering {
     // Inverted sort order!
     T::cmp(b, a)
 }
@@ -40,7 +40,7 @@ fn invert_sort<T: core::cmp::Ord>(a: &T, b: &T) -> core::cmp::Ordering {
 impl<T> SortedList<T>
 where
     T: Linked<Links<T>>,
-    T: core::cmp::Ord,
+    T: Ord,
 {
     /// Create a new (empty) sorted list, sorted LEAST FIRST
     ///
@@ -104,7 +104,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
-    pub const fn new_with_cmp(f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+    pub const fn new_with_cmp(f: fn(&T, &T) -> Ordering) -> Self {
         Self {
             func: f,
             head: None,
@@ -112,7 +112,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
     }
 
     /// Create a new sorted list, consuming the stack, using the provided ordering function
-    pub fn from_stack_with_cmp(stack: Stack<T>, f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+    pub fn from_stack_with_cmp(stack: Stack<T>, f: fn(&T, &T) -> Ordering) -> Self {
         let mut slist = Self::new_with_cmp(f);
         slist.extend(stack);
         slist
@@ -168,7 +168,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
 
             // If cursor node is LESS or EQUAL: keep moving.
             // If cursor node is GREATER: we need to place the new item BEFORE
-            if cmp == core::cmp::Ordering::Greater {
+            if cmp == Ordering::Greater {
                 unsafe {
                     let links = T::links(ptr).as_mut();
                     links.next.with_mut(|next| {
@@ -208,7 +208,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
                             (self.func)(nref, eref)
                         };
 
-                        if cmp == core::cmp::Ordering::Greater {
+                        if cmp == Ordering::Greater {
                             // As above, if cursor.next > element, then we
                             // need to insert between cursor and next.
                             //

--- a/cordyceps/src/sorted_list.rs
+++ b/cordyceps/src/sorted_list.rs
@@ -1,9 +1,9 @@
-//! [Intrusive], singly-linked, sorted, linked-list.
+//! [Intrusive], singly-linked, sorted, linked list.
 //!
 //! See the documentation for the [`SortedList`] and [`SortedListIter`] types for
 //! details.
 //!
-//! [intrusive]: crate#intrusive-data-structures
+//! [Intrusive]: crate#intrusive-data-structures
 
 use crate::{Linked, Stack};
 use core::{marker::PhantomData, ptr::NonNull};
@@ -14,7 +14,7 @@ pub use crate::stack::Links;
 ///
 /// This behaves similar to [`Stack`], in that it is a singly linked list,
 /// however items are stored in an ordered fashion. This means that insertion
-/// is an `O(n)` operation, and retrieval of the first item is an `O(1)` operation.
+/// is an _O_(_n_) operation, and retrieval of the first item is an _O_(1) operation.
 ///
 /// It allows for a user selected ordering operation. If your type `T` implements
 /// [`Ord`]:
@@ -50,11 +50,13 @@ where
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
+    #[must_use]
     pub const fn new_min() -> Self {
         Self::new_custom(T::cmp)
     }
 
     /// Create a new sorted list, consuming the stack, sorted LEAST FIRST
+    #[must_use]
     pub fn from_stack_min(stack: Stack<T>) -> Self {
         Self::from_stack_custom(stack, T::cmp)
     }
@@ -67,11 +69,13 @@ where
     ///
     /// If two items are considered of equal value, new values will be placed AFTER
     /// old values.
+    #[must_use]
     pub const fn new_max() -> Self {
         Self::new_custom(invert_sort::<T>)
     }
 
     /// Create a new sorted list, consuming the stack, sorted GREATEST FIRST
+    #[must_use]
     pub fn from_stack_max(stack: Stack<T>) -> Self {
         Self::from_stack_custom(stack, invert_sort::<T>)
     }
@@ -116,7 +120,7 @@ impl<T: Linked<Links<T>>> SortedList<T> {
 
     /// Pop the front-most item from the list, returning it by ownership (if it exists)
     ///
-    /// This is an `O(1)` operation.
+    /// This is an _O_(1) operation.
     #[must_use]
     pub fn pop_front(&mut self) -> Option<T::Handle> {
         test_trace!(?self.head, "SortedList::pop_front");
@@ -135,9 +139,9 @@ impl<T: Linked<Links<T>>> SortedList<T> {
         }
     }
 
-    /// Insert a single item into the list, in it's sorted order position
+    /// Insert a single item into the list, in its sorted order position
     ///
-    /// This is an `O(n)` operation.
+    /// This is an _O_(_n_) operation.
     pub fn insert(&mut self, element: T::Handle) {
         let ptr = T::into_ptr(element);
         test_trace!(?ptr, ?self.head, "SortedList::insert");

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use core::{
     fmt,
-    marker::{PhantomData, PhantomPinned},
+    marker::PhantomPinned,
     ptr::{self, NonNull},
 };
 
@@ -83,17 +83,25 @@ pub struct TransferStack<T: Linked<Links<T>>> {
 ///
 /// [intrusive]: crate#intrusive-data-structures
 pub struct Stack<T: Linked<Links<T>>> {
-    head: Option<NonNull<T>>,
+    pub(crate) head: Option<NonNull<T>>,
 }
 
-/// Links to other nodes in a [`TransferStack`] or [`Stack`].
+/// Singly-linked-list linkage
 ///
-/// In order to be part of a [`Stack`] or [`TransferStack`], a type must contain
-/// an instance of this type, and must implement the [`Linked`] trait for
-/// `Links<Self>`.
+/// Links to other nodes in a [`TransferStack`], [`Stack`], or [`SortedList`].
+///
+/// In order to be part of a [`TransferStack`], [`Stack`], or [`SortedList`],
+/// a type must contain an instance of this type, and must implement the
+/// [`Linked`] trait for `Links<Self>`.
+///
+/// [`SortedList`]: crate::SortedList
+//
+// TODO(AJM): In the next breaking change, we might want to specifically have
+// a `SingleLinks` and `DoubleLinks` type to make the relationship more clear,
+// instead of "stack" being singly-flavored and "list" being doubly-flavored
 pub struct Links<T> {
     /// The next node in the queue.
-    next: UnsafeCell<Option<NonNull<T>>>,
+    pub(crate) next: UnsafeCell<Option<NonNull<T>>>,
 
     /// Linked list links must always be `!Unpin`, in order to ensure that they
     /// never recieve LLVM `noalias` annotations; see also
@@ -169,8 +177,9 @@ where
                 .compare_exchange_weak(head, ptr.as_ptr(), AcqRel, Acquire)
             {
                 Ok(old) => {
-                    test_trace!(?ptr, ?head, "TransferStack::push -> pushed");
-                    return old.is_null();
+                    let was_empty = old.is_null();
+                    test_trace!(?ptr, ?head, was_empty, "TransferStack::push -> pushed");
+                    return was_empty;
                 }
                 Err(actual) => head = actual,
             }
@@ -416,245 +425,6 @@ impl<T> Default for Links<T> {
     }
 }
 
-// --------------------------------------------------------------------------
-// This should live somewhere else, but for now it doesn't.
-// -AJM
-// --------------------------------------------------------------------------
-
-/// A sorted singly linked list
-///
-/// This behaves similar to [`Stack`], in that it is a singly linked list,
-/// however items are stored in an ordered fashion. This means that insertion
-/// is an O(n) operation, and retrieval of the first item is an O(1) operation.
-///
-/// It allows for a user selected ordering operation, see [`SortedList::new`]
-/// for usage example.
-#[derive(Debug)]
-pub struct SortedList<T: Linked<Links<T>>> {
-    head: Option<NonNull<T>>,
-    // Returns if LHS is less/same/greater than RHS
-    func: fn(&T, &T) -> core::cmp::Ordering,
-}
-
-impl<T: Linked<Links<T>>> SortedList<T> {
-    /// Create a new (empty) sorted list with the given ordering function
-    ///
-    /// If `T` contained an `i32`, and you wanted the SMALLEST items at the
-    /// front, then you could provide a function something like:
-    ///
-    /// ```rust
-    /// let f: fn(&i32, &i32) -> core::cmp::Ordering = |lhs, rhs| {
-    ///     lhs.cmp(rhs)
-    /// };
-    /// ```
-    ///
-    /// SortedList takes a function (and not just [Ord]) so you can use it on types
-    /// that don't have a general way of ordering them, allowing you to select a
-    /// specific metric within the sorting function.
-    ///
-    /// If two items are considered of equal value, new values will be placed AFTER
-    /// old values.
-    pub const fn new(f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
-        Self {
-            func: f,
-            head: None,
-        }
-    }
-
-    /// Create a new sorted list, consuming the stack, using the provided ordering function
-    pub fn from_stack(stack: Stack<T>, f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
-        let mut slist = Self::new(f);
-        slist.extend(stack);
-        slist
-    }
-
-    /// Pop the front-most item from the list, returning it by ownership (if it exists)
-    #[must_use]
-    pub fn pop_front(&mut self) -> Option<T::Handle> {
-        test_trace!(?self.head, "SortedList::pop_front");
-        let head = self.head.take()?;
-        unsafe {
-            // Safety: we have exclusive ownership over this chunk of stack.
-
-            // advance the head link to the next node after the current one (if
-            // there is one).
-            self.head = T::links(head).as_mut().next.with_mut(|next| (*next).take());
-
-            test_trace!(?self.head, "SortedList::pop -> popped");
-
-            // return the current node
-            Some(T::from_ptr(head))
-        }
-    }
-
-    /// Insert a single item into the list, in it's sorted order position
-    pub fn insert(&mut self, element: T::Handle) {
-        let ptr = T::into_ptr(element);
-        test_trace!(?ptr, ?self.head, "SortedList::insert");
-
-        // Take a long-lived reference to the new element
-        let eref = unsafe { ptr.as_ref() };
-
-        // Special case for empty head
-        //
-        // If the head is null, then just place the item
-        let Some(mut cursor) = self.head else {
-            // todo: assert element.next is null?
-            self.head = Some(ptr);
-            return;
-        };
-
-        // Special case for head: do we replace current head with new element?
-        {
-            // compare, but make sure we drop the live reference to the cursor
-            let cmp = {
-                let cref = unsafe { cursor.as_ref() };
-                (self.func)(cref, eref)
-            };
-
-            // If cursor node is LESS or EQUAL: keep moving.
-            // If cursor node is GREATER: we need to place the new item BEFORE
-            if cmp == core::cmp::Ordering::Greater {
-                unsafe {
-                    let links = T::links(ptr).as_mut();
-                    links.next.with_mut(|next| {
-                        // ensure that `element`'s next is null
-                        debug_assert!((*next).is_none());
-                        *next = self.head.replace(ptr);
-                    });
-                    return;
-                }
-            }
-        }
-
-        // On every iteration of the loop, we know that the new element should
-        // be placed AFTER the current value of `cursor`, meaning that we need
-        // to decide whether we:
-        //
-        // * just append (if next is null)
-        // * insert between cursor and cursor.next (if elem is < c.next)
-        // * just iterate (if elem >= c.next)
-        loop {
-            // SAFETY: We have exclusive access to the list, we are allowed to
-            // access and mutate it (carefully)
-            unsafe {
-                // Get the cursor's links
-                let clinks = T::links(cursor).as_mut();
-                // Peek into the cursor's next item
-                let next = clinks.next.with_mut(|next| {
-                    // We can take a reference here, as we have exclusive access
-                    let mutref = &mut *next;
-
-                    if let Some(n) = mutref {
-                        // If next is some, store this pointer
-                        let nptr: NonNull<T> = *n;
-                        // Then compare the next element with the new element
-                        let cmp = {
-                            let nref: &T = nptr.as_ref();
-                            (self.func)(nref, eref)
-                        };
-
-                        if cmp == core::cmp::Ordering::Greater {
-                            // As above, if cursor.next > element, then we
-                            // need to insert between cursor and next.
-                            //
-                            // First, get the current element's links...
-                            let elinks = T::links(ptr).as_mut();
-                            // ...then store cursor.next.next in element.next,
-                            // and store element in cursor.next.
-                            elinks.next.with_mut(|enext| {
-                                *enext = mutref.replace(ptr);
-                            });
-                            // If we have placed element, there is no next value
-                            // for cursor.
-                            None
-                        } else {
-                            // If cursor.next <= element, then we just need to
-                            // iterate, so return the NonNull that represents
-                            // cursor.next, so we can move cursor there.
-                            Some(nptr)
-                        }
-                    } else {
-                        // "just append" case - assign element to cursor.next
-                        *mutref = Some(ptr);
-                        // If we have placed element, there is no next value
-                        // for cursor
-                        None
-                    }
-                });
-
-                // We do the assignment through this tricky return to ensure that the
-                // mutable reference to cursor.next we held as "mutref" above has been
-                // dropped, so we are not mutating `cursor` while a reference derived
-                // from it's provenance is live.
-                //
-                // We also can't early return inside the loop because all of the body
-                // is inside a closure.
-                //
-                // This might be overly cautious, refactor carefully (with miri).
-                let Some(n) = next else {
-                    // We're done, return
-                    return;
-                };
-                cursor = n;
-            }
-        }
-    }
-
-    /// Iterate through the items of the list, in sorted order
-    pub fn iter(&self) -> SortedListIter<'_, T> {
-        SortedListIter {
-            _plt: PhantomData,
-            node: self.head,
-        }
-    }
-}
-
-impl<T: Linked<Links<T>>> Extend<T::Handle> for SortedList<T> {
-    fn extend<I: IntoIterator<Item = T::Handle>>(&mut self, iter: I) {
-        for elem in iter {
-            self.insert(elem);
-        }
-    }
-}
-
-impl<T: Linked<Links<T>>> Drop for SortedList<T> {
-    fn drop(&mut self) {
-        // TODO: This is a hack. We just turn the list into a stack then run the
-        // stack drop code. It already has correct + tested logic for dropping
-        // a singly linked list of items one at a time.
-        let stack = Stack {
-            head: self.head.take(),
-        };
-        drop(stack);
-    }
-}
-
-/// A borrowing iterator of a [`SortedList`]
-#[derive(Debug)]
-pub struct SortedListIter<'a, T: Linked<Links<T>>> {
-    _plt: PhantomData<&'a SortedList<T>>,
-    node: Option<NonNull<T>>,
-}
-
-impl<'a, T: Linked<Links<T>>> Iterator for SortedListIter<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let nn = self.node.take()?;
-        unsafe {
-            // Advance our pointer to next
-            let links = T::links(nn).as_ref();
-            self.node = links.next.with(|t| *t);
-            Some(nn.as_ref())
-        }
-    }
-}
-
-// --------------------------------------------------------------------------
-// End of stuff that probably shouldn't live here
-// --------------------------------------------------------------------------
-
 #[cfg(test)]
 mod loom {
     use super::*;
@@ -861,56 +631,6 @@ mod loom {
             stack.push(Entry::new(3));
         })
     }
-
-    #[test]
-    fn slist_basic() {
-        loom::model(|| {
-            let mut slist = SortedList::<Entry>::new(|lhs, rhs| lhs.val.cmp(&rhs.val));
-            // Insert out of order
-            slist.insert(Entry::new(20));
-            slist.insert(Entry::new(10));
-            slist.insert(Entry::new(30));
-            slist.insert(Entry::new(25));
-            slist.insert(Entry::new(35));
-            slist.insert(Entry::new(1));
-            slist.insert(Entry::new(2));
-            slist.insert(Entry::new(3));
-            // expected is in order
-            let expected = [1, 2, 3, 10, 20, 25, 30, 35];
-
-            // Does iteration work (twice)?
-            {
-                let mut ct = 0;
-                let siter = slist.iter();
-                for (l, r) in expected.iter().zip(siter) {
-                    ct += 1;
-                    assert_eq!(*l, r.val);
-                }
-                assert_eq!(ct, expected.len());
-            }
-            {
-                let mut ct = 0;
-                let siter = slist.iter();
-                for (l, r) in expected.iter().zip(siter) {
-                    ct += 1;
-                    assert_eq!(*l, r.val);
-                }
-                assert_eq!(ct, expected.len());
-            }
-
-            // Does draining work (once)?
-            {
-                let mut ct = 0;
-                for exp in expected.iter() {
-                    let act = slist.pop_front().unwrap();
-                    ct += 1;
-                    assert_eq!(*exp, act.val);
-                }
-                assert_eq!(ct, expected.len());
-                assert!(slist.pop_front().is_none());
-            }
-        })
-    }
 }
 
 #[cfg(test)]
@@ -929,16 +649,16 @@ mod test {
 }
 
 #[cfg(test)]
-mod test_util {
+pub(crate) mod test_util {
     use super::*;
     use crate::loom::alloc;
     use core::pin::Pin;
 
     #[pin_project::pin_project]
-    pub(super) struct Entry {
+    pub(crate) struct Entry {
         #[pin]
         links: Links<Entry>,
-        pub(super) val: i32,
+        pub(crate) val: i32,
         track: alloc::Track<()>,
     }
 
@@ -973,7 +693,7 @@ mod test_util {
     }
 
     impl Entry {
-        pub(super) fn new(val: i32) -> Pin<Box<Entry>> {
+        pub(crate) fn new(val: i32) -> Pin<Box<Entry>> {
             Box::pin(Entry {
                 links: Links::new(),
                 val,

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -662,6 +662,29 @@ pub(crate) mod test_util {
         track: alloc::Track<()>,
     }
 
+    // ----------------------------------------------------------------------
+    // Helper impls for `sorted_list`
+    impl PartialEq for Entry {
+        fn eq(&self, other: &Self) -> bool {
+            self.val.eq(&other.val)
+        }
+    }
+
+    impl Eq for Entry {}
+
+    impl PartialOrd for Entry {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for Entry {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+            self.val.cmp(&other.val)
+        }
+    }
+    // ----------------------------------------------------------------------
+
     unsafe impl Linked<Links<Self>> for Entry {
         type Handle = Pin<Box<Entry>>;
 

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use core::{
     fmt,
-    marker::PhantomPinned,
+    marker::{PhantomData, PhantomPinned},
     ptr::{self, NonNull},
 };
 
@@ -135,7 +135,23 @@ where
     /// This takes ownership over `element` through its [owning `Handle`
     /// type](Linked::Handle). If the `TransferStack` is dropped before the
     /// pushed `element` is removed from the stack, the `element` will be dropped.
+    #[inline]
     pub fn push(&self, element: T::Handle) {
+        self.push_was_empty(element);
+    }
+
+    /// Pushes `element` onto the end of this `TransferStack`, taking ownership
+    /// of it. Returns `true` if the stack was previously empty (the previous
+    /// head was null).
+    ///
+    /// This is an *O*(1) operation, although it performs a compare-and-swap
+    /// loop that may repeat if another producer is concurrently calling `push`
+    /// on the same `TransferStack`.
+    ///
+    /// This takes ownership over `element` through its [owning `Handle`
+    /// type](Linked::Handle). If the `TransferStack` is dropped before the
+    /// pushed `element` is removed from the stack, the `element` will be dropped.
+    pub fn push_was_empty(&self, element: T::Handle) -> bool {
         let ptr = T::into_ptr(element);
         test_trace!(?ptr, "TransferStack::push");
         let links = unsafe { T::links(ptr).as_mut() };
@@ -152,9 +168,9 @@ where
                 .head
                 .compare_exchange_weak(head, ptr.as_ptr(), AcqRel, Acquire)
             {
-                Ok(_) => {
+                Ok(old) => {
                     test_trace!(?ptr, ?head, "TransferStack::push -> pushed");
-                    return;
+                    return old.is_null();
                 }
                 Err(actual) => head = actual,
             }
@@ -400,6 +416,245 @@ impl<T> Default for Links<T> {
     }
 }
 
+// --------------------------------------------------------------------------
+// This should live somewhere else, but for now it doesn't.
+// -AJM
+// --------------------------------------------------------------------------
+
+/// A sorted singly linked list
+///
+/// This behaves similar to [`Stack`], in that it is a singly linked list,
+/// however items are stored in an ordered fashion. This means that insertion
+/// is an O(n) operation, and retrieval of the first item is an O(1) operation.
+///
+/// It allows for a user selected ordering operation, see [`SortedList::new`]
+/// for usage example.
+#[derive(Debug)]
+pub struct SortedList<T: Linked<Links<T>>> {
+    head: Option<NonNull<T>>,
+    // Returns if LHS is less/same/greater than RHS
+    func: fn(&T, &T) -> core::cmp::Ordering,
+}
+
+impl<T: Linked<Links<T>>> SortedList<T> {
+    /// Create a new (empty) sorted list with the given ordering function
+    ///
+    /// If `T` contained an `i32`, and you wanted the SMALLEST items at the
+    /// front, then you could provide a function something like:
+    ///
+    /// ```rust
+    /// let f: fn(&i32, &i32) -> core::cmp::Ordering = |lhs, rhs| {
+    ///     lhs.cmp(rhs)
+    /// };
+    /// ```
+    ///
+    /// SortedList takes a function (and not just [Ord]) so you can use it on types
+    /// that don't have a general way of ordering them, allowing you to select a
+    /// specific metric within the sorting function.
+    ///
+    /// If two items are considered of equal value, new values will be placed AFTER
+    /// old values.
+    pub const fn new(f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+        Self {
+            func: f,
+            head: None,
+        }
+    }
+
+    /// Create a new sorted list, consuming the stack, using the provided ordering function
+    pub fn from_stack(stack: Stack<T>, f: fn(&T, &T) -> core::cmp::Ordering) -> Self {
+        let mut slist = Self::new(f);
+        slist.extend(stack);
+        slist
+    }
+
+    /// Pop the front-most item from the list, returning it by ownership (if it exists)
+    #[must_use]
+    pub fn pop_front(&mut self) -> Option<T::Handle> {
+        test_trace!(?self.head, "SortedList::pop_front");
+        let head = self.head.take()?;
+        unsafe {
+            // Safety: we have exclusive ownership over this chunk of stack.
+
+            // advance the head link to the next node after the current one (if
+            // there is one).
+            self.head = T::links(head).as_mut().next.with_mut(|next| (*next).take());
+
+            test_trace!(?self.head, "SortedList::pop -> popped");
+
+            // return the current node
+            Some(T::from_ptr(head))
+        }
+    }
+
+    /// Insert a single item into the list, in it's sorted order position
+    pub fn insert(&mut self, element: T::Handle) {
+        let ptr = T::into_ptr(element);
+        test_trace!(?ptr, ?self.head, "SortedList::insert");
+
+        // Take a long-lived reference to the new element
+        let eref = unsafe { ptr.as_ref() };
+
+        // Special case for empty head
+        //
+        // If the head is null, then just place the item
+        let Some(mut cursor) = self.head else {
+            // todo: assert element.next is null?
+            self.head = Some(ptr);
+            return;
+        };
+
+        // Special case for head: do we replace current head with new element?
+        {
+            // compare, but make sure we drop the live reference to the cursor
+            let cmp = {
+                let cref = unsafe { cursor.as_ref() };
+                (self.func)(cref, eref)
+            };
+
+            // If cursor node is LESS or EQUAL: keep moving.
+            // If cursor node is GREATER: we need to place the new item BEFORE
+            if cmp == core::cmp::Ordering::Greater {
+                unsafe {
+                    let links = T::links(ptr).as_mut();
+                    links.next.with_mut(|next| {
+                        // ensure that `element`'s next is null
+                        debug_assert!((*next).is_none());
+                        *next = self.head.replace(ptr);
+                    });
+                    return;
+                }
+            }
+        }
+
+        // On every iteration of the loop, we know that the new element should
+        // be placed AFTER the current value of `cursor`, meaning that we need
+        // to decide whether we:
+        //
+        // * just append (if next is null)
+        // * insert between cursor and cursor.next (if elem is < c.next)
+        // * just iterate (if elem >= c.next)
+        loop {
+            // SAFETY: We have exclusive access to the list, we are allowed to
+            // access and mutate it (carefully)
+            unsafe {
+                // Get the cursor's links
+                let clinks = T::links(cursor).as_mut();
+                // Peek into the cursor's next item
+                let next = clinks.next.with_mut(|next| {
+                    // We can take a reference here, as we have exclusive access
+                    let mutref = &mut *next;
+
+                    if let Some(n) = mutref {
+                        // If next is some, store this pointer
+                        let nptr: NonNull<T> = *n;
+                        // Then compare the next element with the new element
+                        let cmp = {
+                            let nref: &T = nptr.as_ref();
+                            (self.func)(nref, eref)
+                        };
+
+                        if cmp == core::cmp::Ordering::Greater {
+                            // As above, if cursor.next > element, then we
+                            // need to insert between cursor and next.
+                            //
+                            // First, get the current element's links...
+                            let elinks = T::links(ptr).as_mut();
+                            // ...then store cursor.next.next in element.next,
+                            // and store element in cursor.next.
+                            elinks.next.with_mut(|enext| {
+                                *enext = mutref.replace(ptr);
+                            });
+                            // If we have placed element, there is no next value
+                            // for cursor.
+                            None
+                        } else {
+                            // If cursor.next <= element, then we just need to
+                            // iterate, so return the NonNull that represents
+                            // cursor.next, so we can move cursor there.
+                            Some(nptr)
+                        }
+                    } else {
+                        // "just append" case - assign element to cursor.next
+                        *mutref = Some(ptr);
+                        // If we have placed element, there is no next value
+                        // for cursor
+                        None
+                    }
+                });
+
+                // We do the assignment through this tricky return to ensure that the
+                // mutable reference to cursor.next we held as "mutref" above has been
+                // dropped, so we are not mutating `cursor` while a reference derived
+                // from it's provenance is live.
+                //
+                // We also can't early return inside the loop because all of the body
+                // is inside a closure.
+                //
+                // This might be overly cautious, refactor carefully (with miri).
+                let Some(n) = next else {
+                    // We're done, return
+                    return;
+                };
+                cursor = n;
+            }
+        }
+    }
+
+    /// Iterate through the items of the list, in sorted order
+    pub fn iter(&self) -> SortedListIter<'_, T> {
+        SortedListIter {
+            _plt: PhantomData,
+            node: self.head,
+        }
+    }
+}
+
+impl<T: Linked<Links<T>>> Extend<T::Handle> for SortedList<T> {
+    fn extend<I: IntoIterator<Item = T::Handle>>(&mut self, iter: I) {
+        for elem in iter {
+            self.insert(elem);
+        }
+    }
+}
+
+impl<T: Linked<Links<T>>> Drop for SortedList<T> {
+    fn drop(&mut self) {
+        // TODO: This is a hack. We just turn the list into a stack then run the
+        // stack drop code. It already has correct + tested logic for dropping
+        // a singly linked list of items one at a time.
+        let stack = Stack {
+            head: self.head.take(),
+        };
+        drop(stack);
+    }
+}
+
+/// A borrowing iterator of a [`SortedList`]
+#[derive(Debug)]
+pub struct SortedListIter<'a, T: Linked<Links<T>>> {
+    _plt: PhantomData<&'a SortedList<T>>,
+    node: Option<NonNull<T>>,
+}
+
+impl<'a, T: Linked<Links<T>>> Iterator for SortedListIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let nn = self.node.take()?;
+        unsafe {
+            // Advance our pointer to next
+            let links = T::links(nn).as_ref();
+            self.node = links.next.with(|t| *t);
+            Some(nn.as_ref())
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// End of stuff that probably shouldn't live here
+// --------------------------------------------------------------------------
+
 #[cfg(test)]
 mod loom {
     use super::*;
@@ -604,6 +859,56 @@ mod loom {
             stack.push(Entry::new(1));
             stack.push(Entry::new(2));
             stack.push(Entry::new(3));
+        })
+    }
+
+    #[test]
+    fn slist_basic() {
+        loom::model(|| {
+            let mut slist = SortedList::<Entry>::new(|lhs, rhs| lhs.val.cmp(&rhs.val));
+            // Insert out of order
+            slist.insert(Entry::new(20));
+            slist.insert(Entry::new(10));
+            slist.insert(Entry::new(30));
+            slist.insert(Entry::new(25));
+            slist.insert(Entry::new(35));
+            slist.insert(Entry::new(1));
+            slist.insert(Entry::new(2));
+            slist.insert(Entry::new(3));
+            // expected is in order
+            let expected = [1, 2, 3, 10, 20, 25, 30, 35];
+
+            // Does iteration work (twice)?
+            {
+                let mut ct = 0;
+                let siter = slist.iter();
+                for (l, r) in expected.iter().zip(siter) {
+                    ct += 1;
+                    assert_eq!(*l, r.val);
+                }
+                assert_eq!(ct, expected.len());
+            }
+            {
+                let mut ct = 0;
+                let siter = slist.iter();
+                for (l, r) in expected.iter().zip(siter) {
+                    ct += 1;
+                    assert_eq!(*l, r.val);
+                }
+                assert_eq!(ct, expected.len());
+            }
+
+            // Does draining work (once)?
+            {
+                let mut ct = 0;
+                for exp in expected.iter() {
+                    let act = slist.pop_front().unwrap();
+                    ct += 1;
+                    assert_eq!(*exp, act.val);
+                }
+                assert_eq!(ct, expected.len());
+                assert!(slist.pop_front().is_none());
+            }
         })
     }
 }


### PR DESCRIPTION
This PR implements:

* A new method for `TransferStack` that reports whether the list was previously empty
* A new type, `SortedList`, that is a sorted singly-linked-list

These are changes I am making for experimentation with embassy's scheduler, which I am using `cordyceps` for.

These changes are currently functional and minimally tested, but probably could use tweaks to better fit naturally in the library.