### PR TITLE
doc(cordyceps): improve List rustdoc

### DIFF
--- a/cordyceps/src/list.rs
+++ b/cordyceps/src/list.rs
@@ -70,7 +70,7 @@ pub use self::cursor::{Cursor, CursorMut};
 ///
 ///     /// Convert an owned `Handle` into a raw pointer
 ///     fn into_ptr(handle: Pin<Box<Entry>>) -> NonNull<Entry> {
-///        unsafe { NonNull::from(Box::leak(Pin::into_inner_unchecked(handle))) }
+///        unsafe { NonNull::new_unchecked(Box::into_raw(Pin::into_inner_unchecked(handle))) }
 ///     }
 ///
 ///     /// Convert a raw pointer back into an owned `Handle`.
@@ -126,7 +126,7 @@ pub use self::cursor::{Cursor, CursorMut};
 /// # unsafe impl Linked<list::Links<Entry>> for Entry {
 /// #     type Handle = Pin<Box<Self>>;
 /// #     fn into_ptr(handle: Pin<Box<Entry>>) -> NonNull<Entry> {
-/// #        unsafe { NonNull::from(Box::leak(Pin::into_inner_unchecked(handle))) }
+/// #        unsafe { NonNull::new_unchecked(Box::into_raw(Pin::into_inner_unchecked(handle))) }
 /// #     }
 /// #     unsafe fn from_ptr(ptr: NonNull<Entry>) -> Pin<Box<Entry>> {
 /// #         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))
@@ -180,7 +180,7 @@ pub use self::cursor::{Cursor, CursorMut};
 /// # unsafe impl Linked<list::Links<Entry>> for Entry {
 /// #     type Handle = Pin<Box<Self>>;
 /// #     fn into_ptr(handle: Pin<Box<Entry>>) -> NonNull<Entry> {
-/// #        unsafe { NonNull::from(Box::leak(Pin::into_inner_unchecked(handle))) }
+/// #        unsafe { NonNull::new_unchecked(Box::into_raw(Pin::into_inner_unchecked(handle))) }
 /// #     }
 /// #     unsafe fn from_ptr(ptr: NonNull<Entry>) -> Pin<Box<Entry>> {
 /// #         Pin::new_unchecked(Box::from_raw(ptr.as_ptr()))


### PR DESCRIPTION
I propose a change to the `List` rustdoc example, imo it's better semantical match for what the `into_ptr` and `from_ptr` methods do - which is ownership transfer via `into` -> `from` pipeline, rather than "leaking" the ptr and then reclaiming it back again. 

My `LinkedHashMap` implementation uses it, I've run it through both `libfuzzer` as well as `miri` with no complaints, so I'd assume that it's both sound as well as it matches the current rust memory model. 