### PR TITLE
docs(maitake): unfuck features table markdown

### DIFF
--- a/maitake/README.md
+++ b/maitake/README.md
@@ -313,7 +313,6 @@ The following features are available (this list is incomplete; you can help by [
 | :---           | :---    | :---        |
 | `alloc`        | `true`  | Enables [`liballoc`] dependency |
 | `std`          | `false`  | Enables the Rust standard library, disabling `#![no-std]`. When `std` is enabled, the [`DefaultMutex`] type will use [`std::sync::Mutex`]. This implies the `alloc` feature. |
-
 | `critical-section` | `false` | Enables support for the [`critical-section`] crate. This includes a variant of the [`DefaultMutex`] type that uses a critical section, as well as the [`portable-atomic`] crate's `critical-section` feature (as [discussed above](#support-for-atomic-operations)) |
 | `no-cache-pad` | `false` | Inhibits cache padding for the [`CachePadded`] struct. When this feature is NOT enabled, the size will be determined based on target platform. |
 | `tracing-01`   | `false` | Enables support for v0.1.x of [`tracing`] (the current release version). Requires `liballoc`.|


### PR DESCRIPTION
The markdown table of feature flags in the `maitake` docs was fucked up. This unfucks it.

It used to look like this:
<img width="1203" height="542" alt="image" src="https://github.com/user-attachments/assets/894a7079-0abc-481a-8690-fcced69da376" />

Now it looks normal:
<img width="1168" height="659" alt="image" src="https://github.com/user-attachments/assets/85acc995-2286-439f-bf93-b42bdce498b0" />
