### PR TITLE
cordyceps: Add "raw" iter for `List`

### DIFF
--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -248,7 +248,7 @@ pub struct Iter<'list, T: Linked<Links<T>> + ?Sized> {
     len: usize,
 }
 
-/// Iterates over the items in a [`List`] by `NonNull<T>` node pointers.
+/// Iterates over the items in a [`List`] as [`NonNull`]`<T>` node pointers.
 ///
 /// Whenever possible, prefer [`Iter`] or [`IterMut`], as they provide
 /// easier-to-hold-right interfaces when iterating over nodes.
@@ -929,7 +929,7 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
     /// Although this method is safe, care must be taken with the items
     /// yielded by the returned iterator.
     ///
-    /// This iterator returns `NonNull<T>` of the individual node elements,
+    /// This iterator returns [`NonNull`]`<T>` of the individual node elements,
     /// rather than references. This is done to allow "type punning" of nodes,
     /// where the creation of a reference could restrict the provenance of the
     /// pointed-to item. This is relevant if your nodes are of a common header

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -248,8 +248,17 @@ pub struct Iter<'list, T: Linked<Links<T>> + ?Sized> {
     len: usize,
 }
 
-/// Iterates over the items in a [`List`] by pointer.
-pub struct RawIter<'list, T: Linked<Links<T>> + ?Sized> {
+/// Iterates over the items in a [`List`] by `NonNull<T>` node pointers.
+///
+/// Whenever possible, prefer [`Iter`] or [`IterMut`], as they provide
+/// easier-to-hold-right interfaces when iterating over nodes.
+///
+/// ## Safety
+///
+/// Although iteration of items is safe, care must be taken with
+/// the returned `NonNull<T>` nodes. See [`List::iter_raw()`] for
+/// more details on safety invariants.
+pub struct IterRaw<'list, T: Linked<Links<T>> + ?Sized> {
     _list: &'list List<T>,
 
     /// The current node when iterating head -> tail.
@@ -914,9 +923,36 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
     }
 
     /// Returns an iterator over the items in this list, by pointer.
+    ///
+    /// ## Safety
+    ///
+    /// Although this method is safe, care must be taken with the items
+    /// yielded by the returned iterator.
+    ///
+    /// This iterator returns `NonNull<T>` of the individual node elements,
+    /// rather than references. This is done to allow "type punning" of nodes,
+    /// where the creation of a reference could restrict the provenance of the
+    /// pointed-to item. This is relevant if your nodes are of a common header
+    /// type, but may have different "body" types you'd like to cast to. This is similar
+    /// to how executors like `maitake` or `tokio` store `Task`s: with a common
+    /// `TaskHeader` but containing varying futured in their bodies. If this is
+    /// NOT a feature you need, consider using [`List::iter()`] or
+    /// [`List::iter_mut()`] instead.
+    ///
+    /// Morally, the elements yielded by this iterator should be treated *as if*
+    /// they were `Pin<NonNull<T>>`, or `Pin<&mut T>`, in that you MUST NOT move
+    /// out of the pointed-to nodes. The nodes are still logically OWNED by the
+    /// list, and must not be removed using this interface. You may still use
+    /// these pointers with whatever provenance they were originally created with,
+    /// allowing for type-punning to a larger type with a common header base.
+    ///
+    /// Unfortunatly we [cannot create] a `Pin<NonNull<T>>`, so you must use the
+    /// pointers yielded by this iterator carefully.
+    ///
+    /// [cannot create]: https://github.com/rust-lang/rust/issues/54815
     #[must_use]
-    pub fn raw_iter(&self) -> RawIter<'_, T> {
-        RawIter {
+    pub fn iter_raw(&mut self) -> IterRaw<'_, T> {
+        IterRaw {
             _list: self,
             curr: self.head,
             curr_back: self.tail,
@@ -1407,7 +1443,7 @@ impl<T: Linked<Links<T>> + ?Sized> iter::FusedIterator for IterMut<'_, T> {}
 
 // === impl RawIter ====
 
-impl<T: Linked<Links<T>> + ?Sized> Iterator for RawIter<'_, T> {
+impl<T: Linked<Links<T>> + ?Sized> Iterator for IterRaw<'_, T> {
     type Item = NonNull<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1434,14 +1470,14 @@ impl<T: Linked<Links<T>> + ?Sized> Iterator for RawIter<'_, T> {
     }
 }
 
-impl<T: Linked<Links<T>> + ?Sized> ExactSizeIterator for RawIter<'_, T> {
+impl<T: Linked<Links<T>> + ?Sized> ExactSizeIterator for IterRaw<'_, T> {
     #[inline]
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<T: Linked<Links<T>> + ?Sized> DoubleEndedIterator for RawIter<'_, T> {
+impl<T: Linked<Links<T>> + ?Sized> DoubleEndedIterator for IterRaw<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len == 0 {
             return None;
@@ -1460,7 +1496,7 @@ impl<T: Linked<Links<T>> + ?Sized> DoubleEndedIterator for RawIter<'_, T> {
     }
 }
 
-impl<T: Linked<Links<T>> + ?Sized> iter::FusedIterator for RawIter<'_, T> {}
+impl<T: Linked<Links<T>> + ?Sized> iter::FusedIterator for IterRaw<'_, T> {}
 
 
 // === impl IntoIter ===

--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -950,6 +950,16 @@ impl<T: Linked<Links<T>> + ?Sized> List<T> {
     /// pointers yielded by this iterator carefully.
     ///
     /// [cannot create]: https://github.com/rust-lang/rust/issues/54815
+    ///
+    /// ## Example
+    ///
+    /// For an end-to-end example of the kind of "spooky type punning" this interface
+    /// aims to allow, check out the [test for `iter_raw`], which demonstrates the
+    /// ability to call a dynamic "print" function on any item in the list, where
+    /// all items are of differing types (but all implement the [`Debug`][core::fmt::Debug]
+    /// trait).
+    ///
+    /// [test for `iter_raw`]: https://github.com/hawkw/mycelium/blob/main/cordyceps/src/list/tests/iter_raw.rs
     #[must_use]
     pub fn iter_raw(&mut self) -> IterRaw<'_, T> {
         IterRaw {

--- a/cordyceps/src/list/tests.rs
+++ b/cordyceps/src/list/tests.rs
@@ -109,6 +109,7 @@ macro_rules! assert_ptr_eq {
 }
 
 mod cursor;
+mod iter_raw;
 mod owned_entry;
 mod remove_by_addr;
 

--- a/cordyceps/src/list/tests/iter_raw.rs
+++ b/cordyceps/src/list/tests/iter_raw.rs
@@ -1,0 +1,131 @@
+use super::*;
+use core::fmt::Debug;
+
+/// This vtable is usable on type-erased nodes.
+///
+/// All functions take the type-erased versions of `NonNull<OwnedEntryNode<T>>`.
+struct VTable {
+    print: fn(NonNull<()>),
+    drop: fn(NonNull<()>),
+}
+
+/// A helper function for creating a basic "print" function
+fn print<T: Debug>(this: NonNull<()>) {
+    let this: NonNull<OwnedEntryNode<T>> = this.cast();
+    let this: &OwnedEntryNode<T> = unsafe { this.as_ref() };
+    println!("PRINT: {:?}", this.item);
+}
+
+/// A helper function for creating a basic "drop" function
+fn droppa<T>(this: NonNull<()>) {
+    let this: NonNull<OwnedEntryNode<T>> = this.cast();
+    unsafe {
+        drop(Box::from_raw(this.as_ptr()));
+    }
+}
+
+impl VTable {
+    /// This can be used to create a vtable for a given type T
+    pub const fn vtable_for<T: Debug>() -> Self {
+        Self {
+            print: print::<T>,
+            drop: droppa::<T>,
+        }
+    }
+}
+
+/// This is the type erased common header of all `OwnedEntryNode` items.
+#[pin_project::pin_project]
+struct OwnedEntryHeader {
+    #[pin]
+    links: Links<OwnedEntryHeader>,
+    vtable: &'static VTable,
+}
+
+// LOAD BEARING: this must be repr(c) to guarantee `hdr` is the first field
+#[repr(C)]
+struct OwnedEntryNode<T> {
+    // LOAD BEARING: this must be the first element for type-punning to work
+    hdr: OwnedEntryHeader,
+    item: T,
+}
+
+/// A wrapper type that allows us to impl drop on a node using vtable methods
+struct NodeRef(NonNull<OwnedEntryHeader>);
+
+/// Convert a typed node into an untyped noderef
+impl<T> From<Pin<Box<OwnedEntryNode<T>>>> for NodeRef {
+    fn from(value: Pin<Box<OwnedEntryNode<T>>>) -> Self {
+        let ptr: NonNull<OwnedEntryNode<T>> =
+            unsafe { NonNull::from(Box::leak(Pin::into_inner_unchecked(value))) };
+        let ptr: NonNull<OwnedEntryHeader> = ptr.cast();
+        NodeRef(ptr)
+    }
+}
+
+/// We need to use the vtable method for drop, because the types are otherwise
+/// erased
+impl Drop for NodeRef {
+    fn drop(&mut self) {
+        let ptr: NonNull<OwnedEntryHeader> = self.0;
+        let vtable: &'static VTable = unsafe { ptr.as_ref().vtable };
+        let ptr: NonNull<()> = ptr.cast();
+        (vtable.drop)(ptr);
+    }
+}
+
+unsafe impl Linked<Links<Self>> for OwnedEntryHeader {
+    type Handle = NodeRef;
+
+    fn into_ptr(handle: NodeRef) -> NonNull<Self> {
+        let ptr = handle.0;
+        core::mem::forget(handle);
+        ptr
+    }
+
+    unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+        NodeRef(ptr)
+    }
+
+    unsafe fn links(target: NonNull<Self>) -> NonNull<Links<Self>> {
+        let links = ptr::addr_of_mut!((*target.as_ptr()).links);
+        NonNull::new_unchecked(links)
+    }
+}
+
+/// Create a new typed node, that can be erased by calling `Into::into` to
+/// a `NodeRef` type.
+fn owned_entry<T: Debug>(val: T) -> Pin<Box<OwnedEntryNode<T>>> {
+    Box::pin(OwnedEntryNode {
+        hdr: OwnedEntryHeader {
+            links: Links::new(),
+            vtable: const { &VTable::vtable_for::<T>() },
+        },
+        item: val,
+    })
+}
+
+/// Just to make sure miri doesn't get big mad about these whole shenanigans
+#[test]
+fn smoke() {
+    let mut list = List::<OwnedEntryHeader>::new();
+    let a = owned_entry(42i32);
+    let b = owned_entry("bar");
+    let c = owned_entry(Some(123u64));
+    list.push_front(a.into());
+    list.push_front(b.into());
+    list.push_front(c.into());
+
+    // We use iter_raw instead of iter_mut to allow type punning
+    for node in list.iter_raw() {
+        // obtain the vtable
+        let vtable: &'static VTable = unsafe { node.as_ref().vtable };
+        // type erase, call vtable method
+        let node: NonNull<()> = node.cast();
+        (vtable.print)(node);
+    }
+
+    // Try running this with `cargo +nightly miri test -- iter_raw --nocapture`, it's pretty neat :)
+
+    drop(list);
+}


### PR DESCRIPTION
closes #532

cc https://github.com/tweedegolf/cfg-noodle/issues/9

This is an initial implementation of a "raw" iterator, that allows for type-punning of nodes of a `List`. Unlike `MpscQueue` and `TransferStack`, which give back `T::Handle` elements, the `iter()` and `iter_mut()` methods of `List` instead give `&T` or `Pin<&mut T>`. However, by creating these references, we narrow the provenance of the reference to only the header of a type-punned object, leading to miri stacked borrow violations.

Ideally, we would be able to provide an iterator over something like `&T::Handle`, as we don't want to necessarily give ownership (which `T::Handle` semantically has), but this is difficult to express in an iterator, as we would need to store the `T::Handle` somewhere, and forget it so we don't consume the handle.

Instead, this "RawIter" just gives "raw" `NonNull<T>` pointers to each element, meaning that no intermediary reference is created. This is spicy, but access to the elements still requires `unsafe` to dereference the `NonNull`s, and the iterator itself is still bound to the lifetime of `'list`, similar to `Iter` and `IterMut`.

In https://github.com/jamesmunns/ergot/commit/332085d931635866f88ec188f90b8cd558bb4649, when running `MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test`, miri now passes, whereas in the previous commit (using `iter_mut`) there is a violation that looks like this:

```
test hello ... error: Undefined Behavior: trying to retag from <378652> for SharedReadWrite permission at alloc118585[0x38], but that tag does not exist in the borrow stack for this location
   --> /Users/james/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:428:18
    |
428 |         unsafe { &*self.as_ptr().cast_const() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
    |                  trying to retag from <378652> for SharedReadWrite permission at alloc118585[0x38], but that tag does not exist in the borrow stack for this location
    |                  this error occurs as part of retag at alloc118585[0x0..0x60]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <378652> was created by a SharedReadWrite retag at offsets [0x0..0x38]
   --> /Users/james/personal/ergot/src/lib.rs:91:59
    |
91  | ...   let this: NonNull<SocketHeader> = NonNull::from(unsafe { socket.get_unchecked_mut() });
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span) on thread `hello`:
    = note: inside `std::ptr::NonNull::<ergot::socket::endpoint::OwnedSocket<ExampleEndpoint>>::as_ref::<'_>` at /Users/james/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:428:18: 428:46
note: inside `ergot::socket::endpoint::OwnedSocket::<ExampleEndpoint>::send_owned`
   --> /Users/james/personal/ergot/src/socket/endpoint.rs:153:36
    |
153 |         let this: &Self = unsafe { this.as_ref() };
    |                                    ^^^^^^^^^^^^^
note: inside closure
   --> /Users/james/personal/ergot/src/lib.rs:95:25
    |
95  |                         (f)(this, that, &TypeId::of::<T>(), src, dst)
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside closure at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mutex-1.0.0/src/lib.rs:80:13: 80:21
    = note: inside closure at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mutex-1.0.0/src/raw_impls.rs:59:27: 59:30
    = note: inside `critical_section::with::<std::option::Option<std::result::Result<(), ()>>, {closure@<mutex::raw_impls::cs::CriticalSectionRawMutex as mutex::ScopedRawMutex>::try_with_lock<std::result::Result<(), ()>, {closure@mutex::BlockingMutex<mutex::raw_impls::cs::CriticalSectionRawMutex, ergot::NetStackInner>::with_lock<std::result::Result<(), ()>, {closure@ergot::NetStack<mutex::raw_impls::cs::CriticalSectionRawMutex>::send_ty<Example>::{closure#0}}>::{closure#0}}>::{closure#0}}>` at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/critical-section-1.2.0/src/lib.rs:248:14: 248:39
    = note: inside `<mutex::raw_impls::cs::CriticalSectionRawMutex as mutex::ScopedRawMutex>::try_with_lock::<std::result::Result<(), ()>, {closure@mutex::BlockingMutex<mutex::raw_impls::cs::CriticalSectionRawMutex, ergot::NetStackInner>::with_lock<std::result::Result<(), ()>, {closure@ergot::NetStack<mutex::raw_impls::cs::CriticalSectionRawMutex>::send_ty<Example>::{closure#0}}>::{closure#0}}>` at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mutex-1.0.0/src/raw_impls.rs:52:13: 62:15
    = note: inside `<mutex::raw_impls::cs::CriticalSectionRawMutex as mutex::ScopedRawMutex>::with_lock::<std::result::Result<(), ()>, {closure@mutex::BlockingMutex<mutex::raw_impls::cs::CriticalSectionRawMutex, ergot::NetStackInner>::with_lock<std::result::Result<(), ()>, {closure@ergot::NetStack<mutex::raw_impls::cs::CriticalSectionRawMutex>::send_ty<Example>::{closure#0}}>::{closure#0}}>` at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mutex-1.0.0/src/raw_impls.rs:70:13: 70:34
    = note: inside `mutex::BlockingMutex::<mutex::raw_impls::cs::CriticalSectionRawMutex, ergot::NetStackInner>::with_lock::<std::result::Result<(), ()>, {closure@ergot::NetStack<mutex::raw_impls::cs::CriticalSectionRawMutex>::send_ty<Example>::{closure#0}}>` at /Users/james/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mutex-1.0.0/src/lib.rs:76:9: 81:11
note: inside `ergot::NetStack::<mutex::raw_impls::cs::CriticalSectionRawMutex>::send_ty::<Example>`
   --> /Users/james/personal/ergot/src/lib.rs:82:19
    |
82  |           let res = self.inner.with_lock(|inner| {
    |  ___________________^
83  | |             for socket in inner.sockets.iter_mut() {
84  | |                 let port = unsafe { *socket.port.get() };
...   |
105 | |             Err(())
106 | |         });
    | |__________^
note: inside closure
   --> tests/smoke.rs:39:9
    |
39  |         STACK.send_ty::<Example>(src, dst, ExampleEndpoint::REQ_KEY, Example { a: 42, b: 789 }).unwrap();
```

This PR probably needs some more docs and tests, but I wanted to open this up for discussion to see if this is a reasonable thing to want, or if there is another approach we should look into.