### PR TITLE
feat(cordyceps): Initial support for non-CAS targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,17 @@ jobs:
     name: no-atomics compat (cordyceps)
     steps:
     - name: install rust toolchain
-      run: |
-        rustup show
-        rustup target add thumbv6m-none-eabi
+      run: rustup show
     - uses: actions/checkout@v4
     - name: run check
-      run: cargo check -p cordyceps --target thumbv6m-none-eabi
+      # we add the target HERE instead of in the 'install rust toolchain' step
+      # because we need the `rust-toolchain.toml` file to be checked out, otherwise
+      # the target is only added for `stable`. We could also add this to the
+      # `targets` item in the toolchain file, but that would be a waste for all
+      # other tests.
+      run: |
+        rustup target add thumbv6m-none-eabi
+        cargo check -p cordyceps --target thumbv6m-none-eabi
 
   ### maitake ###
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,21 @@ jobs:
     - name: run Miri tests
       run: just miri cordyceps
 
+  # run no-atomics target tests
+  cordyceps_no_atomics_compat:
+    needs: changed_paths
+    if: needs.changed_paths.outputs.should_skip != 'true' || !fromJSON(needs.changed_paths.outputs.paths_result).cordyceps.should_skip
+    runs-on: ubuntu-latest
+    name: no-atomics compat (cordyceps)
+    steps:
+    - name: install rust toolchain
+      run: |
+        rustup show
+        rustup target add thumbv6m-none-eabi
+    - uses: actions/checkout@v4
+    - name: run check
+      run: cargo check -p cordyceps --target thumbv6m-none-eabi
+
   ### maitake ###
 
   # test with `--no-default-features`
@@ -313,6 +328,7 @@ jobs:
     - docs
     - cordyceps_loom
     - cordyceps_miri
+    - cordyceps_no_atomics_compat
     - maitake_no_default_features
     - maitake_loom
     - maitake_miri

--- a/cordyceps/README.md
+++ b/cordyceps/README.md
@@ -86,6 +86,21 @@ than owning those values.
   *must* be pinned in memory; they may not move (or be dropped) while linked
   into an intrusive collection.
 
+## Compatibility
+
+Rudimentary support for targets without CAS (Compare and Swap) atomics, such as
+Cortex-M0+/`thumbv6m-none-eabi`, is provided, however not all structures and
+features may be available.
+
+CAS atomic support is automatically detected with `cfg(target_has_atomic = "ptr")`,
+which notes that a [platform has support] for both load/store operations as well
+as support for CAS atomics.
+
+No crate-level features are necessary to enable/disable structures that require
+CAS atomics.
+
+[platform has support]: https://doc.rust-lang.org/reference/conditional-compilation.html#r-cfg.target_has_atomic
+
 ## about the name
 
 In keeping with Mycelium's fungal naming theme, _Cordyceps_ is a genus of

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -68,18 +68,23 @@ extern crate std;
 pub(crate) mod util;
 
 pub mod list;
+#[cfg(target_has_atomic="ptr")]
 pub mod mpsc_queue;
 pub mod sorted_list;
 pub mod stack;
 
 #[doc(inline)]
 pub use list::List;
+#[cfg(target_has_atomic="ptr")]
 #[doc(inline)]
 pub use mpsc_queue::MpscQueue;
 #[doc(inline)]
 pub use sorted_list::{SortedList, SortedListIter};
 #[doc(inline)]
-pub use stack::{Stack, TransferStack};
+pub use stack::Stack;
+#[cfg(target_has_atomic="ptr")]
+#[doc(inline)]
+pub use stack::TransferStack;
 
 pub(crate) mod loom;
 

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -34,6 +34,9 @@
 //!   [`MpscQueue`]s can be used to efficiently share data from multiple
 //!   concurrent producers with a consumer.
 //!
+//!   This structure is only available if the target supports CAS (Compare and
+//!   Swap) atomics.
+//!
 //! - **[`Stack`]: a mutable, singly-linked first-in, first-out (FIFO)
 //!   stack.**
 //!
@@ -59,6 +62,9 @@
 //!   A [`TransferStack`] can be used to efficiently transfer ownership of
 //!   resources from multiple producers to a consumer, such as for reuse or
 //!   cleanup.
+//!
+//!   This structure is only available if the target supports CAS (Compare and
+//!   Swap) atomics.
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(test)]
@@ -68,21 +74,26 @@ extern crate std;
 pub(crate) mod util;
 
 pub mod list;
-#[cfg(target_has_atomic="ptr")]
-pub mod mpsc_queue;
 pub mod sorted_list;
 pub mod stack;
 
 #[doc(inline)]
 pub use list::List;
-#[cfg(target_has_atomic="ptr")]
-#[doc(inline)]
-pub use mpsc_queue::MpscQueue;
 #[doc(inline)]
 pub use sorted_list::{SortedList, SortedListIter};
 #[doc(inline)]
 pub use stack::Stack;
-#[cfg(target_has_atomic="ptr")]
+
+//
+// The following items are only available if we have atomics
+//
+#[cfg(target_has_atomic = "ptr")]
+pub mod mpsc_queue;
+
+#[cfg(target_has_atomic = "ptr")]
+#[doc(inline)]
+pub use mpsc_queue::MpscQueue;
+#[cfg(target_has_atomic = "ptr")]
 #[doc(inline)]
 pub use stack::TransferStack;
 

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -65,12 +65,6 @@
 //!
 //!   This structure is only available if the target supports CAS (Compare and
 //!   Swap) atomics.
-//!
-//! ## Compatibility
-//!
-//! Rudimentary support for targets without CAS (Compare and Swap) atomics, such as
-//! Cortex-M0+/`thumbv6m-none-eabi`, is provided, however not all structures and
-//! features may be available.
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(test)]
@@ -97,11 +91,16 @@ pub use stack::Stack;
 pub mod mpsc_queue;
 
 #[cfg(target_has_atomic = "ptr")]
-#[doc(inline)]
-pub use mpsc_queue::MpscQueue;
+pub use has_cas_atomics::*;
+
 #[cfg(target_has_atomic = "ptr")]
-#[doc(inline)]
-pub use stack::TransferStack;
+mod has_cas_atomics {
+    #[doc(inline)]
+    pub use crate::mpsc_queue::MpscQueue;
+
+    #[doc(inline)]
+    pub use crate::stack::TransferStack;
+}
 
 pub(crate) mod loom;
 

--- a/cordyceps/src/lib.rs
+++ b/cordyceps/src/lib.rs
@@ -65,6 +65,12 @@
 //!
 //!   This structure is only available if the target supports CAS (Compare and
 //!   Swap) atomics.
+//!
+//! ## Compatibility
+//!
+//! Rudimentary support for targets without CAS (Compare and Swap) atomics, such as
+//! Cortex-M0+/`thumbv6m-none-eabi`, is provided, however not all structures and
+//! features may be available.
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(test)]

--- a/cordyceps/src/mpsc_queue.rs
+++ b/cordyceps/src/mpsc_queue.rs
@@ -21,6 +21,18 @@ use core::{
     ptr::{self, NonNull},
 };
 
+macro_rules! feature {
+    (
+        #![$meta:meta]
+        $($item:item)*
+    ) => {
+        $(
+            #[cfg($meta)]
+            $item
+        )*
+    }
+}
+
 /// A multi-producer, single-consumer (MPSC) queue, implemented using a
 /// lock-free [intrusive] singly-linked list.
 ///

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -6,58 +6,191 @@
 //! [intrusive]: crate#intrusive-data-structures
 #![warn(missing_debug_implementations)]
 
-#[cfg(target_has_atomic = "ptr")]
-use crate::loom::sync::atomic::{AtomicPtr, Ordering::*};
 use crate::{loom::cell::UnsafeCell, Linked};
-#[cfg(target_has_atomic = "ptr")]
-use core::ptr;
 use core::{fmt, marker::PhantomPinned, ptr::NonNull};
 
-/// An [intrusive] lock-free singly-linked FIFO stack, where all entries
-/// currently in the stack are consumed in a single atomic operation.
-///
-/// A transfer stack is perhaps the world's simplest lock-free concurrent data
-/// structure. It provides two primary operations:
-///
-/// - [`TransferStack::push`], which appends an element to the end of the
-///   transfer stack,
-///
-/// - [`TransferStack::take_all`], which atomically takes all elements currently
-///   on the transfer stack and returns them as a new mutable [`Stack`].
-///
-/// These are both *O*(1) operations, although `push` performs a
-/// compare-and-swap loop that may be retried if another producer concurrently
-/// pushed an element.
-///
-/// In order to be part of a `TransferStack`, a type `T` must implement
-/// the [`Linked`] trait for [`stack::Links<T>`](Links).
-///
-/// Pushing elements into a `TransferStack` takes ownership of those elements
-/// through an owning [`Handle` type](Linked::Handle). Dropping a
-/// [`TransferStack`] drops all elements currently linked into the stack.
-///
-/// A transfer stack is often useful in cases where a large number of resources
-/// must be efficiently transferred from several producers to a consumer, such
-/// as for reuse or cleanup. For example, a [`TransferStack`] can be used as the
-/// "thread" (shared) free list in a [`mimalloc`-style sharded
-/// allocator][mimalloc], with a mutable [`Stack`] used as the local
-/// (unsynchronized) free list. When an allocation is freed from the same CPU
-/// core that it was allocated on, it is pushed to the local free list, using an
-/// unsynchronized mutable [`Stack::push`] operation. If an allocation is freed
-/// from a different thread, it is instead pushed to that thread's shared free
-/// list, a [`TransferStack`], using an atomic [`TransferStack::push`]
-/// operation. New allocations are popped from the local unsynchronized free
-/// list, and if the local free list is empty, the entire shared free list is
-/// moved onto the local free list. This allows objects which do not leave the
-/// CPU core they were allocated on to be both allocated and deallocated using
-/// unsynchronized operations, and new allocations only perform an atomic
-/// operation when the local free list is empty.
-///
-/// [intrusive]: crate#intrusive-data-structures
-/// [mimalloc]: https://www.microsoft.com/en-us/research/uploads/prod/2019/06/mimalloc-tr-v1.pdf
 #[cfg(target_has_atomic = "ptr")]
-pub struct TransferStack<T: Linked<Links<T>>> {
-    head: AtomicPtr<T>,
+pub use has_cas_atomics::*;
+
+/// Items exclusive to targets with CAS atomics
+#[cfg(target_has_atomic = "ptr")]
+mod has_cas_atomics {
+    use core::{
+        fmt,
+        ptr::{self, NonNull},
+        sync::atomic::{AtomicPtr, Ordering::*},
+    };
+
+    use crate::Linked;
+
+    use super::{Links, Stack};
+
+    /// An [intrusive] lock-free singly-linked FIFO stack, where all entries
+    /// currently in the stack are consumed in a single atomic operation.
+    ///
+    /// A transfer stack is perhaps the world's simplest lock-free concurrent data
+    /// structure. It provides two primary operations:
+    ///
+    /// - [`TransferStack::push`], which appends an element to the end of the
+    ///   transfer stack,
+    ///
+    /// - [`TransferStack::take_all`], which atomically takes all elements currently
+    ///   on the transfer stack and returns them as a new mutable [`Stack`].
+    ///
+    /// These are both *O*(1) operations, although `push` performs a
+    /// compare-and-swap loop that may be retried if another producer concurrently
+    /// pushed an element.
+    ///
+    /// In order to be part of a `TransferStack`, a type `T` must implement
+    /// the [`Linked`] trait for [`stack::Links<T>`](Links).
+    ///
+    /// Pushing elements into a `TransferStack` takes ownership of those elements
+    /// through an owning [`Handle` type](Linked::Handle). Dropping a
+    /// [`TransferStack`] drops all elements currently linked into the stack.
+    ///
+    /// A transfer stack is often useful in cases where a large number of resources
+    /// must be efficiently transferred from several producers to a consumer, such
+    /// as for reuse or cleanup. For example, a [`TransferStack`] can be used as the
+    /// "thread" (shared) free list in a [`mimalloc`-style sharded
+    /// allocator][mimalloc], with a mutable [`Stack`] used as the local
+    /// (unsynchronized) free list. When an allocation is freed from the same CPU
+    /// core that it was allocated on, it is pushed to the local free list, using an
+    /// unsynchronized mutable [`Stack::push`] operation. If an allocation is freed
+    /// from a different thread, it is instead pushed to that thread's shared free
+    /// list, a [`TransferStack`], using an atomic [`TransferStack::push`]
+    /// operation. New allocations are popped from the local unsynchronized free
+    /// list, and if the local free list is empty, the entire shared free list is
+    /// moved onto the local free list. This allows objects which do not leave the
+    /// CPU core they were allocated on to be both allocated and deallocated using
+    /// unsynchronized operations, and new allocations only perform an atomic
+    /// operation when the local free list is empty.
+    ///
+    /// [intrusive]: crate#intrusive-data-structures
+    /// [mimalloc]: https://www.microsoft.com/en-us/research/uploads/prod/2019/06/mimalloc-tr-v1.pdf
+    pub struct TransferStack<T: Linked<Links<T>>> {
+        head: AtomicPtr<T>,
+    }
+
+    // === impl TransferStack ===
+    impl<T> TransferStack<T>
+    where
+        T: Linked<Links<T>>,
+    {
+        /// Returns a new `TransferStack` with no elements.
+        #[cfg(not(loom))]
+        #[must_use]
+        pub const fn new() -> Self {
+            Self {
+                head: AtomicPtr::new(ptr::null_mut()),
+            }
+        }
+
+        /// Returns a new `TransferStack` with no elements.
+        #[cfg(loom)]
+        #[must_use]
+        pub fn new() -> Self {
+            Self {
+                head: AtomicPtr::new(ptr::null_mut()),
+            }
+        }
+
+        /// Pushes `element` onto the end of this `TransferStack`, taking ownership
+        /// of it.
+        ///
+        /// This is an *O*(1) operation, although it performs a compare-and-swap
+        /// loop that may repeat if another producer is concurrently calling `push`
+        /// on the same `TransferStack`.
+        ///
+        /// This takes ownership over `element` through its [owning `Handle`
+        /// type](Linked::Handle). If the `TransferStack` is dropped before the
+        /// pushed `element` is removed from the stack, the `element` will be dropped.
+        #[inline]
+        pub fn push(&self, element: T::Handle) {
+            self.push_was_empty(element);
+        }
+
+        /// Pushes `element` onto the end of this `TransferStack`, taking ownership
+        /// of it. Returns `true` if the stack was previously empty (the previous
+        /// head was null).
+        ///
+        /// This is an *O*(1) operation, although it performs a compare-and-swap
+        /// loop that may repeat if another producer is concurrently calling `push`
+        /// on the same `TransferStack`.
+        ///
+        /// This takes ownership over `element` through its [owning `Handle`
+        /// type](Linked::Handle). If the `TransferStack` is dropped before the
+        /// pushed `element` is removed from the stack, the `element` will be dropped.
+        pub fn push_was_empty(&self, element: T::Handle) -> bool {
+            let ptr = T::into_ptr(element);
+            test_trace!(?ptr, "TransferStack::push");
+            let links = unsafe { T::links(ptr).as_mut() };
+            debug_assert!(links.next.with(|next| unsafe { (*next).is_none() }));
+
+            let mut head = self.head.load(Relaxed);
+            loop {
+                test_trace!(?ptr, ?head, "TransferStack::push");
+                links.next.with_mut(|next| unsafe {
+                    *next = NonNull::new(head);
+                });
+
+                match self
+                    .head
+                    .compare_exchange_weak(head, ptr.as_ptr(), AcqRel, Acquire)
+                {
+                    Ok(old) => {
+                        let was_empty = old.is_null();
+                        test_trace!(?ptr, ?head, was_empty, "TransferStack::push -> pushed");
+                        return was_empty;
+                    }
+                    Err(actual) => head = actual,
+                }
+            }
+        }
+
+        /// Takes all elements *currently* in this `TransferStack`, returning a new
+        /// mutable [`Stack`] containing those elements.
+        ///
+        /// This is an *O*(1) operation which does not allocate memory. It will
+        /// never loop and does not spin.
+        #[must_use]
+        pub fn take_all(&self) -> Stack<T> {
+            let head = self.head.swap(ptr::null_mut(), AcqRel);
+            let head = NonNull::new(head);
+            Stack { head }
+        }
+    }
+
+    impl<T> Drop for TransferStack<T>
+    where
+        T: Linked<Links<T>>,
+    {
+        fn drop(&mut self) {
+            // The stack owns any entries that are still in the stack; ensure they
+            // are dropped before dropping the stack.
+            for entry in self.take_all() {
+                drop(entry);
+            }
+        }
+    }
+
+    impl<T> fmt::Debug for TransferStack<T>
+    where
+        T: Linked<Links<T>>,
+    {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let Self { head } = self;
+            f.debug_struct("TransferStack").field("head", head).finish()
+        }
+    }
+
+    impl<T> Default for TransferStack<T>
+    where
+        T: Linked<Links<T>>,
+    {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
 }
 
 /// An [intrusive] singly-linked mutable FIFO stack.
@@ -102,131 +235,6 @@ pub struct Links<T> {
     /// never recieve LLVM `noalias` annotations; see also
     /// <https://github.com/rust-lang/rust/issues/63818>.
     _unpin: PhantomPinned,
-}
-
-// === impl TransferStack ===
-#[cfg(target_has_atomic = "ptr")]
-impl<T> TransferStack<T>
-where
-    T: Linked<Links<T>>,
-{
-    /// Returns a new `TransferStack` with no elements.
-    #[cfg(not(loom))]
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            head: AtomicPtr::new(ptr::null_mut()),
-        }
-    }
-
-    /// Returns a new `TransferStack` with no elements.
-    #[cfg(loom)]
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            head: AtomicPtr::new(ptr::null_mut()),
-        }
-    }
-
-    /// Pushes `element` onto the end of this `TransferStack`, taking ownership
-    /// of it.
-    ///
-    /// This is an *O*(1) operation, although it performs a compare-and-swap
-    /// loop that may repeat if another producer is concurrently calling `push`
-    /// on the same `TransferStack`.
-    ///
-    /// This takes ownership over `element` through its [owning `Handle`
-    /// type](Linked::Handle). If the `TransferStack` is dropped before the
-    /// pushed `element` is removed from the stack, the `element` will be dropped.
-    #[inline]
-    pub fn push(&self, element: T::Handle) {
-        self.push_was_empty(element);
-    }
-
-    /// Pushes `element` onto the end of this `TransferStack`, taking ownership
-    /// of it. Returns `true` if the stack was previously empty (the previous
-    /// head was null).
-    ///
-    /// This is an *O*(1) operation, although it performs a compare-and-swap
-    /// loop that may repeat if another producer is concurrently calling `push`
-    /// on the same `TransferStack`.
-    ///
-    /// This takes ownership over `element` through its [owning `Handle`
-    /// type](Linked::Handle). If the `TransferStack` is dropped before the
-    /// pushed `element` is removed from the stack, the `element` will be dropped.
-    pub fn push_was_empty(&self, element: T::Handle) -> bool {
-        let ptr = T::into_ptr(element);
-        test_trace!(?ptr, "TransferStack::push");
-        let links = unsafe { T::links(ptr).as_mut() };
-        debug_assert!(links.next.with(|next| unsafe { (*next).is_none() }));
-
-        let mut head = self.head.load(Relaxed);
-        loop {
-            test_trace!(?ptr, ?head, "TransferStack::push");
-            links.next.with_mut(|next| unsafe {
-                *next = NonNull::new(head);
-            });
-
-            match self
-                .head
-                .compare_exchange_weak(head, ptr.as_ptr(), AcqRel, Acquire)
-            {
-                Ok(old) => {
-                    let was_empty = old.is_null();
-                    test_trace!(?ptr, ?head, was_empty, "TransferStack::push -> pushed");
-                    return was_empty;
-                }
-                Err(actual) => head = actual,
-            }
-        }
-    }
-
-    /// Takes all elements *currently* in this `TransferStack`, returning a new
-    /// mutable [`Stack`] containing those elements.
-    ///
-    /// This is an *O*(1) operation which does not allocate memory. It will
-    /// never loop and does not spin.
-    #[must_use]
-    pub fn take_all(&self) -> Stack<T> {
-        let head = self.head.swap(ptr::null_mut(), AcqRel);
-        let head = NonNull::new(head);
-        Stack { head }
-    }
-}
-
-#[cfg(target_has_atomic = "ptr")]
-impl<T> Drop for TransferStack<T>
-where
-    T: Linked<Links<T>>,
-{
-    fn drop(&mut self) {
-        // The stack owns any entries that are still in the stack; ensure they
-        // are dropped before dropping the stack.
-        for entry in self.take_all() {
-            drop(entry);
-        }
-    }
-}
-
-#[cfg(target_has_atomic = "ptr")]
-impl<T> fmt::Debug for TransferStack<T>
-where
-    T: Linked<Links<T>>,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { head } = self;
-        f.debug_struct("TransferStack").field("head", head).finish()
-    }
-}
-
-#[cfg(target_has_atomic = "ptr")]
-impl<T> Default for TransferStack<T>
-where
-    T: Linked<Links<T>>,
-{
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 // === impl Stack ===
@@ -651,6 +659,7 @@ pub(crate) mod test_util {
     use super::*;
     use crate::loom::alloc;
     use core::pin::Pin;
+    use core::ptr;
 
     #[pin_project::pin_project]
     pub(crate) struct Entry {

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -7,17 +7,18 @@
 #![warn(missing_debug_implementations)]
 
 use crate::{
-    loom::{
-        cell::UnsafeCell,
-        sync::atomic::{AtomicPtr, Ordering::*},
-    },
+    loom::cell::UnsafeCell,
     Linked,
 };
 use core::{
     fmt,
     marker::PhantomPinned,
-    ptr::{self, NonNull},
+    ptr::NonNull,
 };
+#[cfg(target_has_atomic="ptr")]
+use crate::loom::sync::atomic::{AtomicPtr, Ordering::*};
+#[cfg(target_has_atomic="ptr")]
+use core::ptr;
 
 /// An [intrusive] lock-free singly-linked FIFO stack, where all entries
 /// currently in the stack are consumed in a single atomic operation.
@@ -61,6 +62,7 @@ use core::{
 ///
 /// [intrusive]: crate#intrusive-data-structures
 /// [mimalloc]: https://www.microsoft.com/en-us/research/uploads/prod/2019/06/mimalloc-tr-v1.pdf
+#[cfg(target_has_atomic="ptr")]
 pub struct TransferStack<T: Linked<Links<T>>> {
     head: AtomicPtr<T>,
 }
@@ -110,7 +112,7 @@ pub struct Links<T> {
 }
 
 // === impl AtomicStack ===
-
+#[cfg(target_has_atomic="ptr")]
 impl<T> TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -199,6 +201,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic="ptr")]
 impl<T> Drop for TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -212,6 +215,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic="ptr")]
 impl<T> fmt::Debug for TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -222,6 +226,7 @@ where
     }
 }
 
+#[cfg(target_has_atomic="ptr")]
 impl<T> Default for TransferStack<T>
 where
     T: Linked<Links<T>>,

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -6,19 +6,12 @@
 //! [intrusive]: crate#intrusive-data-structures
 #![warn(missing_debug_implementations)]
 
-use crate::{
-    loom::cell::UnsafeCell,
-    Linked,
-};
-use core::{
-    fmt,
-    marker::PhantomPinned,
-    ptr::NonNull,
-};
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 use crate::loom::sync::atomic::{AtomicPtr, Ordering::*};
-#[cfg(target_has_atomic="ptr")]
+use crate::{loom::cell::UnsafeCell, Linked};
+#[cfg(target_has_atomic = "ptr")]
 use core::ptr;
+use core::{fmt, marker::PhantomPinned, ptr::NonNull};
 
 /// An [intrusive] lock-free singly-linked FIFO stack, where all entries
 /// currently in the stack are consumed in a single atomic operation.
@@ -62,7 +55,7 @@ use core::ptr;
 ///
 /// [intrusive]: crate#intrusive-data-structures
 /// [mimalloc]: https://www.microsoft.com/en-us/research/uploads/prod/2019/06/mimalloc-tr-v1.pdf
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 pub struct TransferStack<T: Linked<Links<T>>> {
     head: AtomicPtr<T>,
 }
@@ -112,7 +105,7 @@ pub struct Links<T> {
 }
 
 // === impl AtomicStack ===
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -201,7 +194,7 @@ where
     }
 }
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> Drop for TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -215,7 +208,7 @@ where
     }
 }
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> fmt::Debug for TransferStack<T>
 where
     T: Linked<Links<T>>,
@@ -226,7 +219,7 @@ where
     }
 }
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl<T> Default for TransferStack<T>
 where
     T: Linked<Links<T>>,

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -104,7 +104,7 @@ pub struct Links<T> {
     _unpin: PhantomPinned,
 }
 
-// === impl AtomicStack ===
+// === impl TransferStack ===
 #[cfg(target_has_atomic = "ptr")]
 impl<T> TransferStack<T>
 where

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -18,10 +18,12 @@ mod has_cas_atomics {
     use core::{
         fmt,
         ptr::{self, NonNull},
-        sync::atomic::{AtomicPtr, Ordering::*},
     };
 
-    use crate::Linked;
+    use crate::{
+        loom::sync::atomic::{AtomicPtr, Ordering::*},
+        Linked,
+    };
 
     use super::{Links, Stack};
 

--- a/cordyceps/src/util.rs
+++ b/cordyceps/src/util.rs
@@ -1,18 +1,109 @@
-use core::{
-    fmt,
-    ops::{Deref, DerefMut},
-};
+use core::fmt;
 
 #[cfg(target_has_atomic = "ptr")]
-macro_rules! feature {
-    (
-        #![$meta:meta]
-        $($item:item)*
-    ) => {
-        $(
-            #[cfg($meta)]
-            $item
-        )*
+pub(crate) use has_cas_atomics::*;
+
+#[cfg(target_has_atomic = "ptr")]
+mod has_cas_atomics {
+    use core::{
+        fmt,
+        ops::{Deref, DerefMut},
+    };
+
+    /// An exponential backoff for spin loops
+    #[derive(Debug, Clone)]
+    pub(crate) struct Backoff {
+        exp: u8,
+        max: u8,
+    }
+
+    pub(crate) use cache_pad::CachePadded;
+
+    /// When configured not to pad to cache alignment, just provide a no-op wrapper struct
+    /// This feature is useful for platforms with no data cache, such as many Cortex-M
+    /// targets.
+    #[cfg(feature = "no-cache-pad")]
+    mod cache_pad {
+        #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
+        pub(crate) struct CachePadded<T>(pub(crate) T);
+    }
+
+    /// When not inhibited, determine cache alignment based on target architecture.
+    /// Align to 128 bytes on 64-bit x86/ARM targets, otherwise align to 64 bytes.
+    #[cfg(not(feature = "no-cache-pad"))]
+    mod cache_pad {
+        #[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(align(128)))]
+        #[cfg_attr(
+            not(any(target_arch = "x86_64", target_arch = "aarch64")),
+            repr(align(64))
+        )]
+        #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
+        pub(crate) struct CachePadded<T>(pub(crate) T);
+    }
+
+    // === impl Backoff ===
+
+    impl Backoff {
+        pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
+
+        pub(crate) const fn new() -> Self {
+            Self {
+                exp: 0,
+                max: Self::DEFAULT_MAX_EXPONENT,
+            }
+        }
+
+        /// Returns a new exponential backoff with the provided max exponent.
+        #[allow(dead_code)]
+        pub(crate) fn with_max_exponent(max: u8) -> Self {
+            assert!(max <= Self::DEFAULT_MAX_EXPONENT);
+            Self { exp: 0, max }
+        }
+
+        /// Perform one spin, squarin the backoff
+        #[inline(always)]
+        pub(crate) fn spin(&mut self) {
+            use crate::loom::hint;
+
+            // Issue 2^exp pause instructions.
+            for _ in 0..(1 << self.exp) {
+                hint::spin_loop();
+            }
+
+            if self.exp < self.max {
+                self.exp += 1
+            }
+        }
+    }
+
+    impl Default for Backoff {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    // === impl CachePadded ===
+
+    impl<T> Deref for CachePadded<T> {
+        type Target = T;
+
+        #[inline]
+        fn deref(&self) -> &T {
+            &self.0
+        }
+    }
+
+    impl<T> DerefMut for CachePadded<T> {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut T {
+            &mut self.0
+        }
+    }
+
+    impl<T: fmt::Debug> fmt::Debug for CachePadded<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.0.fmt(f)
+        }
     }
 }
 
@@ -23,110 +114,9 @@ macro_rules! test_trace {
     }
 }
 
-/// An exponential backoff for spin loops
-#[cfg(target_has_atomic = "ptr")]
-#[derive(Debug, Clone)]
-pub(crate) struct Backoff {
-    exp: u8,
-    max: u8,
-}
-
-pub(crate) use cache_pad::CachePadded;
-
-/// When configured not to pad to cache alignment, just provide a no-op wrapper struct
-/// This feature is useful for platforms with no data cache, such as many Cortex-M
-/// targets.
-#[cfg(feature = "no-cache-pad")]
-mod cache_pad {
-    #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
-    pub(crate) struct CachePadded<T>(pub(crate) T);
-}
-
-/// When not inhibited, determine cache alignment based on target architecture.
-/// Align to 128 bytes on 64-bit x86/ARM targets, otherwise align to 64 bytes.
-#[cfg(not(feature = "no-cache-pad"))]
-mod cache_pad {
-    #[cfg_attr(not(target_has_atomic = "ptr"), allow(dead_code))]
-    #[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(align(128)))]
-    #[cfg_attr(
-        not(any(target_arch = "x86_64", target_arch = "aarch64")),
-        repr(align(64))
-    )]
-    #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
-    pub(crate) struct CachePadded<T>(pub(crate) T);
-}
-
 pub(crate) struct FmtOption<'a, T> {
     opt: Option<&'a T>,
     or_else: &'a str,
-}
-
-// === impl Backoff ===
-
-#[cfg(target_has_atomic = "ptr")]
-impl Backoff {
-    pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
-
-    pub(crate) const fn new() -> Self {
-        Self {
-            exp: 0,
-            max: Self::DEFAULT_MAX_EXPONENT,
-        }
-    }
-
-    /// Returns a new exponential backoff with the provided max exponent.
-    #[allow(dead_code)]
-    pub(crate) fn with_max_exponent(max: u8) -> Self {
-        assert!(max <= Self::DEFAULT_MAX_EXPONENT);
-        Self { exp: 0, max }
-    }
-
-    /// Perform one spin, squarin the backoff
-    #[cfg(target_has_atomic = "ptr")]
-    #[inline(always)]
-    pub(crate) fn spin(&mut self) {
-        use crate::loom::hint;
-
-        // Issue 2^exp pause instructions.
-        for _ in 0..(1 << self.exp) {
-            hint::spin_loop();
-        }
-
-        if self.exp < self.max {
-            self.exp += 1
-        }
-    }
-}
-
-#[cfg(target_has_atomic = "ptr")]
-impl Default for Backoff {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// === impl CachePadded ===
-
-impl<T> Deref for CachePadded<T> {
-    type Target = T;
-
-    #[inline]
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for CachePadded<T> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
-}
-
-impl<T: fmt::Debug> fmt::Debug for CachePadded<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
 }
 
 // === impl FmtOption ===

--- a/cordyceps/src/util.rs
+++ b/cordyceps/src/util.rs
@@ -1,9 +1,9 @@
-use crate::loom::hint;
 use core::{
     fmt,
     ops::{Deref, DerefMut},
 };
 
+#[cfg(target_has_atomic="ptr")]
 macro_rules! feature {
     (
         #![$meta:meta]
@@ -24,6 +24,7 @@ macro_rules! test_trace {
 }
 
 /// An exponential backoff for spin loops
+#[cfg(target_has_atomic="ptr")]
 #[derive(Debug, Clone)]
 pub(crate) struct Backoff {
     exp: u8,
@@ -45,6 +46,7 @@ mod cache_pad {
 /// Align to 128 bytes on 64-bit x86/ARM targets, otherwise align to 64 bytes.
 #[cfg(not(feature = "no-cache-pad"))]
 mod cache_pad {
+    #[cfg_attr(not(target_has_atomic="ptr"), allow(dead_code))]
     #[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(align(128)))]
     #[cfg_attr(
         not(any(target_arch = "x86_64", target_arch = "aarch64")),
@@ -61,6 +63,7 @@ pub(crate) struct FmtOption<'a, T> {
 
 // === impl Backoff ===
 
+#[cfg(target_has_atomic="ptr")]
 impl Backoff {
     pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
 
@@ -79,8 +82,11 @@ impl Backoff {
     }
 
     /// Perform one spin, squarin the backoff
+    #[cfg(target_has_atomic="ptr")]
     #[inline(always)]
     pub(crate) fn spin(&mut self) {
+        use crate::loom::hint;
+
         // Issue 2^exp pause instructions.
         for _ in 0..(1 << self.exp) {
             hint::spin_loop();
@@ -92,6 +98,7 @@ impl Backoff {
     }
 }
 
+#[cfg(target_has_atomic="ptr")]
 impl Default for Backoff {
     fn default() -> Self {
         Self::new()

--- a/cordyceps/src/util.rs
+++ b/cordyceps/src/util.rs
@@ -3,7 +3,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 macro_rules! feature {
     (
         #![$meta:meta]
@@ -24,7 +24,7 @@ macro_rules! test_trace {
 }
 
 /// An exponential backoff for spin loops
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 #[derive(Debug, Clone)]
 pub(crate) struct Backoff {
     exp: u8,
@@ -46,7 +46,7 @@ mod cache_pad {
 /// Align to 128 bytes on 64-bit x86/ARM targets, otherwise align to 64 bytes.
 #[cfg(not(feature = "no-cache-pad"))]
 mod cache_pad {
-    #[cfg_attr(not(target_has_atomic="ptr"), allow(dead_code))]
+    #[cfg_attr(not(target_has_atomic = "ptr"), allow(dead_code))]
     #[cfg_attr(any(target_arch = "x86_64", target_arch = "aarch64"), repr(align(128)))]
     #[cfg_attr(
         not(any(target_arch = "x86_64", target_arch = "aarch64")),
@@ -63,7 +63,7 @@ pub(crate) struct FmtOption<'a, T> {
 
 // === impl Backoff ===
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl Backoff {
     pub(crate) const DEFAULT_MAX_EXPONENT: u8 = 8;
 
@@ -82,7 +82,7 @@ impl Backoff {
     }
 
     /// Perform one spin, squarin the backoff
-    #[cfg(target_has_atomic="ptr")]
+    #[cfg(target_has_atomic = "ptr")]
     #[inline(always)]
     pub(crate) fn spin(&mut self) {
         use crate::loom::hint;
@@ -98,7 +98,7 @@ impl Backoff {
     }
 }
 
-#[cfg(target_has_atomic="ptr")]
+#[cfg(target_has_atomic = "ptr")]
 impl Default for Backoff {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
This PR is a first attempt to allow building of `cordyceps` on non-CAS enabled targets, such as `thumbv6m-none-eabi`/Cortex-M0+/rp2040.

Doing this as a first feature, prior to implementing a non-atomic and `critical_section` based version of TransferStack, in service of https://github.com/embassy-rs/embassy/pull/4035.

Rather than making a default-on "CAS" feature, we instead gate on `cfg(target_has_atomic = "ptr")`, which was [stabilized in 1.60](https://github.com/rust-lang/rust/pull/93824), which currently has the meaning of "this target has CAS". This automatically gates-out `TransferStack` and `MpscQueue`, while the "mutable" collections can still be used.

Right now the cfg gating is a little scattershot, I wanted to open this to discuss, if you'd like me to clean things up a bit to group the CAS-ful parts, I'm happy to do so.