### PR TITLE
write_str loop should terminate

### DIFF
--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -418,7 +418,8 @@ where
         for line in lines {
             let mut line = line;
             while self.current_line + line.len() >= self.cfg.line_len {
-                let offset = if let Some(last_ws) = line[..self.cfg.line_len - self.current_line]
+                let max_amount = self.cfg.line_len - self.current_line;
+                let offset = if let Some(last_ws) = line[..max_amount]
                     .chars()
                     .rev()
                     .position(|c| c.is_whitespace())
@@ -427,7 +428,9 @@ where
                     self.writer.write_str(&line[..last_ws])?;
                     last_ws
                 } else {
-                    0
+                    // no whitespace to break on, so write out all we can and hope it makes sense.
+                    self.writer.write_str(&line[..max_amount])?;
+                    max_amount
                 };
                 self.writer.write_char('\n')?;
                 self.write_newline()?;


### PR DESCRIPTION
i've got a sneaking suspicion that in the serial context the ANSI control characters are taking up invisible space, which definitely makes #493 look way goofier than it should:
<img width="1047" height="185" alt="image" src="https://github.com/user-attachments/assets/4367103c-9be1-4360-84ff-9d0c5658f2f3" />

but at least with this the above doesn't send the kernel off into a spin? anyway this seems to do the needful for #550.