### PR TITLE
feat(cordyceps): add `Stack::push_was_empty` method to match TransferStack's API

### DIFF
--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -1508,7 +1508,6 @@ impl<T: Linked<Links<T>> + ?Sized> DoubleEndedIterator for IterRaw<'_, T> {
 
 impl<T: Linked<Links<T>> + ?Sized> iter::FusedIterator for IterRaw<'_, T> {}
 
-
 // === impl IntoIter ===
 
 impl<T: Linked<Links<T>> + ?Sized> fmt::Debug for IntoIter<T> {

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -290,6 +290,9 @@ where
     /// type](Linked::Handle). If the `Stack` is dropped before the
     /// pushed `element` is [`pop`](Self::pop)pped from the stack, the `element`
     /// will be dropped.
+    ///
+    /// For a variant of this method that returns a `bool` indicating if the
+    /// list was empty, see [`Stack::push_was_empty`].
     pub fn push(&mut self, element: T::Handle) {
         self.push_was_empty(element);
     }

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -264,7 +264,6 @@ where
     /// type](Linked::Handle). If the `Stack` is dropped before the
     /// pushed `element` is [`pop`](Self::pop)pped from the stack, the `element`
     /// will be dropped.
-    #[inline]
     pub fn push_was_empty(&mut self, element: T::Handle) -> bool {
         let ptr = T::into_ptr(element);
         test_trace!(?ptr, ?self.head, "Stack::push_was_empty");
@@ -293,6 +292,7 @@ where
     ///
     /// For a variant of this method that returns a `bool` indicating if the
     /// list was empty, see [`Stack::push_was_empty`].
+    #[inline]
     pub fn push(&mut self, element: T::Handle) {
         self.push_was_empty(element);
     }

--- a/cordyceps/src/stack.rs
+++ b/cordyceps/src/stack.rs
@@ -254,6 +254,35 @@ where
     /// Pushes `element` onto the end of this `Stack`, taking ownership
     /// of it.
     ///
+    /// Returns `true` if the stack was previously empty, and `false` if the stack
+    /// contained at least one other element.
+    ///
+    /// This is an *O*(1) operation that does not allocate memory. It will never
+    /// loop.
+    ///
+    /// This takes ownership over `element` through its [owning `Handle`
+    /// type](Linked::Handle). If the `Stack` is dropped before the
+    /// pushed `element` is [`pop`](Self::pop)pped from the stack, the `element`
+    /// will be dropped.
+    #[inline]
+    pub fn push_was_empty(&mut self, element: T::Handle) -> bool {
+        let ptr = T::into_ptr(element);
+        test_trace!(?ptr, ?self.head, "Stack::push_was_empty");
+        unsafe {
+            // Safety: we have exclusive mutable access to the stack, and
+            // therefore can also mutate the stack's entries.
+            let links = T::links(ptr).as_mut();
+            links.next.with_mut(|next| {
+                debug_assert!((*next).is_none());
+                *next = self.head.replace(ptr);
+                (*next).is_none()
+            })
+        }
+    }
+
+    /// Pushes `element` onto the end of this `Stack`, taking ownership
+    /// of it.
+    ///
     /// This is an *O*(1) operation that does not allocate memory. It will never
     /// loop.
     ///
@@ -262,17 +291,7 @@ where
     /// pushed `element` is [`pop`](Self::pop)pped from the stack, the `element`
     /// will be dropped.
     pub fn push(&mut self, element: T::Handle) {
-        let ptr = T::into_ptr(element);
-        test_trace!(?ptr, ?self.head, "Stack::push");
-        unsafe {
-            // Safety: we have exclusive mutable access to the stack, and
-            // therefore can also mutate the stack's entries.
-            let links = T::links(ptr).as_mut();
-            links.next.with_mut(|next| {
-                debug_assert!((*next).is_none());
-                *next = self.head.replace(ptr);
-            })
-        }
+        self.push_was_empty(element);
     }
 
     /// Returns the element most recently [push](Self::push)ed to this `Stack`,


### PR DESCRIPTION
also rustfmt deleted an extra line in list.rs.