### PR TITLE
Fix spinlock race condition (rwlock)

### DIFF
--- a/maitake-sync/src/spin.rs
+++ b/maitake-sync/src/spin.rs
@@ -236,7 +236,7 @@ unsafe impl RawRwLock for RwSpinlock {
     #[cfg_attr(test, track_caller)]
     #[inline]
     unsafe fn unlock_exclusive(&self) {
-        let _val = test_dbg!(self.state.swap(UNLOCKED, Release));
+        let _val = test_dbg!(self.state.fetch_sub(WRITER, Release));
     }
 
     #[inline]


### PR DESCRIPTION
Readers try to acquire the lock using `fetch_add(2)` (least significant bit is reserved for the writers) and they check if a writer exists after they perform the addition. If there is a writer they undo their change using `fetch_sub(2)` . However if the writer unlocks before the `fetch_sub(2)` of the reader, setting the state to `UNLOCKED = 0`, then the subsequent `fetch_sub` of the reader ends up corrupting the state, overflowing and wrapping around.

With this change the `unlock_exclusive` just clears the writer bit from the state, leaving the reader counts unchanged. The caller must hold the lock so the state must have the writer bit set prior.

```
$ RUSTFLAGS="--cfg loom" cargo test blocking::rwlock
   
running 2 tests
test blocking::rwlock::tests::read_write ... ok
test blocking::rwlock::tests::write ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 43 filtered out; finished in 0.00s```