### PR TITLE
Correct borrow, and impl Send for RawIter

### DIFF
--- a/cordyceps/src/list/tests/iter_raw.rs
+++ b/cordyceps/src/list/tests/iter_raw.rs
@@ -129,3 +129,8 @@ fn smoke() {
 
     drop(list);
 }
+
+#[test]
+fn assert_send() {
+    crate::util::assert_send::<IterRaw<'_, OwnedEntryHeader>>();
+}

--- a/cordyceps/src/util.rs
+++ b/cordyceps/src/util.rs
@@ -150,3 +150,6 @@ impl<T: fmt::Display> fmt::Display for FmtOption<'_, T> {
 
 #[cfg(test)]
 pub(crate) fn assert_send_sync<T: Send + Sync>() {}
+
+#[cfg(test)]
+pub(crate) fn assert_send<T: Send>() {}


### PR DESCRIPTION
Fixes #535

This change fixes the two things noted in the #535: RawIter now holds an `&mut` to the List, and also now implements Send.

I think we could also implement Send for Iter/IterMut, but I'm less confident about that.

I also am not certain whether the unsafe `Send` impl should be gated on `T: Send`, I opted not to because we never take ownership of a node (e.g. a `pop`) using the RawIter interface, so we're only ever "visiting" a pinned node, so requiring `T: Send` didn't seem necessary. I'm open to more confident logic around that.

I also added a util helper to assert that RawIter remains Send.